### PR TITLE
Handle interrupted scans that have completed everything but fingerprint processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,9 +112,6 @@ migrations/
 # From ide
 .idea/
 
-# Facts
-raw_facts/
-
 # node
 node_modules
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean-cli:
 	-rm -rf dist/ build/ quipucords.egg-info/
 
 clean: clean-cli
-	rm -rf quipucords/api/migrations/ quipucords/db.sqlite3 quipucords/raw_facts/*
+	rm -rf quipucords/api/migrations/ quipucords/db.sqlite3
 
 install: build
 	$(PYTHON) setup.py install -f

--- a/quipucords/api/fact/model.py
+++ b/quipucords/api/fact/model.py
@@ -11,29 +11,40 @@
 
 """Models to capture system facts."""
 
+import json
 from django.db import models
 
 
 class FactCollection(models.Model):
     """A reported set of facts."""
 
-    FC_STATUS_PERSISTED = 'persisted'
+    FC_STATUS_PENDING = 'pending'
+    FC_STATUS_FAILED = 'failed'
     FC_STATUS_COMPLETE = 'complete'
-    FC_STATUS_CHOICES = ((FC_STATUS_PERSISTED,
-                          FC_STATUS_PERSISTED),
+    FC_STATUS_CHOICES = ((FC_STATUS_PENDING,
+                          FC_STATUS_PENDING),
+                         (FC_STATUS_FAILED,
+                          FC_STATUS_FAILED),
                          (FC_STATUS_COMPLETE,
                           FC_STATUS_COMPLETE))
 
     status = models.CharField(
         max_length=16,
         choices=FC_STATUS_CHOICES,
-        default=FC_STATUS_PERSISTED
+        default=FC_STATUS_PENDING
     )
-    path = models.CharField(max_length=256)
+    sources = models.TextField(null=False)
 
     def __str__(self):
         """Convert to string."""
         return '{' +\
-            'id:{}, status:{}, path:{}'.format(self.id,
-                                               self.status,
-                                               self.path) + '}'
+            'id:{}, status:{}, sources:{}'.format(self.id,
+                                                  self.status,
+                                                  self.sources) + '}'
+
+    def get_sources(self):
+        """Access facts as python dict instead of str.
+
+        :returns: facts as a python dict
+        """
+        return json.loads(self.sources)

--- a/quipucords/api/fact/serializer.py
+++ b/quipucords/api/fact/serializer.py
@@ -11,18 +11,18 @@
 
 """Serializer for system facts models."""
 
-from rest_framework.serializers import JSONField
 from api.models import FactCollection
-from api.common.serializer import NotEmptySerializer
+from api.common.serializer import (NotEmptySerializer,
+                                   CustomJSONField)
 
 
 class FactCollectionSerializer(NotEmptySerializer):
     """Serializer for the FactCollection model."""
 
-    sources = JSONField(required=False)
+    sources = CustomJSONField(required=True)
 
     class Meta:
         """Meta class for FactCollectionSerializer."""
 
         model = FactCollection
-        fields = ['id', 'sources']
+        fields = '__all__'

--- a/quipucords/fingerprinter/__init__.py
+++ b/quipucords/fingerprinter/__init__.py
@@ -84,7 +84,7 @@ def process_fact_collection(sender, instance, **kwargs):
 def _process_sources(fact_collection):
     """Process facts and convert to fingerprints.
 
-    :param json_fact_collection: Collected raw facts for all sources
+    :param fact_collection: FactCollection containing raw facts
     :returns: list of fingerprints for all systems (all scans)
     """
     network_fingerprints = []

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -226,6 +226,3 @@ ES_CONFIGURATION = {
     'fingerprint_index_name': 'fingerprints_index',
     'doc_type': 'fingerprint'
 }
-
-
-FACTS_DIR = BASE_DIR + '/raw_facts'

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -163,6 +163,10 @@ LOGGING = {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
         },
+        'api.fact': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
+        },
         'api.scanjob': {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -14,7 +14,8 @@
 import logging
 from time import sleep
 from threading import Thread
-from api.models import ScanTask, ScanJob
+from api.models import (ScanTask,
+                        ScanJob)
 from scanner import ScanJobRunner
 from django.db.models import Q
 
@@ -81,8 +82,8 @@ class Manager(Thread):
                              task_id)
             return killed
 
-    def look_for_incomplete_scans(self):
-        """Look for incomplete scans."""
+    def restart_incomplete_scansjobs(self):
+        """Look for incomplete scans and restart."""
         logger.debug('Scan manager searching for incomplete scans')
 
         incomplete_scans = ScanJob.objects.filter(
@@ -102,7 +103,7 @@ class Manager(Thread):
 
     def run(self):
         """Trigger thread execution."""
-        self.look_for_incomplete_scans()
+        self.restart_incomplete_scansjobs()
         logger.debug('Scan manager started.')
         while self.running:
             queue_len = len(self.scan_queue)


### PR DESCRIPTION
- Moved fact_collection_json into the fact_collection model instead of an external file.  This impacts the job, util, and fact view
- ScanJobs now reflect the status of the fingerprint processing.  Interrupted job logic will now cover fingerprint processing.  In other words, a scanjob is not complete until the fingerprint processing is complete.

Closes #377 