### PR TITLE
Timeout individual Ansible tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ script:
   - make swagger-valid
 after_success:
   - coveralls
+addons:
+  apt:
+    packages:
+      - sshpass
 notifications:
   slack:
     secure: SSlalMN72w3gghu0RRTEznrdVgFCSCLheutRp9O9W82LVaz4K7xu9Qel7pRghgoiafS2nBufaGXrmk6mj4InNhJfc0hwLpa9kZcntD8kuap5qJC4A5Qvx1gq+70DjVbaVbBfrAl1Bsu+dkR6SfuCV9sWTFjUfnCt5H1ugprQXe0utLt7P//ZELOWVghyiFBIr+kOrUCfDV0HecTHOxQIFlxZpB2Y0QGYXUwtljhVFaMcCQLHvOhQelIellrRjSUURQOo9TLw8NQUdJHWxnKqAXl2VNG9CCRKJoH6i1sGi53gWou+EeKXM6ERCgO4mgzDyrPJe644Q7e6Gt6Htz1Oc22n0ghR4CE62B44bzhtViCmpptmgMIFLJfEg+zq0ZQzdxSx6dblkT0hC/dVwPLyjUFffojYPnarx9rvmM56yq3FS++2nbSg2JLvscHCDYqbivykdgz80VujxfYKSOtHTirteNDbKinx1DtibBhl0GNeRE0xM/OEPgLyD1eQbak7Dfr9rwebO2sSxplvH5CNn16jarpnqC+2x47leNOxjba2Je/fN01tIcHKQzgVn7TI/jfek+CJpqdgU2eXpz0g18PnPjMpdfZefdW2V/HTA7ucCJyoDEuouI54AtzvW3Oi9kJ81kesutNBl1zyCjiGrL9ynyDS9xPmPbJCWTTXw9A=

--- a/bin/timeout_ssh
+++ b/bin/timeout_ssh
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+"""Run ssh with a timeout."""
+
+import os
+import sys
+
+ARG_EXECUTABLE = '--executable='
+ARG_TIMEOUT = '--timeout='
+
+# Ansible lets us set the ssh executable, but whatever string we
+# provide is interpreted as an executable, so we can't set it to
+# 'timeout 100' or something like that. Instead, we have this tiny
+# program whose only job is to be a single executable that Ansible can
+# call which will then trampoline out to timeout.
+
+def main(argv):
+    # I don't think we can control the order that Ansible passes
+    # arguments to its ssh program, so we can't just make hte
+    # executable the first positional argument. Instead, we pass the
+    # executable as --executable=<program>, and then we remove that
+    # flag before we pass the rest of the args to the executable.
+    executable = None
+    timeout = None
+    for arg in argv[1:]:
+        if arg.startswith(ARG_EXECUTABLE):
+            executable = arg[len(ARG_EXECUTABLE):]
+        # timeout works the same way as executable
+        if arg.startswith(ARG_TIMEOUT):
+            timeout = arg[len(ARG_TIMEOUT):]
+
+    if not executable:
+        print('Error: must pass --executable to timeout_ssh. Got:', argv)
+        sys.exit(1)
+
+    if not timeout:
+        print('Error: must pass --timeout to timeout_ssh. Got:', argv)
+        sys.exit(1)
+
+    executable_args = [arg for arg in argv[1:]
+                       if (not arg.startswith(ARG_EXECUTABLE) and
+                           not arg.startswith(ARG_TIMEOUT))]
+
+    timeout_args = ['timeout', timeout, executable] + executable_args
+
+    os.execvp('timeout', timeout_args)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/quipucords/scanner/network/inspect_callback.py
+++ b/quipucords/scanner/network/inspect_callback.py
@@ -23,12 +23,16 @@ from scanner.network.processing import process
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 ANSIBLE_FACTS = 'ansible_facts'
+FAILED = 'failed'
 HOST = 'host'
 HOST_DONE = 'host_done'
 INTERNAL_ = 'internal_'
 KEY = 'key'
 NO_KEY = 'no_key'
+RC = 'rc'
 RESULT = 'result'
+
+TIMEOUT_RC = 124  # 'timeout's return code when it times out.
 
 
 def _construct_result(result):
@@ -100,6 +104,11 @@ class InspectResultCallback(CallbackBase):
         result_obj = _construct_result(result)
         self.results.append(result_obj)
         logger.debug('%s', result_obj)
