### PR TITLE
Modify behavior for trailing slashes on REST API

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -16,7 +16,7 @@ tags:
   description: "API related to the Host Credential model"
 
 paths:
-  /credentials/hosts:
+  /credentials/hosts/:
     post:
       tags:
         - "Host Credential"
@@ -136,7 +136,7 @@ paths:
           description: "Host credential deleted"
         404:
           description: "Host credential not found"
-  /profiles/networks:
+  /profiles/networks/:
     post:
       tags:
         - "Network Profile"
@@ -256,7 +256,7 @@ paths:
           description: "Network profile deleted"
         404:
           description: "Network profile not found"
-  /scans:
+  /scans/:
     post:
       tags:
         - "Scan"

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -37,6 +37,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+APPEND_SLASH = False
 
 # Application definition
 


### PR DESCRIPTION
Closes #89 
- Trailing slashes are now required (return 404 regardless of HTTP verb)
- Updated swagger to match new requirement