### PR TITLE
Create Model and ViewSet for NetworkProfile objects

### DIFF
--- a/quipucords/api/models.py
+++ b/quipucords/api/models.py
@@ -53,3 +53,16 @@ class HostCredential(Credential):
 
     class Meta:
         verbose_name_plural = 'Host Credentials'
+
+
+class NetworkProfile(models.Model):
+    """A network profile connects a list of credentials and a list of hosts."""
+    name = models.CharField(max_length=64, unique=True)
+    # Comma-separated list of host specifiers
+    hosts = models.CharField(max_length=1024)
+    ssh_port = models.IntegerField()
+    # Comma-separated list of credential names. We identify
+    # credentials by name, not ID, to support the behavior where a
+    # user creates a credential of a given name, deletes it, and makes
+    # a new one of the same name.
+    credentials = models.CharField(max_length=1024)

--- a/quipucords/api/models.py
+++ b/quipucords/api/models.py
@@ -58,11 +58,32 @@ class HostCredential(Credential):
 class NetworkProfile(models.Model):
     """A network profile connects a list of credentials and a list of hosts."""
     name = models.CharField(max_length=64, unique=True)
-    # Comma-separated list of host specifiers
-    hosts = models.CharField(max_length=1024)
     ssh_port = models.IntegerField()
-    # Comma-separated list of credential names. We identify
-    # credentials by name, not ID, to support the behavior where a
-    # user creates a credential of a given name, deletes it, and makes
-    # a new one of the same name.
-    credentials = models.CharField(max_length=1024)
+    credentials = models.ManyToManyField(HostCredential)
+    # NetworkProfile also has the field hosts, which is created by the
+    # ForeignKey in HostRange below.
+
+
+class HostRange(models.Model):
+    """A HostRange is a subset of a network to scan.
+
+    It can be either an IP range or a DNS name range. A HostRange is
+    not the same as a set of hosts because there may be parts of the
+    IP or DNS range that don't correspond to any host, but we still
+    need to remember them because in the future there could be hosts
+    there.
+    """
+
+    # HostRanges provide a convenient way for a NetworkProfile to
+    # store a list of name ranges.  As of now we don't make any effort
+    # to deduplicate when different NetworkProfiles have overlapping
+    # (or identical) ranges. If we ever want to show the user exactly
+    # what parts of their network are being scanned, we will have to
+    # dedup.
+
+    # host_range is an IP address range or a DNS name range in Ansible
+    # format.
+    host_range = models.CharField(max_length=1024)
+    network_profile = models.ForeignKey(NetworkProfile,
+                                        models.CASCADE,
+                                        related_name='hosts')

--- a/quipucords/api/models.py
+++ b/quipucords/api/models.py
@@ -59,7 +59,7 @@ class NetworkProfile(models.Model):
     """A network profile connects a list of credentials and a list of hosts."""
     name = models.CharField(max_length=64, unique=True)
     ssh_port = models.IntegerField()
-    credentials = models.ManyToManyField(HostCredential)
+    credential_ids = models.ManyToManyField(HostCredential)
     # NetworkProfile also has the field hosts, which is created by the
     # ForeignKey in HostRange below.
 

--- a/quipucords/api/models.py
+++ b/quipucords/api/models.py
@@ -59,7 +59,7 @@ class NetworkProfile(models.Model):
     """A network profile connects a list of credentials and a list of hosts."""
     name = models.CharField(max_length=64, unique=True)
     ssh_port = models.IntegerField()
-    credential_ids = models.ManyToManyField(HostCredential)
+    credentials = models.ManyToManyField(HostCredential)
     # NetworkProfile also has the field hosts, which is created by the
     # ForeignKey in HostRange below.
 

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -98,8 +98,8 @@ class NetworkProfileSerializer(ModelSerializer):
             HostRange.objects.create(network_profile=netprof,
                                      **host_data)
 
-        for cred_id in credentials:
-            netprof.credentials.add(cred_id)
+        for credential in credentials:
+            netprof.credentials.add(credential)
 
         return netprof
 

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -11,9 +11,11 @@
 """Module for serializing all model object for database storage"""
 
 import os
+from django.db import transaction
 from django.utils.translation import ugettext as _
