### PR TITLE
Type and description for Credentials Swagger doc

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -674,7 +674,8 @@ definitions:
           type: "string"
           description: "The user to become when running a privileged command during network scan."
         become_password:
-          type: "The privilege escalation password to be used when running a network scan."
+          type: "string"
+          description: "The privilege escalation password to be used when running a network scan."
   CredentialMin:
     type: "object"
     required:


### PR DESCRIPTION
Mixed up type and description for Credentials "become_password".

closes #492 

@abaiken 