### PR TITLE
Add token authentication to server. Closes #322.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,14 @@ install: build
 	$(PYTHON) setup.py install -f
 
 test:
-	$(PYTHON) quipucords/manage.py test -v 2 quipucords/ qpc/
+	QPC_DISABLE_AUTHENTICATION=True $(PYTHON) quipucords/manage.py test -v 2 quipucords/ qpc/
 
 test-case:
 	echo $(pattern)
 	$(PYTHON) quipucords/manage.py test -v 2 quipucords/ qpc/ -p $(pattern)
 
 test-coverage:
-	coverage run --source=quipucords/,qpc/ quipucords/manage.py test -v 2 quipucords/ qpc/
+	QPC_DISABLE_AUTHENTICATION=True coverage run --source=quipucords/,qpc/ quipucords/manage.py test -v 2 quipucords/ qpc/
 	coverage report -m --omit $(OMIT_PATTERNS)
 
 lint-flake8:
@@ -56,7 +56,7 @@ lint-pylint:
 lint: lint-flake8 lint-pylint
 
 server-init:
-	$(PYTHON) quipucords/manage.py makemigrations api; $(PYTHON) quipucords/manage.py migrate
+	$(PYTHON) quipucords/manage.py makemigrations api; $(PYTHON) quipucords/manage.py migrate; echo "from django.contrib.auth.models import User; User.objects.filter(email='admin@example.com').delete(); User.objects.create_superuser('admin', 'admin@example.com', 'pass')" | $(PYTHON) quipucords/manage.py shell
 
 serve:
 	$(PYTHON) quipucords/manage.py runserver

--- a/README.rst
+++ b/README.rst
@@ -155,12 +155,17 @@ In order to setup the server execute the following command::
 
     make server-init
 
+This command will create a super user with name *admin* and password of *pass*.
 
 Running Server
 ^^^^^^^^^^^^^^
 In order to run the server execute the following command::
 
     make serve
+
+In order to login to the server you must launch to http://127.0.0.1:8000/admin/ and provide the super user credentials.
+From here you can change the password and also go to some fo the browsable APIs like http://127.0.0.1:8000/api/v1/credentials/.
+Using the CLI you can configure access to the server using `qpc server config` and login using `qpc server login`.
 
 If you intend to run on Mac OS there are several more steps required.
 

--- a/docs/source/man.rst
+++ b/docs/source/man.rst
@@ -30,6 +30,10 @@ Usage
 
 ``qpc`` performs four major tasks:
 
+* Server login:
+
+  ``qpc server login --username admin``
+
 * Creating credentials:
 
   ``qpc cred add ...``
@@ -48,8 +52,53 @@ Usage
 
 The following sections describe these commands, their subcommands, and their options in more detail.
 
+Server Authentication
+---------------------
+
+Use the ``qpc server`` command to configure connectivity and login and logout of the server.
+
+Configuring the server
+~~~~~~~~~~~~~~~~~~~~~~
+
+To configure connection to the server supply the host address and optionally the port.
+
+**qpc server config --host=** *host* **[--port=** *port* **]**
+
+``--host=host``
+
+  Required. Sets the host address for the server. If running QPC on the same system as the server you can use "127.0.0.1".
+
+``--port=port``
+
+  Optional. Sets the port to connect to the server on, defaulting to 8000.
+
+
+Authentication with the server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To log in to the server after the connection has been configured use the login subcommand.
+
+**qpc server login [--username=** *username* **]**
+
+``--username=username``
+
+  Optional. Sets the username used to authenticate with the server.
+
+
+This command retrieves a token used for authentication for subsequent CLI commands.
+
+Log out of the server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To log out of the server use the logout subcommand.
+
+**qpc server logout***
+
+This command removes the token used for authentication for subsequent CLI commands.
+
+
 Credentials
------------------------
+-----------
 
 Use the ``qpc cred`` command to create and manage credentials.
 
@@ -58,7 +107,7 @@ A credential defines a set of user authentication configuration to be used durin
 When a scan runs, it uses a source that contains the host names or IP addresses to be accessed. The source also contains references to the credentials that are required to access those systems. A single source can contain a reference to multiple credentials as needed to connect to all systems in that network.
 
 Creating and Editing Credentials
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To create a credential, supply SSH credentials as either a username-password pair or a username-key pair. Quipucords stores each set of credentials in a separate credential entry.
 
@@ -352,4 +401,4 @@ Quipucords was originally written by Chris Hambridge <chambrid@redhat.com>, Noah
 Copyright
 ---------
 
