### PR TITLE
Update readme with required package info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,13 @@ Installing Dependencies
 From within the local clone root directory run the following command to install
 dependencies needed for development and testing purposes::
 
+First, you need to collect some packages available through either `yum` (RHEL)
+or `dnf` (fedora)::
+
+    sudo yum install python-tools
+
+The rest of the packages can be installed locally in your virtual environment::
+
     pip install -r requirements.txt
 
 ^^^^^^^


### PR DESCRIPTION
`/usr/bin/2to3` is required by one of the dependencies installed by pip,
and this is provided by the `python-tools` package in both Fedora and RHEL
7

Just a small update, but this not installed on a standard RHEL 7 or Fedora 25 install, and may slow users down, as the error  message is not totally clear, nor what package might provide this utility.