### PR TITLE
Handle failed hosts post discovery

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -49,6 +49,7 @@ class ScanJob(models.Model):
     max_concurrency = models.PositiveIntegerField(default=50)
     systems_count = models.PositiveIntegerField(null=True)
     systems_scanned = models.PositiveIntegerField(null=True)
+    failed_scans = models.PositiveIntegerField(null=True)
     fact_collection_id = models.IntegerField(null=True)
 
     def __str__(self):
@@ -59,12 +60,14 @@ class ScanJob(models.Model):
             'max_concurrency: {}, '\
             'systems_count: {}, '\
             'systems_scanned: {}, '\
+            'failed_scans: {}, '\
             'fact_collection_id: {}'.format(self.id,
                                             self.scan_type,
                                             self.profile,
                                             self.max_concurrency,
                                             self.systems_count,
                                             self.systems_scanned,
+                                            self.failed_scans,
                                             self.fact_collection_id) + '}'
 
     class Meta:

--- a/quipucords/api/scanjob/serializer.py
+++ b/quipucords/api/scanjob/serializer.py
@@ -41,6 +41,7 @@ class ScanJobSerializer(ModelSerializer):
     max_concurrency = IntegerField(required=False, min_value=1, default=50)
     systems_count = IntegerField(required=False, min_value=0, read_only=True)
     systems_scanned = IntegerField(required=False, min_value=0, read_only=True)
+    failed_scans = IntegerField(required=False, min_value=0, read_only=True)
     fact_collection_id = IntegerField(read_only=True)
 
     class Meta:

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -122,6 +122,7 @@ class ScanJobTest(TestCase):
                      'max_concurrency': 50,
                      'systems_count': None,
                      'systems_scanned': None,
+                     'failed_scans': None,
                      'fact_collection_id': None},
                     {'id': 2,
                      'profile': {'id': 1, 'name': 'profile1'},
@@ -130,6 +131,7 @@ class ScanJobTest(TestCase):
                      'max_concurrency': 50,
                      'systems_count': None,
                      'systems_scanned': None,
+                     'failed_scans': None,
                      'fact_collection_id': None}]
         self.assertEqual(content, expected)
 

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -37,8 +37,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-APPEND_SLASH = False
-
 # Application definition
 
 INSTALLED_APPS = [

--- a/quipucords/scanner/tests_discovery.py
+++ b/quipucords/scanner/tests_discovery.py
@@ -68,6 +68,7 @@ class DiscoveryScannerTest(TestCase):
 
         self.scanjob = ScanJob(profile_id=self.network_profile.id,
                                scan_type=ScanJob.DISCOVERY)
+        self.scanjob.failed_scans = 0
         self.scanjob.save()
 
     def test_construct_vars(self):
@@ -83,7 +84,7 @@ class DiscoveryScannerTest(TestCase):
 
     def test_populate_callback(self):
         """Test the population of the callback object."""
-        callback = ResultCallback()
+        callback = ResultCallback(scanjob=self.scanjob)
         host = Mock(name='1.2.3.4')
         result = Mock(_host=host, _results={'rc': 0})
         callback.v2_runner_on_ok(result)

--- a/quipucords/scanner/utils.py
+++ b/quipucords/scanner/utils.py
@@ -221,7 +221,7 @@ def _process_connect_callback(callback, credential):
     return success, failed
 
 
-def _construct_error(return_code):
+def _construct_error_msg(return_code):
     message = ANSIBLE_DEFAULT_ERR_MSG
     if return_code == TaskQueueManager.RUN_FAILED_HOSTS:
         message = ANSIBLE_FAILED_HOST_ERR_MSG
@@ -229,7 +229,11 @@ def _construct_error(return_code):
         message = ANSIBLE_UNREACHABLE_HOST_ERR_MSG
     elif return_code == TaskQueueManager.RUN_FAILED_BREAK_PLAY:
         message = ANSIBLE_PLAYBOOK_ERR_MSG
-    return AnsibleError(message=message)
+    return message
+
+
+def _construct_error(return_code):
+    return AnsibleError(message=_construct_error_msg(return_code))
 
 
 def _handle_ssh_passphrase(credential):


### PR DESCRIPTION
The following changes were made:
- Host scans will now continue even if a previously reachable host is not unreachable
- If a host connectivity changes, the host will move from success to failed in the scan results
- Host scan will now count failed scans so a completed scan does not appear to be missing systems
- Added back APPEND_SLASH

Closes #203 