### PR TITLE
Make user name prompt match password prompt

### DIFF
--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -173,7 +173,7 @@ SERVER_CONFIG_SSL_CERT_HELP = 'File path to the SSL certificate '\
     'to use for verification.'
 
 LOGIN_USER_HELP = 'The user name to log in to the server.'
-LOGIN_USERNAME_PROMPT = 'User name:'
+LOGIN_USERNAME_PROMPT = 'User name: '
 LOGIN_SUCCESS = 'Login successful.'
 
 LOGOUT_SUCCESS = 'Logged out.'


### PR DESCRIPTION
Currently there is no space after the `User name:` prompt and this is slightly annoying 🙄 . 
```
$ qpc server login
User name:admin
Password: (your cursor starts here)
```