-from rest_framework.serializers import ModelSerializer, ValidationError
-from api.models import Credential, HostCredential, NetworkProfile
+from rest_framework.serializers import ModelSerializer, ValidationError, \
+    SlugRelatedField
+from api.models import Credential, HostCredential, HostRange, NetworkProfile
 
 
 class CredentialSerializer(ModelSerializer):
@@ -41,11 +43,81 @@ class HostCredentialSerializer(ModelSerializer):
         return attrs
 
 
+class HostRangeField(SlugRelatedField):
+    # SlugRelatedField is *almost* what we want for HostRanges, but it
+    # doesn't allow creating new HostRanges because it requires them
+    # to already exist or else to_internal_value raises a
+    # ValidationError, and Serializer.is_valid() will call
+    # to_internal_value() before it calls our custom create() method.
+
+    def to_internal_value(self, data):
+        if not isinstance(data, str):
+            raise ValidationError('A host range must be a string.')
+
+        return {'host_range': data}
+
+
 class NetworkProfileSerializer(ModelSerializer):
     """Serializer for the NetworkProfile model"""
+
+    hosts = HostRangeField(
+        many=True,
+        slug_field='host_range',
+        queryset=HostRange.objects.all())
+
     class Meta:
         model = NetworkProfile
         fields = '__all__'
+
+    # Have to implement explicit create() and update() methods to
+    # allow creates/updates of nested HostRange field. See
+    # http://www.django-rest-framework.org/api-guide/relations/
+    @transaction.atomic
+    def create(self, validated_data):
+        hosts_data = validated_data.pop('hosts')
+        credentials = validated_data.pop('credentials')
+
+        netprof = NetworkProfile.objects.create(**validated_data)
+
+        for host_data in hosts_data:
+            HostRange.objects.create(network_profile=netprof,
+                                     **host_data)
+
+        for cred_id in credentials:
+            netprof.credentials.add(cred_id)
+
+        return netprof
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        # If we ever add optional fields to NetworkProfile, we need to
+        # add logic here to clear them on full update even if they are
+        # not supplied.
+
+        hosts_data = validated_data.pop('hosts', None)
+        credentials = validated_data.pop('credentials', None)
+                    
+        for name, value in validated_data.items():
+            setattr(instance, name, value)
+        instance.save()
+
+        # If hosts_data was not supplied and this is a full update,
+        # then we should already have raised a ValidationError before
+        # this point, so it's safe to use hosts_data as an indicator
+        # of whether to replace the hosts.
+        if hosts_data:
+            new_hosts = [
+                HostRange.objects.create(network_profile=instance,
+                                         **host_data)
+                for host_data in hosts_data]
+            instance.hosts.set(new_hosts)
+
+        # credentials is safe to use as a flag for the same reason as
+        # hosts_data above.
+        if credentials:
+            instance.credentials.set(credentials)
+
+        return instance
 
     @staticmethod
     def validate_name(name):
@@ -57,9 +129,8 @@ class NetworkProfileSerializer(ModelSerializer):
 
     @staticmethod
     def validate_hosts(hosts):
-        """Make sure the hosts list is reasonable."""
-        host_parts = hosts.split(',')
-        if not host_parts:
+        """Make sure the hosts list is present."""
+        if not hosts:
             raise ValidationError('NetworkProfile must have at least one '
                                   'host.')
 
@@ -76,7 +147,7 @@ class NetworkProfileSerializer(ModelSerializer):
 
     @staticmethod
     def validate_credentials(credentials):
-        """Make sure the credentials list is there."""
+        """Make sure the credentials list is present."""
         if not credentials:
             raise ValidationError('NetworkProfile must have at least one set '
                                   'of credentials.')

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -96,7 +96,7 @@ class NetworkProfileSerializer(ModelSerializer):
 
         hosts_data = validated_data.pop('hosts', None)
         credentials = validated_data.pop('credentials', None)
-                    
+
         for name, value in validated_data.items():
             setattr(instance, name, value)
         instance.save()

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -75,7 +75,7 @@ class NetworkProfileSerializer(ModelSerializer):
     @transaction.atomic
     def create(self, validated_data):
         hosts_data = validated_data.pop('hosts')
-        credentials = validated_data.pop('credentials')
+        credential_ids = validated_data.pop('credential_ids')
 
         netprof = NetworkProfile.objects.create(**validated_data)
 
@@ -83,8 +83,8 @@ class NetworkProfileSerializer(ModelSerializer):
             HostRange.objects.create(network_profile=netprof,
                                      **host_data)
 
