### PR TITLE
Add quipucords/db.sqlite3 to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@
 
 Dockerfile
 client
-
+quipucords/db.sqlite3


### PR DESCRIPTION
This lets us build a Docker container after previously using the
source tree for running a server directly. This is an improvement on
the current situation, but the build still might not be clean.

Closes #341 