### PR TITLE
Logging fixes and scan job API updates

### DIFF
--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -103,6 +103,9 @@ SJ_EXTRA_VARS_KEY = 'Extra vars keys must be jboss_eap, jboss_fuse, '\
     'or jboss_brms.'
 
 
+# Scan Manager/Signal
+SIGNAL_STATE_CHANGE = 'SIGNAL %s received for scan job.'
+
 # scan task messages
 PLURAL_SCAN_TASKS_MSG = 'Scan Tasks'
 ST_STATUS_MSG_RUNNING = 'Task is running.'

--- a/quipucords/api/signals/scanjob_signal.py
+++ b/quipucords/api/signals/scanjob_signal.py
@@ -13,6 +13,8 @@
 
 import logging
 import django.dispatch
+from django.utils.translation import ugettext as _
+import api.messages as messages
 from scanner.manager import SCAN_MANAGER
 from scanner import ScanJobRunner
 
@@ -34,6 +36,7 @@ def handle_scan(sender, instance, **kwargs):
     :param kwargs: Other args
     :returns: None
     """
+    instance.log_message(_(messages.SIGNAL_STATE_CHANGE) % ('START'))
     scanner = ScanJobRunner(instance)
     if not SCAN_MANAGER.is_alive():
         SCAN_MANAGER.start()
@@ -52,9 +55,8 @@ def scan_action(sender, instance, action, **kwargs):
     :param kwargs: Other args
     :returns: None
     """
-    logger.info('Handling %s action on scan %s', action, instance)
     if action == PAUSE or action == CANCEL:
-        SCAN_MANAGER.kill(instance.id)
+        SCAN_MANAGER.kill(instance)
 
 
 def scan_pause(sender, instance, **kwargs):
@@ -65,6 +67,7 @@ def scan_pause(sender, instance, **kwargs):
     :param kwargs: Other args
     :returns: None
     """
+    instance.log_message(_(messages.SIGNAL_STATE_CHANGE) % ('PAUSE'))
     scan_action(sender, instance, PAUSE, **kwargs)
 
 
@@ -76,6 +79,7 @@ def scan_cancel(sender, instance, **kwargs):
     :param kwargs: Other args
     :returns: None
     """
+    instance.log_message(_(messages.SIGNAL_STATE_CHANGE) % ('CANCEL'))
     scan_action(sender, instance, CANCEL, **kwargs)
 
 
@@ -87,6 +91,7 @@ def scan_restart(sender, instance, **kwargs):
     :param kwargs: Other args
     :returns: None
     """
+    instance.log_message(_(messages.SIGNAL_STATE_CHANGE) % ('RESTART'))
     scanner = ScanJobRunner(instance)
 
     if not SCAN_MANAGER.is_alive():

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -50,17 +50,18 @@ class Manager(Thread):
         """
         self.scan_queue.insert(0, task)
 
-    def kill(self, task_id):
+    def kill(self, job):
         """Kill a task or remove it from the running queue.
 
-        :param task_id: The identifier of the task to queue.
+        :param job: The task to kill.
         :returns: True if killed, False otherwise.
         """
         killed = False
-        logger.info('Killing task %d', task_id)
+        job_id = job.id
+        job.log_message('TERMINATING TASK PROCESS')
         logger.debug('Current task is %s.', self.current_task)
         if (self.current_task is not None and
-                self.current_task.identifier == task_id and
+                self.current_task.identifier == job_id and
                 self.current_task.is_alive()):
             self.current_task.terminate()
             self.current_task = None
@@ -68,18 +69,18 @@ class Manager(Thread):
         else:
             logger.debug('Checking scan queue for task to remove.')
             removed = False
-            for task in self.scan_queue:
-                if task.identifier == task_id:
-                    self.scan_queue.remove(task)
+            for queued_job in self.scan_queue:
+                if queued_job.identifier == job_id:
+                    self.scan_queue.remove(queued_job)
                     removed = True
                     break
             if removed:
                 killed = True
                 logger.debug('Task %d has been removed from the scan queue.',
-                             task_id)
+                             job_id)
             else:
                 logger.debug('Task %d was not found in the scan queue.',
-                             task_id)
+                             job_id)
             return killed
 
     def restart_incomplete_scansjobs(self):

--- a/quipucords/scanner/tests_manager.py
+++ b/quipucords/scanner/tests_manager.py
@@ -18,6 +18,7 @@ from scanner.manager import Manager
 class MockTask(Thread):
     """Mock Task class."""
 
+    # pylint: disable=invalid-name
     def __init__(self):
         """Create a mock task."""
         Thread.__init__(self)

--- a/quipucords/scanner/tests_manager.py
+++ b/quipucords/scanner/tests_manager.py
@@ -21,7 +21,11 @@ class MockTask(Thread):
     def __init__(self):
         """Create a mock task."""
         Thread.__init__(self)
-        self.identifier = 1
+        self.id = 1
+
+    def log_message(self, message):
+        """Fake log message."""
+        pass
 
 
 class ScanManagerTest(TestCase):
@@ -55,5 +59,6 @@ class ScanManagerTest(TestCase):
 
     def test_kill_missing(self):
         """Test kill on missing id."""
-        killed = self.scan_manager.kill(1)
+        task = MockTask()
+        killed = self.scan_manager.kill(task)
         self.assertFalse(killed)


### PR DESCRIPTION
- Fixed logging for signal/manager
- Removed POST /jobs API.  Now must use POST /scans/{id}/jobs
- Updated test cases