-        for cred_id in credentials:
-            netprof.credentials.add(cred_id)
+        for cred_id in credential_ids:
+            netprof.credential_ids.add(cred_id)
 
         return netprof
 
@@ -95,7 +95,7 @@ class NetworkProfileSerializer(ModelSerializer):
         # not supplied.
 
         hosts_data = validated_data.pop('hosts', None)
-        credentials = validated_data.pop('credentials', None)
+        credential_ids = validated_data.pop('credential_ids', None)
 
         for name, value in validated_data.items():
             setattr(instance, name, value)
@@ -112,10 +112,10 @@ class NetworkProfileSerializer(ModelSerializer):
                 for host_data in hosts_data]
             instance.hosts.set(new_hosts)
 
-        # credentials is safe to use as a flag for the same reason as
+        # credential_ids is safe to use as a flag for the same reason as
         # hosts_data above.
-        if credentials:
-            instance.credentials.set(credentials)
+        if credential_ids:
+            instance.credential_ids.set(credential_ids)
 
         return instance
 
@@ -146,10 +146,10 @@ class NetworkProfileSerializer(ModelSerializer):
         return ssh_port
 
     @staticmethod
-    def validate_credentials(credentials):
-        """Make sure the credentials list is present."""
-        if not credentials:
+    def validate_credential_ids(credential_ids):
+        """Make sure the credential_ids list is present."""
+        if not credential_ids:
             raise ValidationError('NetworkProfile must have at least one set '
                                   'of credentials.')
 
-        return credentials
+        return credential_ids

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -58,18 +58,24 @@ class HostRangeField(SlugRelatedField):
 
         return {'host_range': data}
 
+    def display_value(self, instance):
+        return instance.host_range
+
 
 class CredentialsField(PrimaryKeyRelatedField):
     """Representation of the credentials associated with a network profile
     """
     def to_internal_value(self, data):
-        return HostCredential.objects.get(pk=data['id'])
+        return HostCredential.objects.get(pk=data)
 
     def to_representation(self, value):
-        return {
-            'id': value.id,
-            'name': value.name
-        }
+        return value.id
+
+    def display_value(self, instance):
+        display = instance
+        if isinstance(instance, HostCredential):
+            display = 'Credential: %s' % instance.name
+        return display
 
 
 class NetworkProfileSerializer(ModelSerializer):
@@ -145,7 +151,7 @@ class NetworkProfileSerializer(ModelSerializer):
     def validate_name(name):
         """Validate the name of the NetworkProfile."""
         if not isinstance(name, str) or not name.isprintable():
-            raise ValidationError('NetworkProfile must have printable name.')
+            raise ValidationError('Network profile must have printable name.')
 
         return name
 
@@ -153,7 +159,7 @@ class NetworkProfileSerializer(ModelSerializer):
     def validate_hosts(hosts):
         """Make sure the hosts list is present."""
         if not hosts:
