### PR TITLE
UI: Container run build updates

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,3 +1,4 @@
+REACT_APP_ENV=development
 REACT_APP_CREDENTIALS_SERVICE=http://localhost:4000/api/v1/credentials/
 REACT_APP_FACTS_SERVICE=http://localhost:4000/api/v1/facts/
 REACT_APP_REPORTS_SERVICE=http://localhost:4000/api/v1/reports/

--- a/client/.env.staging
+++ b/client/.env.staging
@@ -1,4 +1,4 @@
-REACT_APP_ENV=production
+REACT_APP_ENV=staging
 REACT_APP_CREDENTIALS_SERVICE=/api/v1/credentials/
 REACT_APP_FACTS_SERVICE=/api/v1/facts/
 REACT_APP_REPORTS_SERVICE=/api/v1/reports/

--- a/client/README.rst
+++ b/client/README.rst
@@ -5,9 +5,9 @@ User interface for Quipucords. This project was bootstrapped with `Create React 
 
 Requirements
 ------------
-Before developing for Quipucords UI, here are some basic guidelines:
- * Your system needs to be running `NodeJS version 6+ <https://nodejs.org/>`_
- * To run the mock API, your system needs to be running `Docker <https://docs.docker.com/engine/installation/>`_
+Before developing for Quipucords UI, the requirements:
+ * Your system needs to be running `NodeJS version 8+ <https://nodejs.org/>`_
+ * And `Docker <https://docs.docker.com/engine/installation/>`_
 
 Development
 -----------
@@ -23,23 +23,25 @@ Installing
     $ cd client
     $ npm install
 
-Development Server & Mock API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To run the development server and mock API, use this command::
+Development Serve
+^^^^^^^^^^^^^^^^^
+To run the development server and API, use this command::
 
     $ npm start
 
-If you have Docker running, this will automatically setup the mock API.
+If you have Docker running, this will automatically setup and start the development API.
 
-Mock API
-********
-To setup the mock API separately you can run::
+Development API
+***************
+To setup the development API separately you can run::
 
-    $ npm run api:mock
+    $ npm run api:dev
+
+The development API produces randomized data against a Swagger spec.
 
 Debugging Redux
 ***************
-This project makes use of React & Redux. To enable Redux console logging, within the `client` directory, add a `.env.local` (dotenv) file with the follow line::
+This project makes use of React & Redux. To enable Redux console logging, within the ``[REPO]/client`` directory, add a ``.env.local`` (dotenv) file with the follow line::
 
   REACT_APP_DEBUG_MIDDLEWARE=true
 
@@ -56,22 +58,34 @@ To run the unit tests, use this command::
 
 Building the Production UI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-The UI is compiled for production within a `client` directory underneath `./quipucords/client`. To build the UI, use this command::
+The UI is compiled for production within a ``client`` directory underneath ``[REPO]/quipucords/client``. To build the UI, use this command::
 
-    $ npm run build:prod
-
-Serving the Production UI & API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you've gone through the Python quipucords installation you can serve the UI and API with this command::
-
-    $ npm run start:quipucords
+    $ npm run build
 
 Using Docker
-************
-If you'd rather run quipucords through Docker you can serve the UI and API with this set of commands::
+^^^^^^^^^^^^
+The UI/UX team currently uses Docker to aid development.
 
-    $ docker stop quipucords || docker ps && npm run api:update && npm run api:quipucords
+Development Serve
+*****************
+This is the default context for running the UI::
+
+    $ npm start
+
+Staging Serve
+*************
+To run the build under a staging context against a production level quipucords API, use this command::
+
+    $ npm run start:stage
+
+The staging context allows development to continue by pointing Docker at the ``[REPO]/client/build`` directory.
+
+Production Serve
+****************
+To run the existing build under a production context, use this command::
+
+    $ npm run start:prod
 
 
-*This set of NPM scripts are not intended as a replacement for serving the application, but as a shortcut during development.*
+*This set of NPM scripts are not intended as a replacement for serving the application, but as shortcuts during development.*
 

--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const WriteFilePlugin = require('write-file-webpack-plugin');
+
+/**
+ * Extend Create-React-App webpack configuration.
+ * @param config
+ * @param env
+ * @returns {Object}
+ */
+const webpack = function(config, env) {
+  let newConfig = { ...config };
+
+  // extended props
+  if (Array.isArray(newConfig.plugins)) {
+    newConfig.plugins.push(new WriteFilePlugin());
+  }
+
+  if (newConfig.output) {
+    newConfig.output.path = path.join(__dirname, './build');
+  }
+
+  return newConfig;
+};
+
+/**
+ * Extend the Create-React-App Jest configuration.
+ * @param config
+ * @returns {Object}
+ */
+const jest = function(config) {
+  const newConfig = { ...config };
+
+  // extended props
+
+  return newConfig;
+};
+
+/**
+ * Extend the Create-React-App webpack dev server configuration during development.
+ * @param configFunction
+ * @returns {Function}
+ */
+const devServer = function(configFunction) {
+  return function(proxy, allowedHost) {
+    const newConfig = configFunction(proxy, allowedHost);
+
+    // extended props
+
+    return newConfig;
+  };
+};
+
+module.exports = { webpack, jest, devServer };