+
+        # 'timeout' returns 124 on timeouts
+        if result_obj[RESULT].get(FAILED) and \
+           result_obj[RESULT].get(RC) == TIMEOUT_RC:
+            logger.warning('Task %s timed out', result_obj[KEY])
 
         host = result_obj[HOST]
         results_to_store = normalize_result(result)

--- a/roles/cpu/tasks/main.yml
+++ b/roles/cpu/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: extract or default cpu.count fact
   set_fact:
-    cpu_count: "{{ internal_cpu_count_cmd['stdout_lines'][0] | default(None)}}"
+    cpu_count: "{{ internal_cpu_count_cmd | json_query('stdout_lines[0]') }}"
 
 - name: gather cpu.core_per_socket fact
   raw: cat /proc/cpuinfo | grep '^cpu cores\s*.' | sed -n -e 's/^.*cpu cores\s*.\s*//p'
@@ -41,7 +41,7 @@
 
 - name: extract or default cpu.core_per_socket fact
   set_fact:
-    cpu_core_per_socket: "{{ internal_cpu_core_per_socket_cmd['stdout_lines'][0] | default(None)}}"
+    cpu_core_per_socket: "{{ internal_cpu_core_per_socket_cmd | json_query('stdout_lines[0]') }}"
 
 - name: gather cpu.siblings fact
   raw: cat /proc/cpuinfo | grep '^siblings\s*.' | sed -n -e 's/^.*siblings\s*.\s*//p'
@@ -50,7 +50,7 @@
 
 - name: extract or default cpu.siblings fact
   set_fact:
-    cpu_siblings: "{{ internal_cpu_siblings_cmd['stdout_lines'][0] | default(None)}}"
+    cpu_siblings: "{{ internal_cpu_siblings_cmd | json_query('stdout_lines[0]') }}"
 
 - name: determine cpu.hyperthreading fact
   set_fact:
@@ -69,7 +69,7 @@
 
 - name: extract result value for cpu.socket_count
   set_fact:
-    cpu_socket_count: "{{ internal_cpu_socket_count_cmd['stdout'] | trim | default('error') if internal_have_dmidecode else 'N/A (dmidecode not found)' }}"
+    cpu_socket_count: "{{ internal_cpu_socket_count_cmd.get('stdout') | trim | default('error') if internal_have_dmidecode else 'N/A (dmidecode not found)' }}"
   when: '"stdout" in internal_cpu_socket_count_cmd'
 
 - name: gather cpu.socket_count fact with fallback

--- a/roles/date/tasks/main.yml
+++ b/roles/date/tasks/main.yml
@@ -43,4 +43,3 @@
   set_fact:
     date_yum_history: "{{  internal_date_yum_history_cmd['stdout_lines'] | select | first | default(None) if internal_have_yum else 'N/A (yum not found)' }}"
   when: '"stdout_lines" in internal_date_yum_history_cmd'
-

--- a/roles/file_contents/tasks/main.yml
+++ b/roles/file_contents/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: set etc_issue
   set_fact:
-    etc_issue: "{{ internal_etc_issue_cmd['stdout'] | default('') }}"
+    etc_issue: "{{ internal_etc_issue_cmd.get('stdout') | default('') }}"
 
 - name: gather instnum.instnum fact
   raw: if [ -f /etc/sysconfig/rhn/install-num ] ; then cat /etc/sysconfig/rhn/install-num ; fi
@@ -16,7 +16,7 @@
 
 - name: set instnum
   set_fact:
-    instnum: "{{ internal_instnum_cmd['stdout'] | default('') }}"
+    instnum: "{{ internal_instnum_cmd.get('stdout') | default('') }}"
 
 - name: gather systemid fact
   raw: if [ -f /etc/sysconfig/rhn/systemid ] ; then cat /etc/sysconfig/rhn/systemid ; fi
@@ -25,4 +25,4 @@
 
 - name: set systemid
   set_fact:
-    systemid: "{{ internal_systemid_cmd['stdout'] | default('') }}"
+    systemid: "{{ internal_systemid_cmd.get('stdout') | default('') }}"

--- a/roles/subman/tasks/main.yml
+++ b/roles/subman/tasks/main.yml
@@ -90,7 +90,7 @@
     subman: "{{ subman|default({}) | combine({ item: internal_subman_has_facts_file['stdout'] | trim | default(None) }) }}"
   with_items:
   - 'subman.has_facts_file'
