### PR TITLE
Improve logging stats for fingerprint deduplication and merging

### DIFF
--- a/quipucords/fingerprinter/tests_engine.py
+++ b/quipucords/fingerprinter/tests_engine.py
@@ -18,7 +18,7 @@ from fingerprinter import (FINGERPRINT_GLOBAL_ID_KEY,
                            _process_source,
                            _remove_duplicate_fingerprints,
                            _merge_fingerprint,
-                           _create_index_for_fingerprint,
+                           _create_index_for_fingerprints,
                            _merge_matching_fingerprints,
                            _merge_fingerprints_from_source_types)
 from api.models import Source
@@ -453,7 +453,7 @@ class EngineTest(TestCase):
             self._create_vcenter_fingerprint(vm_uuid='match'),
             self._create_vcenter_fingerprint(vm_uuid='2')]
 
-        result_fingerprints = _merge_fingerprints_from_source_types(
+        _, result_fingerprints = _merge_fingerprints_from_source_types(
             NETWORK_VCENTER_MERGE_KEYS,
             nfingerprints, vfingerprints)
 
@@ -515,7 +515,7 @@ class EngineTest(TestCase):
             vfingerprint_no_key
         ]
 
-        merge_list, no_match_found_list = _merge_matching_fingerprints(
+        _, merge_list, no_match_found_list = _merge_matching_fingerprints(
             'bios_uuid', nfingerprints, 'vm_uuid', vfingerprints)
 
         # merge list should always contain all nfingerprints (base_list)
@@ -552,7 +552,7 @@ class EngineTest(TestCase):
             {'id': 3,
              'os_release': 'RHEL 6'}
         ]
-        index, no_key_found = _create_index_for_fingerprint(
+        index, no_key_found = _create_index_for_fingerprints(
             'mac_addresses', fingerprints)
 
         self.assertEqual(len(no_key_found), 1)
@@ -594,12 +594,12 @@ class EngineTest(TestCase):
         ]
 
         # Test that unique id not in objects
-        index, no_key_found = _create_index_for_fingerprint(
+        index, no_key_found = _create_index_for_fingerprints(
             'bios_uuid', fingerprints, False)
         self.assertIsNone(no_key_found[0].get(FINGERPRINT_GLOBAL_ID_KEY))
 
         # Tests with unique id in objects
-        index, no_key_found = _create_index_for_fingerprint(
+        index, no_key_found = _create_index_for_fingerprints(
             'bios_uuid', fingerprints)
 
         self.assertEqual(len(no_key_found), 1)


### PR DESCRIPTION
Sample output: 
```
Remove duplicate network fingerprints by ['subscription_manager_id', 'bios_uuid']
Number network fingerprints before de-duplication: 25
Number network fingerprints after de-duplication: 25

Remove duplicate satellite fingerprints by ['subscription_manager_id']
Number satellite fingerprints before de-duplication: 167
Number satellite fingerprints after de-duplication: 167

Remove duplicate vcenter fingerprints by ['vm_uuid']
Number vcenter fingerprints before de-duplication: 109
Number vcenter fingerprints after de-duplication: 109

Merged network and satellite fingerprints using keypairs. Pairs: [(network_key, satellite_key)]=[('subscription_manager_id', 'subscription_manager_id'), ('mac_addresses', 'mac_addresses')]
Number network before: 25
Number satellite before: 167
_create_index_for_fingerprints - Potential lost fingerprint due to duplicate mac_addresses: 1.
_create_index_for_fingerprints - Potential lost fingerprint due to duplicate mac_addresses: 124.
Number fingerprints merged together: 0
Total number network/satellite after merge: 68
Total merged count decreased by 124

Merged network/satellite and vcenter fingerprints using keypairs. Pairs: [(network/satelllite, vcenter)]=[('bios_uuid', 'vm_uuid'), ('mac_addresses', 'mac_addresses')]
Number merged network/satellite before: 68
Number vcenter before: 109
_create_index_for_fingerprints - Potential lost fingerprint due to duplicate mac_addresses: 1.
_create_index_for_fingerprints - Potential lost fingerprint due to duplicate mac_addresses: 1.
Number fingerprints merged together: 8
Total number network/satellite/vcenter after merge: 169
Total merged count decreased by 8
```

Closes #510 