### PR TITLE
Suppress stderr for anaconda-ks.cfg command

### DIFF
--- a/roles/date/tasks/main.yml
+++ b/roles/date/tasks/main.yml
@@ -6,7 +6,7 @@
   ignore_errors: yes
 
 - name: gather date.anaconda_log fact
-  raw: ls --full-time /root/anaconda-ks.cfg | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
+  raw: ls --full-time /root/anaconda-ks.cfg 2>/dev/null | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
   register: internal_date_anaconda_log_cmd
   become: yes
   ignore_errors: yes


### PR DESCRIPTION
This will cause the date to be None.  Facts with None are not included.

Closes #217 