-  when: 'internal_have_subscription_manager'
+  when: 'internal_have_subscription_manager and "stdout" in internal_subman_has_facts_file'
 
 # subman_consumed fact
 - name: gather subman.consumed fact

--- a/roles/uname/tasks/main.yml
+++ b/roles/uname/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: add uname.os to dictionary
   set_fact:
-    uname_os: "{{ uname_os['stdout_lines'][0] | default('error') }}"
+    uname_os: "{{ uname_os | json_query('stdout_lines[0]') | default('error') }}"
 
 - name: gather uname.hostname fact
   raw: uname -n
@@ -16,7 +16,7 @@
 
 - name: add uname.hostname to dictionary
   set_fact:
-    uname_hostname: "{{ uname_hostname['stdout_lines'][0] | default('error') }}"
+    uname_hostname: "{{ uname_hostname | json_query('stdout_lines[0]') | default('error') }}"
 
 - name: gather uname.processor fact
   raw: uname -p
@@ -25,7 +25,7 @@
 
 - name: add uname.processor to dictionary
   set_fact:
-    uname_processor: "{{ uname_processor['stdout_lines'][0] | default('error') }}"
+    uname_processor: "{{ uname_processor | json_query('stdout_lines[0]') | default('error') }}"
 
 - name: gather uname.kernel fact
   raw: uname -r
@@ -34,7 +34,7 @@
 
 - name: add uname.kernel to dictionary
   set_fact:
-    uname_kernel: "{{ uname_kernel['stdout_lines'][0] | default('error') }}"
+    uname_kernel: "{{ uname_kernel | json_query('stdout_lines[0]') | default('error') }}"
 
 - name: gather uname.all fact
   raw: uname -a
@@ -43,7 +43,7 @@
 
 - name: add uname.all to dictionary
   set_fact:
-    uname_all: "{{ uname_all['stdout_lines'][0] | default('error') }}"
+    uname_all: "{{ uname_all | json_query('stdout_lines[0]') | default('error') }}"
 
 - name: gather uname.hardware_platform fact
   raw: uname -i
@@ -52,4 +52,4 @@
 
 - name: add uname.hardware_platform to dictionary
   set_fact:
-    uname_hardware_platform: "{{ uname_hardware_platform['stdout_lines'][0] | default('error') }}"
+    uname_hardware_platform: "{{ uname_hardware_platform | json_query('stdout_lines[0]') | default('error') }}"

--- a/roles/virt_what/tasks/main.yml
+++ b/roles/virt_what/tasks/main.yml
@@ -13,8 +13,8 @@
 
 - name: extract virt-what error code
   set_fact:
-    internal_virt_what_error: '{{ internal_virt_what_output["stdout"].split("\r\n")[-1] | int }}'
-  when: 'internal_have_virt_what'
+    internal_virt_what_error: '{{ internal_virt_what_output["stdout_lines"][-1] | int }}'
+  when: 'internal_have_virt_what and "stdout_lines" in internal_virt_what_output'
 
 - name: set virt-what.type fact to bare metal if virt-what errored
   set_fact:
@@ -23,5 +23,5 @@
 
 - name: set virt-what.type fact if virt-what ran successfully
   set_fact:
-    virt_what_type: '{{ ";".join(internal_virt_what_output["stdout"].split("\r\n")[:-1]) }}'
-  when: 'internal_have_virt_what and (internal_virt_what_error|int == 0)'
+    virt_what_type: '{{ ";".join(internal_virt_what_output["stdout_lines"][:-1]) }}'
+  when: 'internal_have_virt_what and (internal_virt_what_error|int == 0) and "stdout_lines" in internal_virt_what_output'

--- a/test_util/crash.py
+++ b/test_util/crash.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+
+"""A program to simulate crashes in an SSH session."""
+
+import sys
+
+
+if __name__ == '__main__':
+    # 'man ssh' says ssh exits with 255 if an error occurs.
+    sys.exit(255)

--- a/test_util/hang.py
+++ b/test_util/hang.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+
+"""A program to simulate hangs in an SSH session."""
+
+
+if __name__ == '__main__':
+    while True:
+        # This will hang while also pegging one CPU at 99%.
+        pass


### PR DESCRIPTION
Provide a custom ssh executable to Ansible that runs regular ssh
inside of 'timeout', and use this to add a timeout to every task. Add
infrastructure for testing this ssh executable by making it time out a
program that will hang forever. Also add a test for SSH crashes.

Closes #484 .