### PR TITLE
Port redhat_release role from rho to quipucords

### DIFF
--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -139,9 +139,22 @@ class InspectTaskRunner(ScanTaskRunner):
 
         :returns: An array of dictionaries of facts
         """
-        roles = ['check_dependencies', 'connection', 'cpu', 'date',
-                 'dmi', 'etc_release', 'file_contents', 'jboss_eap',
-                 'ifconfig', 'uname', 'virt', 'virt_what', 'host_done']
+        roles = [
+            'check_dependencies',
+            'connection',
+            'cpu',
+            'date',
+            'dmi',
+            'etc_release',
+            'file_contents',
+            'jboss_eap',
+            'ifconfig',
+            'redhat_release',
+            'uname',
+            'virt',
+            'virt_what',
+            'host_done',
+        ]
         playbook = {'name': 'scan systems for product fingerprint facts',
                     'hosts': 'all',
                     'gather_facts': False,

--- a/roles/redhat_release/tasks/main.yml
+++ b/roles/redhat_release/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- name: initialize redhat_release facts
+  set_fact:
+    redhat_release_name: 'N/A (rpm not found)'
+    redhat_release_version: 'N/A (rpm not found)'
+    redhat_release_release: 'N/A (rpm not found)'
+
+- name: gather internal_redhat_release fact
+  raw: rpm -q --queryformat "%{NAME}\n%{VERSION}\n%{RELEASE}\n" --whatprovides redhat-release
+  register: internal_redhat_release
+  ignore_errors: yes
+  when: 'internal_have_rpm'
+
+- name: set redhat_release facts based on internal_redhat_release
+  set_fact:
+    redhat_release_name: "{{ internal_redhat_release['stdout_lines'][0] }}"
+    redhat_release_version: "{{ internal_redhat_release['stdout_lines'][1] }}"
+    redhat_release_release: "{{ internal_redhat_release['stdout_lines'][2] }}"
+  ignore_errors: yes
+  when:
+    - "'stdout_lines' in internal_redhat_release"
+    - "internal_redhat_release['stdout_lines']|length == 3"


### PR DESCRIPTION
This should run 3x faster than the corresponding role in rho because this
implementation is deduplicated and collects its information from rpm only
once instead of using three separate rpm commands.

Closes #360.