-            raise ValidationError('NetworkProfile must have at least one '
+            raise ValidationError('Network profile must have at least one '
                                   'host.')
 
         return hosts
@@ -162,8 +168,8 @@ class NetworkProfileSerializer(ModelSerializer):
     def validate_ssh_port(ssh_port):
         """validate the ssh port."""
         if not ssh_port or ssh_port < 0 or ssh_port > 65536:
-            raise ValidationError('NetworkProfile must have ssh port in range '
-                                  '[0, 65535]')
+            raise ValidationError('Network profile must have ssh port in'
+                                  ' range [0, 65535]')
 
         return ssh_port
 
@@ -171,7 +177,7 @@ class NetworkProfileSerializer(ModelSerializer):
     def validate_credentials(credentials):
         """Make sure the credentials list is present."""
         if not credentials:
-            raise ValidationError('NetworkProfile must have at least one set '
+            raise ValidationError('Network profile must have at least one set '
                                   'of credentials.')
 
         return credentials

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -13,7 +13,7 @@
 import os
 from django.utils.translation import ugettext as _
 from rest_framework.serializers import ModelSerializer, ValidationError
-from api.models import Credential, HostCredential
+from api.models import Credential, HostCredential, NetworkProfile
 
 
 class CredentialSerializer(ModelSerializer):
@@ -39,3 +39,46 @@ class HostCredentialSerializer(ModelSerializer):
             raise ValidationError(_('ssh_keyfile, %s, is not a valid file'
                                     ' on the system.' % (ssh_keyfile)))
         return attrs
+
+
+class NetworkProfileSerializer(ModelSerializer):
+    """Serializer for the NetworkProfile model"""
+    class Meta:
+        model = NetworkProfile
+        fields = '__all__'
+
+    @staticmethod
+    def validate_name(name):
+        """Validate the name of the NetworkProfile."""
+        if not isinstance(name, str) or not name.isprintable():
+            raise ValidationError('NetworkProfile must have printable name.')
+
+        return name
+
+    @staticmethod
+    def validate_hosts(hosts):
+        """Make sure the hosts list is reasonable."""
+        host_parts = hosts.split(',')
+        if not host_parts:
+            raise ValidationError('NetworkProfile must have at least one '
+                                  'host.')
+
+        return hosts
+
+    @staticmethod
+    def validate_ssh_port(ssh_port):
+        """validate the ssh port."""
+        if not ssh_port or ssh_port < 0 or ssh_port > 65536:
+            raise ValidationError('NetworkProfile must have ssh port in range '
+                                  '[0, 65535]')
+
+        return ssh_port
+
+    @staticmethod
+    def validate_credentials(credentials):
+        """Make sure the credentials list is there."""
+        if not credentials:
+            raise ValidationError('NetworkProfile must have at least one set '
+                                  'of credentials.')
+
+        return credentials

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -44,6 +44,8 @@ class HostCredentialSerializer(ModelSerializer):
 
 
 class HostRangeField(SlugRelatedField):
+    """Representation of the host range with in a network profile
+    """
     # SlugRelatedField is *almost* what we want for HostRanges, but it
     # doesn't allow creating new HostRanges because it requires them
     # to already exist or else to_internal_value raises a
@@ -58,13 +60,15 @@ class HostRangeField(SlugRelatedField):
 
 
 class CredentialsField(PrimaryKeyRelatedField):
+    """Representation of the credentials associated with a network profile
+    """
     def to_internal_value(self, data):
         return HostCredential.objects.get(pk=data['id'])
 
-    def to_representation(self, instance):
+    def to_representation(self, value):
         return {
-            'id': instance.id,
-            'name': instance.name
+            'id': value.id,
+            'name': value.name
         }
 
 

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -121,11 +121,14 @@ class NetworkProfileSerializer(ModelSerializer):
         # this point, so it's safe to use hosts_data as an indicator
         # of whether to replace the hosts.
         if hosts_data:
+            old_hosts = list(instance.hosts.all())
             new_hosts = [
                 HostRange.objects.create(network_profile=instance,
                                          **host_data)
                 for host_data in hosts_data]
             instance.hosts.set(new_hosts)
+            for host in old_hosts:
+                host.delete()
 
         # credentials is safe to use as a flag for the same reason as
         # hosts_data above.

--- a/quipucords/api/tests.py
+++ b/quipucords/api/tests.py
@@ -319,14 +319,21 @@ class NetworkProfileTest(TestCase):
 
         data = {'name': 'netprof2-new',
                 'hosts': ['1.2.3.5'],
-                'ssh_port': '22',
-                'credentials': [self.cred_for_upload]}
+                'ssh_port': 22,
+                'credentials': [{
+                    'id': self.cred.id,
+                    'name': self.cred.name}]}
         url = reverse('networkprofile-detail', args=(initial['id'],))
         response = self.client.put(url,
                                    json.dumps(data),
                                    content_type='application/json',
                                    format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # data should be a strict subset of the response, because the
+        # response adds an id field.
+        for key, value in data.items():
+            self.assertEqual(data[key], response.json()[key])
 
     def test_partial_update(self):
         """Partially update a NetworkProfile."""
@@ -345,6 +352,8 @@ class NetworkProfileTest(TestCase):
                                      content_type='application/json',
                                      format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['name'], 'netprof3-new')
+        self.assertEqual(response.json()['hosts'], ['1.2.3.5'])
 
     def test_delete(self):
         """Delete a NetworkProfile."""

--- a/quipucords/api/tests.py
+++ b/quipucords/api/tests.py
@@ -178,7 +178,7 @@ class NetworkProfileTest(TestCase):
         """Create a network profile, return the response as a dict."""
 
         response = self.create(data)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED) 
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         return response.json()
 
     def test_successful_create(self):
