### PR TITLE
Only add facts file to dict if subscription manager is present.

### DIFF
--- a/roles/subman/tasks/main.yml
+++ b/roles/subman/tasks/main.yml
@@ -90,6 +90,7 @@
     subman: "{{ subman|default({}) | combine({ item: internal_subman_has_facts_file['stdout'] | trim | default(None) }) }}"
   with_items:
   - 'subman.has_facts_file'
+  when: 'internal_have_subscription_manager'
 
 # subman_consumed fact
 - name: gather subman.consumed fact


### PR DESCRIPTION
This should solve #438 and allow the scan to complete without encountering key errors if data is unavailable.