### PR TITLE
Rename qpc cred become_* options to become-*

### DIFF
--- a/docs/source/man.rst
+++ b/docs/source/man.rst
@@ -111,7 +111,7 @@ Creating and Editing Credentials
 
 To create a credential, supply SSH credentials as either a username-password pair or a username-key pair. Quipucords stores each set of credentials in a separate credential entry.
 
-**qpc cred add --name=** *name* **--type=** *(network | vcenter | satellite)* **--username=** *username* **(--password | --sshkeyfile=** *key_file* **)** **[--sshpassphrase]** **--become_method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become_user=** *user* **[--become_password]**
+**qpc cred add --name=** *name* **--type=** *(network | vcenter | satellite)* **--username=** *username* **(--password | --sshkeyfile=** *key_file* **)** **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]**
 
 ``--name=name``
 
@@ -137,21 +137,21 @@ To create a credential, supply SSH credentials as either a username-password pai
 
   Prompts for the passphrase to be used when connecting using an ssh keyfile that requires a passphrase. Can only be used with the ``--sshkeyfile`` option.
 
-``--become_password``
+``--become-password``
 
   Prompts for the privilege escalation password to be used when running a network scan.
 
-``--become_method=become_method``
+``--become-method=become_method``
 
   Sets the method to become for privilege escalation when running an ansible playbook. Must be ``sudo``, ``su``, ``pbrun``, ``pfexec``, ``doas``, ``dzdo``, ``ksu``, ``runas``. The default is set to 'sudo' when the credential type is network.
 
-``--become_user=user``
+``--become-user=user``
 
   Sets the user to become when running a privileged command during network scan.
 
 The information in a credential, such as a password, become password, SSH keys, the become_method, or even the username, might change. For example, network security might require passwords to be updated every few months. Use the ``qpc cred edit`` command to change the SSH credential information in a credential. The parameters for ``qpc cred edit`` are the same as those for ``qpc cred add``.
 
-**qpc cred edit --name=** *name* **--username=** *username* **(--password | --sshkeyfile=** *key_file* **)** **[--sshpassphrase]** **--become_method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become_user=** *user* **[--become_password]**
+**qpc cred edit --name=** *name* **--username=** *username* **(--password | --sshkeyfile=** *key_file* **)** **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]**
 
 Listing and Showing Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/qpc/cred/add.py
+++ b/qpc/cred/add.py
@@ -63,14 +63,14 @@ class CredAddCommand(CliCommand):
         self.parser.add_argument('--sshpassphrase', dest='ssh_passphrase',
                                  action='store_true',
                                  help=_(messages.CRED_SSH_PSPH_HELP))
-        self.parser.add_argument('--become_method', dest='become_method',
+        self.parser.add_argument('--become-method', dest='become_method',
                                  choices=credential.BECOME_CHOICES,
                                  metavar='BECOME_METHOD',
                                  help=_(messages.CRED_BECOME_METHOD_HELP))
-        self.parser.add_argument('--become_user', dest='become_user',
+        self.parser.add_argument('--become-user', dest='become_user',
                                  metavar='BECOME_USER',
                                  help=_(messages.CRED_BECOME_USER_HELP))
-        self.parser.add_argument('--become_password', dest='become_password',
+        self.parser.add_argument('--become-password', dest='become_password',
                                  action='store_true',
                                  help=_(messages.CRED_BECOME_PASSWORD_HELP))
 

--- a/qpc/cred/edit.py
+++ b/qpc/cred/edit.py
@@ -56,14 +56,14 @@ class CredEditCommand(CliCommand):
         self.parser.add_argument('--sshpassphrase', dest='ssh_passphrase',
                                  action='store_true',
                                  help=_(messages.CRED_SSH_PSPH_HELP))
-        self.parser.add_argument('--become_method', dest='become_method',
+        self.parser.add_argument('--become-method', dest='become_method',
                                  choices=credential.BECOME_CHOICES,
                                  metavar='BECOME_METHOD',
                                  help=_(messages.CRED_BECOME_METHOD_HELP))
-        self.parser.add_argument('--become_user', dest='become_user',
+        self.parser.add_argument('--become-user', dest='become_user',
                                  metavar='BECOME_USER',
                                  help=_(messages.CRED_BECOME_USER_HELP))
-        self.parser.add_argument('--become_password', dest='become_password',
+        self.parser.add_argument('--become-password', dest='become_password',
                                  action='store_true',
                                  help=_(messages.CRED_BECOME_PASSWORD_HELP))
         self.cred_type = None


### PR DESCRIPTION
Be consistent on using dashes and the word separator for qpc options.

Close #475