@@ -332,7 +332,7 @@ class NetworkProfileTest(TestCase):
 
         # data should be a strict subset of the response, because the
         # response adds an id field.
-        for key, value in data.items():
+        for key, value in data.items():  # pylint: disable=unused-variable
             self.assertEqual(data[key], response.json()[key])
 
     def test_partial_update(self):

--- a/quipucords/api/tests.py
+++ b/quipucords/api/tests.py
@@ -182,7 +182,7 @@ class NetworkProfileTest(TestCase):
         data = {'name': 'netprof1',
                 'hosts': ['1.2.3.4'],
                 'ssh_port': '22',
-                'credentials': [self.cred_id]}
+                'credential_ids': [self.cred_id]}
         response = self.create_expect_201(data)
         self.assertIn('id', response)
 
@@ -192,7 +192,7 @@ class NetworkProfileTest(TestCase):
         data = {'name': 'netprof1',
                 'hosts': ['1.2.3.4', '1.2.3.5'],
                 'ssh_port': '22',
-                'credentials': [self.cred_id]}
+                'credential_ids': [self.cred_id]}
         self.create_expect_201(data)
 
     def test_create_no_name(self):
@@ -201,7 +201,7 @@ class NetworkProfileTest(TestCase):
         self.create_expect_400(
             {'hosts': '1.2.3.4',
              'ssh_port': '22',
-             'credentials': [self.cred_id]})
+             'credential_ids': [self.cred_id]})
 
     def test_create_unprintable_name(self):
         """The NetworkProfile name must be printable."""
@@ -210,7 +210,7 @@ class NetworkProfileTest(TestCase):
             {'name': '\r\n',
              'hosts': '1.2.3.4',
              'ssh_port': '22',
-             'credentials': [self.cred_id]})
+             'credential_ids': [self.cred_id]})
 
     def test_create_no_host(self):
         """A NetworkProfile needs a host."""
@@ -218,7 +218,7 @@ class NetworkProfileTest(TestCase):
         self.create_expect_400(
             {'name': 'netprof1',
              'ssh_port': '22',
-             'credentials': [self.cred_id]})
+             'credential_ids': [self.cred_id]})
 
     def test_create_empty_host(self):
         """An empty string is not a host identifier."""
@@ -227,7 +227,7 @@ class NetworkProfileTest(TestCase):
             {'name': 'netprof1',
              'hosts': [],
              'ssh_port': '22',
-             'credentials': [self.cred_id]})
+             'credential_ids': [self.cred_id]})
 
     def test_create_no_ssh_port(self):
         """A NetworkProfile needs an ssh port."""
@@ -235,7 +235,7 @@ class NetworkProfileTest(TestCase):
         self.create_expect_400(
             {'name': 'netprof1',
              'hosts': '1.2.3.4',
-             'credentials': [self.cred_id]})
+             'credential_ids': [self.cred_id]})
 
     def test_create_bad_ssh_port(self):
         """-1 is not a valid ssh port."""
@@ -244,7 +244,7 @@ class NetworkProfileTest(TestCase):
             {'name': 'netprof1',
              'hosts': '1.2.3.4',
              'ssh_port': '-1',
-             'credentials': [self.cred_id]})
+             'credential_ids': [self.cred_id]})
 
     def test_create_no_credentials(self):
         """A NetworkProfile needs credentials."""
@@ -261,14 +261,26 @@ class NetworkProfileTest(TestCase):
             {'name': 'netprof1',
              'hosts': '1.2.3.4',
              'ssh_port': '22',
-             'credentials': []})
+             'credential_ids': []})
 
     def test_list(self):
         """List all NetworkProfile objects."""
 
+        data = {'name': 'netprof',
+                'ssh_port': '22',
+                'hosts': ['1.2.3.4'],
+                'credential_ids': [self.cred_id]}
+        for i in range(3):
+            this_data = data.copy()
+            this_data['name'] = 'netprof' + str(i)
+            self.create_expect_201(this_data)
+
         url = reverse('networkprofile-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        content = json.loads(response.content)
+        self.assertGreaterEqual(len(content), 3)
 
     def test_retrieve(self):
         """Get details on a specific NetworkProfile by primary key."""
@@ -277,7 +289,7 @@ class NetworkProfileTest(TestCase):
             'name': 'netprof1',
             'hosts': ['1.2.3.4'],
             'ssh_port': '22',
-            'credentials': [self.cred_id]})
+            'credential_ids': [self.cred_id]})
 
         url = reverse('networkprofile-detail', args=(initial['id'],))
         response = self.client.get(url)