--- a/client/package.json
+++ b/client/package.json
@@ -13,28 +13,30 @@
     "url": "https://github.com/quipucords/quipucords/issues"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "sassDepIncludes": "--include-path node_modules/patternfly/dist/sass --include-path node_modules/patternfly/node_modules/bootstrap-sass/assets/stylesheets --include-path node_modules/patternfly/node_modules/font-awesome-sass/assets/stylesheets",
   "scripts": {
-    "api:mock": "sh ./scripts/api.sh -p 4000 -f \"$(pwd)/../docs/swagger.yml\"",
-    "api:quipucords": "sh ./scripts/api.sh -p 443",
-    "api:update": "npm run api:mock -- -u; npm run api:quipucords -- -u",
+    "api:dev": "sh ./scripts/api.sh -p 4000 -f \"$(pwd)/../docs/swagger.yml\"",
+    "api:stage": "sh ./scripts/api.sh -p 4001 -t stage -d \"$(pwd)/build\"",
+    "api:prod": "sh ./scripts/api.sh -p 443 -t prod",
+    "api:update": "npm run api:dev -- -u; npm run api:stage -- -u; npm run api:prod -- -u",
     "api:doc": "node ./scripts/swagger.js & open http://localhost:4040/docs/api",
     "build:css": "node-sass --include-path ./src/styles $npm_package_sassDepIncludes src/styles/entitlements.scss -o src/styles/css",
-    "watch:css": "npm run build:css && node-sass --include-path ./src/styles $npm_package_sassDepIncludes src/styles/entitlements.scss -o src/styles/css --watch --recursive",
     "build:js": "react-scripts build",
-    "build": "run-s build:css build:js",
+    "build:ui": "run-s build:css build:js",
     "build:asset-deps": "mkdir -p public/assets/rcue && cp -R node_modules/rcue/dist/* public/assets/rcue",
     "build:asset-images": "mkdir -p public/assets/images && cp -R src/styles/images/* public/assets/images",
-    "build:assets": "npm-run-all build:asset-*",
-    "build:prod": "run-s build:assets build && mkdir -p ../quipucords/client && cp -R ./build/* ../quipucords/client",
-    "create-react-app": "create-react-app",
-    "start:js": "run-p -l api:mock api:doc start:client",
-    "start": "npm-run-all -p watch:css start:js",
-    "start:client": "react-scripts start",
-    "start:quipucords-docker": "npm run api:quipucords; open https://localhost/login/",
-    "start:quipucords": "open http://127.0.0.1:8000/index.html; source ../venv/bin/activate; cd ../; make serve",
+    "build:assets": "run-s build:asset-*",
+    "build:finish": "mkdir -p ../quipucords/client && cp -R ./build/* ../quipucords/client",
+    "build": "run-s -l build:assets build:ui build:finish",
+    "start:css": "npm run build:css && node-sass --include-path ./src/styles $npm_package_sassDepIncludes src/styles/entitlements.scss -o src/styles/css --watch --recursive",
+    "start:ui": "react-scripts start",
+    "start:ui-stage": "sh -ac '. .env.staging; react-app-rewired start'",
+    "start": "run-p -l api:dev api:doc start:css start:ui",
+    "start:stage": "open https://localhost:4001/login/; run-p -l api:stage start:css start:ui-stage",
+    "start:prod": "npm run api:prod; open https://localhost/login/",
+    "support:create-react-app": "create-react-app",
     "test": "run-s test:**",
     "test:lint-js": "eslint --ext=js --ext=jsx src",
     "test:unit": "react-scripts test --env=jsdom"
@@ -78,8 +80,10 @@
     "node-sass": "^4.7.2",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.10.2",
+    "react-app-rewired": "^1.4.1",
     "swagger-parser": "^4.0.2",
     "swagger-ui-express": "^2.0.14",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "write-file-webpack-plugin": "^4.2.0"
   }
 }

--- a/client/src/services/userService.js
+++ b/client/src/services/userService.js
@@ -3,7 +3,7 @@ import cookies from 'js-cookie';
 class UserService {
   static authorizeUser() {
     // ToDo: ReEvaluate placement of this spoof for auth. Also consider using a helper function.
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.REACT_APP_ENV === 'development') {
       cookies.set(process.env.REACT_APP_AUTH_TOKEN, 'spoof');
 
       console.warn('Warning: Loading spoof auth token.');


### PR DESCRIPTION
### Feature Addition
This PR adds the ability to run a containerized API against a generated local UI directory. 

**How to use & what to check**
1. run ``` $ npm run start:stage```
    * You may have to wait as the Docker scripts recompile everything.
    * Two browser tabs/windows should open, one broken (_see limitations below_), and the second, the login screen.
    * You may have to clear the existing ```csrftoken``` authentication token/cookie 
2. Login
3. Edit a file with a visible change within the UI directory under ```[REPO]/client/src```. 
4. Focus back on the browser tab/window and navigate to https://localhost/client/index.html to refresh the screen (_see limitations below_). 
5. Your change should appear.

**Limitations:**
* Doesn't automatically refresh
* Django routing currently doesn't have index.html as the default. When you hit refresh on the app you'll need to manually enter "/client/index.html"
* Webpack automatically opens the original ```npm start``` browser window/tab, and it throws an authentication error.
    * Taking a look at a potential fix
* Create-React-App doesn't currently support custom configurations for Webpack. Instead, added a holdover plugin that appears to give us the ability to customize these parts of Webpack. However, we should probably evaluate ejecting Create-React-App if we continue to customize. Or look at another alternative similar to [NWB](http://bit.ly/1Mea57K)

**Advantages:**
* No more lengthy compiles to see the UI run within the Quipucords context.
* Actual data can be entered and measured against API responses. Should enable the UI team to debug and verify the API responds correctly

### Commits
Run containers under dev, staging, & prod context. 
* Create React App plugin adds for webpack config
* Separated dev, stage, and prod build scripts
* Staging NPM scripts & more specific dotenv env flag

updates #690 