-(c) 2017 Red Hat, Inc. Licensed under the GNU Public License version 3.
+(c) 2018 Red Hat, Inc. Licensed under the GNU Public License version 3.

--- a/qpc/cli.py
+++ b/qpc/cli.py
@@ -23,7 +23,9 @@ from qpc.utils import (ensure_config_dir_exists,
                        ensure_data_dir_exists,
                        setup_logging,
                        log)
-from qpc.server.commands import ConfigureHostCommand
+from qpc.server.commands import (ConfigureHostCommand,
+                                 LoginHostCommand,
+                                 LogoutHostCommand)
 from qpc.cred.commands import (CredAddCommand,
                                CredListCommand,
                                CredEditCommand,
@@ -64,7 +66,8 @@ class CLI(object):
         self.args = None
         self.subcommands = {}
         self._add_subcommand(server.SUBCOMMAND,
-                             [ConfigureHostCommand])
+                             [ConfigureHostCommand, LoginHostCommand,
+                              LogoutHostCommand])
         self._add_subcommand(cred.SUBCOMMAND,
                              [CredAddCommand, CredListCommand,
                               CredEditCommand, CredShowCommand,

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -119,3 +119,9 @@ VALIDATE_SSHKEY = 'The file path provided, %s, could not be found on the ' \
 CONN_PASSWORD = 'Provide connection password.'
 SUDO_PASSWORD = 'Provide password for sudo.'
 SSH_PASSPHRASE = 'Provide passphrase for ssh keyfile.'
+
+LOGIN_USER_HELP = 'The username to login to the server.'
+LOGIN_USERNAME_PROMPT = 'Username:'
+LOGIN_SUCCESS = 'Login successful.'
+
+LOGOUT_SUCCESS = 'Logged out.'

--- a/qpc/server/__init__.py
+++ b/qpc/server/__init__.py
@@ -13,3 +13,7 @@
 
 SUBCOMMAND = 'server'
 CONFIG = 'config'
+LOGIN = 'login'
+LOGOUT = 'logout'
+
+LOGIN_URI = '/api/v1/token/'

--- a/qpc/server/commands.py
+++ b/qpc/server/commands.py
@@ -13,3 +13,5 @@
 # flake8: noqa
 # pylint: disable=unused-import
 from qpc.server.configure_host import ConfigureHostCommand
+from qpc.server.login_host import LoginHostCommand
+from qpc.server.logout_host import LogoutHostCommand

--- a/qpc/server/login_host.py
+++ b/qpc/server/login_host.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+#
+"""LoginHostCommand is used to login with username and password."""
+
+from __future__ import print_function
+from getpass import getpass
+from requests import codes
+from qpc.clicommand import CliCommand
+from qpc.request import POST
+from qpc.utils import write_client_token
+import qpc.server as server
+from qpc.translation import _
+import qpc.messages as messages
+
+
+# pylint: disable=too-few-public-methods
+class LoginHostCommand(CliCommand):
+    """Defines the login host command.
+
+    This command is for logging into the target
+    host for the CLI.
+    """
+
+    SUBCOMMAND = server.SUBCOMMAND
+    ACTION = server.LOGIN
+
+    def __init__(self, subparsers):
+        """Create command."""
+        # pylint: disable=no-member
+        CliCommand.__init__(self, self.SUBCOMMAND, self.ACTION,
+                            subparsers.add_parser(self.ACTION), POST,
+                            server.LOGIN_URI, [codes.ok])
+
+        self.parser.add_argument('--username', dest='username',
+                                 metavar='USERNAME',
+                                 help=_(messages.LOGIN_USER_HELP),
+                                 required=False)
+        self.username = None
+        self.password = None
+
+    def _validate_args(self):
+        CliCommand._validate_args(self)
+
+        if 'username' in self.args and self.args.username:
+            # check for file existence on system
+            self.username = self.args.username
+        else:
+            self.username = input(_(messages.LOGIN_USERNAME_PROMPT))
+
+        self.password = getpass()
+
+    def _build_data(self):
+        """Construct the dictionary credential given our arguments.
+
+        :returns: a dictionary representing the credential being added
+        """
+        self.req_payload = {'username': self.username,
+                            'password': self.password}
+
+    def _handle_response_success(self):
+        json_data = self.response.json()
+        write_client_token(json_data)
+        print(_(messages.LOGIN_SUCCESS))

--- a/qpc/server/logout_host.py
+++ b/qpc/server/logout_host.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+#
+"""LogoutHostCommand is used to remove any existing login token."""
+
+from __future__ import print_function
+from qpc.clicommand import CliCommand
+import qpc.server as server
+from qpc.utils import delete_client_token
+from qpc.translation import _
+import qpc.messages as messages
+
+
+# pylint: disable=too-few-public-methods
+class LogoutHostCommand(CliCommand):
+    """Defines the logout host command.
+
+    This command is for logging out of theserver for the CLI.
+    """
+
+    SUBCOMMAND = server.SUBCOMMAND
+    ACTION = server.LOGOUT
+
+    def __init__(self, subparsers):
+        """Create command."""
+        # pylint: disable=no-member
+        CliCommand.__init__(self, self.SUBCOMMAND, self.ACTION,
+                            subparsers.add_parser(self.ACTION), None,
+                            None, [])
+
+    def _do_command(self):
+        """Remove the client token."""
+        delete_client_token()
+        print(_(messages.LOGOUT_SUCCESS))

--- a/qpc/server/tests_login.py
+++ b/qpc/server/tests_login.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+#
+"""Test the CLI module."""
+
+import unittest
+from unittest.mock import patch
+import sys
+from io import StringIO
+from argparse import ArgumentParser, Namespace
+import requests_mock
+from qpc.tests_utilities import HushUpStderr, redirect_stdout
+from qpc.utils import get_server_location, write_server_config
+from qpc.server import LOGIN_URI
+from qpc.server.login_host import LoginHostCommand
+
+
+TMP_KEY = '/tmp/testkey'
+PARSER = ArgumentParser()
+SUBPARSER = PARSER.add_subparsers(dest='subcommand')
+
+write_server_config({'host': '127.0.0.1', 'port': 8000})
+BASE_URL = get_server_location()
+
+
+class LoginCliTests(unittest.TestCase):
+    """Class for testing the login server command for qpc."""
+
+    def setUp(self):
+        """Create test setup."""
+        # Temporarily disable stderr for these tests, CLI errors clutter up
+        # nosetests command.
+        self.orig_stderr = sys.stderr
+        sys.stderr = HushUpStderr()
+
+    def tearDown(self):
+        """Remove test setup."""
+        # Restore stderr
+        sys.stderr = self.orig_stderr
+
+    @patch('getpass._raw_input')
+    def test_login_bad_cred(self, do_mock_raw_input):
+        """Testing the login with bad creds."""
+        server_out = StringIO()
+        url = BASE_URL + LOGIN_URI
+        e_msg = 'Unable to log in with provided credentials.'
+        error = {'detail': [e_msg]}
+        with requests_mock.Mocker() as mocker:
+            mocker.post(url, status_code=400, json=error)
+            lhc = LoginHostCommand(SUBPARSER)
+            lhc.password = 'password'
+            args = Namespace(username='admin')
+            do_mock_raw_input.return_value = 'abc'
+            with self.assertRaises(SystemExit):
+                with redirect_stdout(server_out):
+                    lhc.main(args)
+                    self.assertTrue(e_msg in server_out.getvalue())
+
+    @patch('getpass._raw_input')
+    def test_login_good(self, do_mock_raw_input):
+        """Testing the login with good creds."""
+        server_out = StringIO()
+        url = BASE_URL + LOGIN_URI
+        error = {'token': 'a_token'}
+        with requests_mock.Mocker() as mocker:
+            mocker.post(url, status_code=200, json=error)
+            lhc = LoginHostCommand(SUBPARSER)
+            lhc.password = 'password'
+            args = Namespace(username='admin')
+            do_mock_raw_input.return_value = 'abc'
+            with redirect_stdout(server_out):
+                lhc.main(args)
+                self.assertEqual(server_out.getvalue(), 'Login successful.\n')

--- a/qpc/server/tests_logout_host.py
+++ b/qpc/server/tests_logout_host.py
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+#
+"""Test the CLI module."""
+
+import unittest
+import sys
+import os
+from qpc.cli import CLI
+from qpc.tests_utilities import HushUpStderr
+from qpc.utils import QPC_CLIENT_TOKEN
+
+
+class LogoutTests(unittest.TestCase):
+    """Class for testing the logout host function."""
+
+    def setUp(self):
+        """Create test setup."""
+        # Temporarily disable stderr for these tests, CLI errors clutter up
+        # nosetests command.
+        self.orig_stderr = sys.stderr
+        sys.stderr = HushUpStderr()
+
+    def tearDown(self):
+        """Remove test case setup."""
+        # Restore stderr
+        sys.stderr = self.orig_stderr
+
+    def test_success_config_server(self):
+        """Testing the logout server green path."""
+        sys.argv = ['/bin/qpc', 'server', 'logout']
+        CLI().main()
+
+        self.assertFalse(os.path.exists(QPC_CLIENT_TOKEN))

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -24,6 +24,7 @@ CONFIG_DIR = os.path.join(xdg_config_home, QPC_PATH)
 DATA_DIR = os.path.join(xdg_data_home, QPC_PATH)
 QPC_LOG = os.path.join(DATA_DIR, 'qpc.log')
 QPC_SERVER_CONFIG = os.path.join(CONFIG_DIR, 'server.config')
+QPC_CLIENT_TOKEN = os.path.join(CONFIG_DIR, 'client_token')
 
 CONFIG_HOST_KEY = 'host'
 CONFIG_PORT_KEY = 'port'
@@ -65,6 +66,25 @@ try:
     exception_class = json.decoder.JSONDecodeError
 except AttributeError:
     exception_class = ValueError
+
+
+def read_client_token():
+    """Retrieve client token for sonar server.
+
+    :returns: The client token or None
+    """
+    if not os.path.exists(QPC_CLIENT_TOKEN):
+        return None
+
+    token = None
+    with open(QPC_CLIENT_TOKEN) as client_token_file:
+        try:
+            token_json = json.load(client_token_file)
+            token = token_json.get('token')
+        except exception_class:
+            pass
+
+        return token
 
 
 def read_server_config():
@@ -114,6 +134,23 @@ def write_server_config(server_config):
         json.dump(server_config, configFile)
 
 
+def write_client_token(client_token):
+    """Write client token to file client_token.
+
+    :param client_token: dict containing client_token
+    """
+    ensure_config_dir_exists()
+
+    with open(QPC_CLIENT_TOKEN, 'w') as configFile:
+        json.dump(client_token, configFile)
+
+
+def delete_client_token():
+    """Remove file client_token."""
+    ensure_config_dir_exists()
+    os.remove(QPC_CLIENT_TOKEN)
+
+
 def ensure_data_dir_exists():
     """Ensure the qpc data directory exists."""
     if not os.path.exists(DATA_DIR):
@@ -156,13 +193,18 @@ def handle_error_response(response):
     """
     try:
         response_data = response.json()
+        if isinstance(response_data, str):
+            log.error('Error: %s', str(response_data))
         if isinstance(response_data, dict):
             for err_key, err_cases in response_data.items():
                 error_context = 'Error'
-                if err_key != 'non_field_errors':
+                if err_key != 'non_field_errors' and err_key != 'detail':
                     error_context = err_key
-                for err_msg in err_cases:
-                    log.error('%s: %s', error_context, err_msg)
+                if isinstance(err_cases, str):
+                    log.error('%s: %s', error_context, err_cases)
+                else:
+                    for err_msg in err_cases:
+                        log.error('%s: %s', error_context, err_msg)
         elif isinstance(response_data, list):
             for err in response_data:
                 log.error('Error: %s', err)

--- a/quipucords/api/credential/view.py
+++ b/quipucords/api/credential/view.py
@@ -10,10 +10,14 @@
 #
 """Describes the views associated with the API models."""
 
+import os
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.authentication import (TokenAuthentication,
+                                           SessionAuthentication)
+from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import (DjangoFilterBackend, FilterSet)
 from filters import mixins
 from api.filters import ListFilter
@@ -56,6 +60,10 @@ class CredentialFilter(FilterSet):
 # pylint: disable=too-many-ancestors
 class CredentialViewSet(mixins.FiltersMixin, ModelViewSet):
     """A view set for the Credential model."""
+
+    if not os.getenv('QPC_DISABLE_AUTHENTICATION', False):
+        authentication_classes = (TokenAuthentication, SessionAuthentication)
+        permission_classes = (IsAuthenticated,)
 
     queryset = Credential.objects.all()
     serializer_class = CredentialSerializer

--- a/quipucords/api/fact/view.py
+++ b/quipucords/api/fact/view.py
@@ -12,8 +12,12 @@
 """Viewset for system facts models."""
 
 import logging
+import os
 from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
+from rest_framework.authentication import (TokenAuthentication,
+                                           SessionAuthentication)
+from rest_framework.permissions import IsAuthenticated
 from api.models import FactCollection
 from api.serializers import FactCollectionSerializer
 from api.fact.util import (validate_fact_collection_json,
@@ -27,6 +31,10 @@ from fingerprinter import pfc_signal
 class FactViewSet(mixins.CreateModelMixin,
                   viewsets.GenericViewSet):
     """ModelViewSet to publish system facts."""
+
+    if not os.getenv('QPC_DISABLE_AUTHENTICATION', False):
+        authentication_classes = (TokenAuthentication, SessionAuthentication)
+        permission_classes = (IsAuthenticated,)
 
     # Get an instance of a logger
     logger = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/quipucords/api/report_views.py
+++ b/quipucords/api/report_views.py
@@ -11,6 +11,7 @@
 
 """Viewset for system reports."""
 import logging
+import os
 from django.utils.translation import ugettext as _
 from django.db.models import Count
 from django.core.exceptions import FieldError
@@ -18,6 +19,9 @@ from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.authentication import (TokenAuthentication,
+                                           SessionAuthentication)
+from rest_framework.permissions import IsAuthenticated
 from api.models import SystemFingerprint
 from api.serializers import FingerprintSerializer
 import api.messages as messages
@@ -29,6 +33,10 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 class ReportListView(APIView):
     """List all system reports."""
+
+    if not os.getenv('QPC_DISABLE_AUTHENTICATION', False):
+        authentication_classes = (TokenAuthentication, SessionAuthentication)
+        permission_classes = (IsAuthenticated,)
 
     def get(self, request):
         """Lookup and return all system reports."""

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -10,9 +10,13 @@
 #
 """Describes the views associated with the API models."""
 
+import os
 from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route
+from rest_framework.authentication import (TokenAuthentication,
+                                           SessionAuthentication)
+from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import (DjangoFilterBackend, FilterSet)
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
@@ -182,6 +186,10 @@ class ScanJobViewSet(mixins.RetrieveModelMixin,
                      mixins.ListModelMixin,
                      viewsets.GenericViewSet):
     """A view set for ScanJob."""
+
+    if not os.getenv('QPC_DISABLE_AUTHENTICATION', False):
+        authentication_classes = (TokenAuthentication, SessionAuthentication)
+        permission_classes = (IsAuthenticated,)
 
     queryset = ScanJob.objects.all()
     serializer_class = ScanJobSerializer

--- a/quipucords/api/signals/token_signal.py
+++ b/quipucords/api/signals/token_signal.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+#
+
+"""Signal manager to auth tokens."""
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
+
+
+# pylint: disable=unused-argument
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    """Create auth tokens for new users."""
+    if created:
+        Token.objects.create(user=instance)

--- a/quipucords/api/source/view.py
+++ b/quipucords/api/source/view.py
@@ -10,9 +10,13 @@
 #
 """Describes the views associated with the API models."""
 
+import os
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.authentication import (TokenAuthentication,
+                                           SessionAuthentication)
+from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import (DjangoFilterBackend, FilterSet)
 from api.filters import ListFilter
 from api.serializers import SourceSerializer
@@ -59,6 +63,10 @@ class SourceFilter(FilterSet):
 # pylint: disable=too-many-ancestors
 class SourceViewSet(ModelViewSet):
     """A view set for Sources."""
+
+    if not os.getenv('QPC_DISABLE_AUTHENTICATION', False):
+        authentication_classes = (TokenAuthentication, SessionAuthentication)
+        permission_classes = (IsAuthenticated,)
 
     queryset = Source.objects.all()
     serializer_class = SourceSerializer

--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -11,6 +11,7 @@
 """Describes the urls and patterns for the API application."""
 
 from django.conf.urls import url
+from rest_framework.authtoken import views
 from rest_framework.routers import SimpleRouter
 from rest_framework.urlpatterns import format_suffix_patterns
 from api.views import (CredentialViewSet, FactViewSet,
@@ -38,5 +39,9 @@ urlpatterns = [
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)
+
+urlpatterns += [
+    url(r'^token/', views.obtain_auth_token)
+]
 
 urlpatterns += ROUTER.urls

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
     'filters',
     'django_filters',
     'drf_generators',


### PR DESCRIPTION
- Creates a super user as part of `make server-init`.
- Establishes token endpoint at `api/v1/token-auth`. Supply POST of `{'username': <user>, 'password':<pass>}`
- Remaining endpoints for `api/v1/*` must be called with Authorization Header: `Authorization: Token <token>` [see link](http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication)
- Creates `qpc server login` cmd to get token
- Creates `qpc server logout` cmd to delete local token
- Adds Token authentication and Session authentication to all views. Requires users to be authenticated.
- Disables authentication during unit tests (i.e. `make test`)