@@ -292,12 +304,12 @@ class NetworkProfileTest(TestCase):
             'name': 'netprof2',
             'hosts': ['1.2.3.4'],
             'ssh_port': '22',
-            'credentials': [self.cred_id]})
+            'credential_ids': [self.cred_id]})
 
         data = {'name': 'netprof2-new',
                 'hosts': ['1.2.3.5'],
                 'ssh_port': '22',
-                'credentials': [self.cred_id]}
+                'credential_ids': [self.cred_id]}
         url = reverse('networkprofile-detail', args=(initial['id'],))
         response = self.client.put(url,
                                    json.dumps(data),
@@ -312,7 +324,7 @@ class NetworkProfileTest(TestCase):
             'name': 'netprof3',
             'hosts': ['1.2.3.4'],
             'ssh_port': '22',
-            'credentials': [self.cred_id]})
+            'credential_ids': [self.cred_id]})
 
         data = {'name': 'netprof3-new',
                 'hosts': ['1.2.3.5']}
@@ -329,7 +341,7 @@ class NetworkProfileTest(TestCase):
         data = {'name': 'netprof3',
                 'hosts': ['1.2.3.4'],
                 'ssh_port': '22',
-                'credentials': [self.cred_id]}
+                'credential_ids': [self.cred_id]}
         response = self.create_expect_201(data)
 
         url = reverse('networkprofile-detail', args=(response['id'],))

