### PR TITLE
Handle Satellite errors on a per system basis. Closes #792.

### DIFF
--- a/quipucords/scanner/satellite/api.py
+++ b/quipucords/scanner/satellite/api.py
@@ -60,29 +60,36 @@ class SatelliteInterface(object):
             name, increment_sys_scanned=True)
 
     @transaction.atomic
-    def record_inspect_result(self, name, facts):
+    def record_inspect_result(self, name, facts,
+                              status=SystemInspectionResult.SUCCESS):
         """Record a new result.
 
         :param name: The host name
         :param facts: The dictionary of facts
+        :param status: The status of the inspection
         """
         sys_result = SystemInspectionResult(
             name=name,
-            status=SystemInspectionResult.SUCCESS)
+            status=status)
         sys_result.save()
 
-        for key, val in facts.items():
-            if val is not None:
-                final_value = json.dumps(val)
-                stored_fact = RawFact(name=key, value=final_value)
-                stored_fact.save()
-                sys_result.facts.add(stored_fact)
+        if status == SystemInspectionResult.SUCCESS:
+            for key, val in facts.items():
+                if val is not None:
+                    final_value = json.dumps(val)
+                    stored_fact = RawFact(name=key, value=final_value)
+                    stored_fact.save()
+                    sys_result.facts.add(stored_fact)
 
         self.inspect_scan_task.inspection_result.systems.add(sys_result)
         self.inspect_scan_task.inspection_result.save()
 
-        self.inspect_scan_task.increment_stats(
-            name, increment_sys_scanned=True)
+        if status == SystemInspectionResult.SUCCESS:
+            self.inspect_scan_task.increment_stats(
+                name, increment_sys_scanned=True)
+        else:
+            self.inspect_scan_task.increment_stats(
+                name, increment_sys_failed=True)
 
     def host_count(self):
         """Obtain the count of managed hosts."""

--- a/quipucords/scanner/satellite/tests_sat_five.py
+++ b/quipucords/scanner/satellite/tests_sat_five.py
@@ -188,11 +188,16 @@ class SatelliteFiveTest(TestCase):
         """Test the host details with an error."""
         client = mock_serverproxy.return_value
         client.auth.login.side_effect = mock_xml_fault
-        with self.assertRaises(SatelliteException):
-            virt = {2: {'uuid': 2, 'name': 'sys2', 'num_virtual_guests': 3}}
-            self.api.host_details(host_id=1, host_name='sys1',
-                                  last_checkin='', virtual_hosts=virt,
-                                  virtual_guests={1: 2})
+        virt = {2: {'uuid': 2, 'name': 'sys2', 'num_virtual_guests': 3}}
+        details = self.api.host_details(host_id=1, host_name='sys1',
+                                        last_checkin='',
+                                        virtual_hosts=virt,
+                                        virtual_guests={1: 2})
+        inspect_result = self.scan_task.inspection_result
+        self.assertEqual(len(inspect_result.systems.all()), 1)
+        sys_result = inspect_result.systems.all().first()
+        self.assertEqual(sys_result.status, SystemInspectionResult.FAILED)
+        self.assertEqual(details, {})
 
     @patch('xmlrpc.client.ServerProxy')
     def test_virtual_guests_with_err(self, mock_serverproxy):


### PR DESCRIPTION
Adds the fix to `master` branch and Sat 5 interaction has been updated to interact like Sat 6.