--- a/quipucords/api/tests.py
+++ b/quipucords/api/tests.py
@@ -144,3 +144,173 @@ class HostCredentialTest(TestCase):
         url = reverse("hostcred-detail", args=(cred.pk,))
         resp = self.client.delete(url, format='json')
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+
+class NetworkProfileTest(TestCase):
+    """Test the basic NetworkProfile infrastructure."""
+
+    def create(self, data):
+        """Utility function to call the create endpoint."""
+
+        url = reverse('networkprofile-list')
+        return self.client.post(url, data, format='json')
+
+    def create_expect_400(self, data):
+        """We will do a lot of create tests that expect HTTP 400s."""
+
+        response = self.create(data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_successful_create(self):
+        """A valid create request should succeed."""
+
+        data = {'name': 'netprof1',
+                'hosts': '1.2.3.4',
+                'ssh_port': '22',
+                'credentials': 'cred1'}
+        response = self.create(data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(models.NetworkProfile.objects.count(), 1)
+        self.assertEqual(models.NetworkProfile.objects.get().name, 'netprof1')
+
+    def test_create_no_name(self):
+        """A create request must have a name."""
+
+        self.create_expect_400(
+            {'hosts': '1.2.3.4',
+             'ssh_port': '22',
+             'credentials': 'cred1'})
+
+    def test_create_unprintable_name(self):
+        """The NetworkProfile name must be printable."""
+
+        self.create_expect_400(
+            {'name': '\r\n',
+             'hosts': '1.2.3.4',
+             'ssh_port': '22',
+             'credentials': 'cred1'})
+
+    def test_create_no_host(self):
+        """A NetworkProfile needs a host."""
+
+        self.create_expect_400(
+            {'name': 'netprof1',
+             'ssh_port': '22',
+             'credentials': 'cred1'})
+
+    def test_create_empty_host(self):
+        """An empty string is not a host identifier."""
+
+        self.create_expect_400(
+            {'name': 'netprof1',
+             'hosts': '',
+             'ssh_port': '22',
+             'credentials': 'cred1'})
+
+    def test_create_no_ssh_port(self):
+        """A NetworkProfile needs an ssh port."""
+
+        self.create_expect_400(
+            {'name': 'netprof1',
+             'hosts': '1.2.3.4',
+             'credentials': 'cred1'})
+
+    def test_create_bad_ssh_port(self):
+        """-1 is not a valid ssh port."""
+
+        self.create_expect_400(
+            {'name': 'netprof1',
+             'hosts': '1.2.3.4',
+             'ssh_port': '-1',
+             'credentials': 'cred1'})
+
+    def test_create_no_credentials(self):
+        """A NetworkProfile needs credentials."""
+
+        self.create_expect_400(
+            {'name': 'netprof1',
+             'hosts': '1.2.3.4',
+             'ssh_port': '22'})
+
+    def test_create_empty_credentials(self):
+        """The empty string is not a valid credential list."""
+
+        self.create_expect_400(
+            {'name': 'netprof1',
+             'hosts': '1.2.3.4',
+             'ssh_port': '22',
+             'credentials': ''})
+
+    def test_list(self):
+        """List all NetworkProfile objects."""
+
+        url = reverse('networkprofile-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieve(self):
+        """Get details on a specific NetworkProfile by primary key."""
+
+        netprof = models.NetworkProfile(name='netprof1',
+                                        hosts='1.2.3.4',
+                                        ssh_port='22',
+                                        credentials='cred1')
+        netprof.save()
+
+        url = reverse('networkprofile-detail', args=(netprof.pk,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # We don't have to test that update validates fields correctly
+    # because the validation code is shared between create and update.
+    def test_update(self):
+        """Completely update a NetworkProfile."""
+
+        netprof = models.NetworkProfile(name='netprof2',
+                                        hosts='1.2.3.4',
+                                        ssh_port='22',
+                                        credentials='cred1')
+        netprof.save()
+
+        data = {'name': 'netprof2-new',
+                'hosts': '1.2.3.5',
+                'ssh_port': '22',
+                'credentials': 'cred1'}
+        url = reverse('networkprofile-detail', args=(netprof.pk,))
+        response = self.client.put(url,
+                                   json.dumps(data),
+                                   content_type='application/json',
+                                   format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_partial_update(self):
+        """Partially update a NetworkProfile."""
+
+        netprof = models.NetworkProfile(name='netprof3',
+                                        hosts='1.2.3.4',
+                                        ssh_port='22',
+                                        credentials='cred1')
+        netprof.save()
+
+        data = {'name': 'netprof3-new',
+                'hosts': '1.2.3.5'}
+#                 'partial': 'true'}
+        url = reverse('networkprofile-detail', args=(netprof.pk,))
+        response = self.client.patch(url,
+                                     json.dumps(data),
+                                     content_type='application/json',
+                                     format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete(self):
+        """Delete a NetworkProfile."""
+
+        netprof = models.NetworkProfile(name='netprof3',
+                                        hosts='1.2.3.4',
+                                        ssh_port='22',
+                                        credentials='cred1')
+        netprof.save()
+
+        url = reverse('networkprofile-detail', args=(netprof.pk,))
+        response = self.client.delete(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/quipucords/api/tests.py
+++ b/quipucords/api/tests.py
@@ -193,7 +193,7 @@ class NetworkProfileTest(TestCase):
                 'hosts': ['1.2.3.4', '1.2.3.5'],
                 'ssh_port': '22',
                 'credentials': [self.cred_id]}
-        response = self.create_expect_201(data)
+        self.create_expect_201(data)
 
     def test_create_no_name(self):
         """A create request must have a name."""

--- a/quipucords/api/tests.py
+++ b/quipucords/api/tests.py
@@ -156,9 +156,7 @@ class NetworkProfileTest(TestCase):
             password='password',
             sudo_password=None,
             ssh_keyfile=None)
-        self.cred_for_upload = {
-            'id': self.cred.id
-        }
+        self.cred_for_upload = self.cred.id
 
     def create(self, data):
         """Utility function to call the create endpoint."""
@@ -302,9 +300,7 @@ class NetworkProfileTest(TestCase):
         self.assertIn('credentials', response.json())
         creds = response.json()['credentials']
 
-        self.assertEqual(creds,
-                         [{'id': self.cred.id,
-                           'name': self.cred.name}])
+        self.assertEqual(creds, [self.cred.id])
 
     # We don't have to test that update validates fields correctly
     # because the validation code is shared between create and update.
@@ -320,9 +316,7 @@ class NetworkProfileTest(TestCase):
         data = {'name': 'netprof2-new',
                 'hosts': ['1.2.3.5'],
                 'ssh_port': 22,
-                'credentials': [{
-                    'id': self.cred.id,
-                    'name': self.cred.name}]}
+                'credentials': [self.cred.id]}
         url = reverse('networkprofile-detail', args=(initial['id'],))
         response = self.client.put(url,
                                    json.dumps(data),

--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -19,6 +19,9 @@ ROUTER = SimpleRouter()
 ROUTER.register(r'credentials/hosts',
                 views.HostCredentialViewSet,
                 base_name='hostcred')
+ROUTER.register(r'profiles/networks',
+                views.NetworkProfileViewSet,
+                base_name='networkprofile')
 
 # pylint: disable=invalid-name
 urlpatterns = ROUTER.urls

--- a/quipucords/api/views.py
+++ b/quipucords/api/views.py
@@ -14,12 +14,12 @@ from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
-from api.serializers import CredentialSerializer, HostCredentialSerializer, \
-    NetworkProfileSerializer
-from api.models import Credential, HostCredential, NetworkProfile
 from django_filters.rest_framework import (DjangoFilterBackend, Filter,
                                            FilterSet)
 from filters import mixins
+from api.serializers import CredentialSerializer, HostCredentialSerializer, \
+    NetworkProfileSerializer
+from api.models import Credential, HostCredential, NetworkProfile
 
 PASSWORD_KEY = 'password'
 SUDO_PASSWORD_KEY = 'sudo_password'

--- a/quipucords/api/views.py
+++ b/quipucords/api/views.py
@@ -14,8 +14,9 @@ from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
-from api.serializers import CredentialSerializer, HostCredentialSerializer
-from api.models import Credential, HostCredential
+from api.serializers import CredentialSerializer, HostCredentialSerializer, \
+    NetworkProfileSerializer
+from api.models import Credential, HostCredential, NetworkProfile
 
 PASSWORD_KEY = 'password'
 SUDO_PASSWORD_KEY = 'sudo_password'
@@ -78,3 +79,37 @@ class HostCredentialViewSet(ModelViewSet):
         self.perform_update(serializer)
         cred = mask_credential(serializer.data)
         return Response(cred)
+
+
+class NetworkProfileViewSet(ModelViewSet):
+    """A view set for NetworkProfiles"""
+
+    queryset = NetworkProfile.objects.all()
+    serializer_class = NetworkProfileSerializer
+
+    def list(self, request):  # pylint: disable=unused-argument
+        serializer = NetworkProfileSerializer(self.queryset, many=True)
+        return Response(serializer.data)
+
+    # pylint: disable=unused-argument
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED,
+                        headers=headers)
+
+    def retrieve(self, request, pk=None):  # pylint: disable=unused-argument
+        network_profile = get_object_or_404(self.queryset, pk=pk)
+        serializer = NetworkProfileSerializer(network_profile)
+        return Response(serializer.data)
+
+    # pylint: disable=unused-argument
+    def update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data,
+                                         partial=kwargs.get('partial', False))
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        return Response(serializer.data)

--- a/quipucords/api/views.py
+++ b/quipucords/api/views.py
@@ -63,6 +63,15 @@ class HostCredentialFilter(FilterSet):
         fields = ['name']
 
 
+class NetworkProfileFilter(FilterSet):
+    """Filter for network profiles by name"""
+    name = ListFilter(name='name')
+
+    class Meta:
+        model = NetworkProfile
+        fields = ['name']
+
+
 # pylint: disable=too-many-ancestors
 class CredentialViewSet(ModelViewSet):
     """A view set for the Credential model"""
@@ -75,7 +84,6 @@ class HostCredentialViewSet(mixins.FiltersMixin, ModelViewSet):
     queryset = HostCredential.objects.all()
     serializer_class = HostCredentialSerializer
     filter_backends = (DjangoFilterBackend,)
-    # filter_fields = ('name',)
     filter_class = HostCredentialFilter
 
     def list(self, request):  # pylint: disable=unused-argument
@@ -117,9 +125,12 @@ class NetworkProfileViewSet(ModelViewSet):
 
     queryset = NetworkProfile.objects.all()
     serializer_class = NetworkProfileSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = NetworkProfileFilter
 
     def list(self, request):  # pylint: disable=unused-argument
-        serializer = NetworkProfileSerializer(self.queryset, many=True)
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = NetworkProfileSerializer(queryset, many=True)
         return Response(serializer.data)
 
     # pylint: disable=unused-argument


### PR DESCRIPTION
This allows basic CRUD operations on NetworkProfiles, and does some
validation. The validation is not complete, but importing all of the
normalization and validation we do in rho will be a big change, and I
think it makes sense to get this reviewed first.

Closes #25 .