### PR TITLE
UI: Minor client directory redirect

### DIFF
--- a/quipucords/quipucords/urls.py
+++ b/quipucords/quipucords/urls.py
@@ -40,6 +40,10 @@ urlpatterns = [
         name='home'),
 
     # static files (*.css, *.js, *.jpg etc.)
+    url(r'^(client/(sources|scans|credentials|))$',
+        RedirectView.as_view(url='/client/index.html', permanent=False),
+        name='client'),
+
     url(r'^(?!/?client/)(?P<path>.*\..*)$',
         RedirectView.as_view(url='/client/%(path)s', permanent=False),
         name='client'),


### PR DESCRIPTION
Regex update for paths inside the UI ```client``` directory, related to page refresh.

The regex is a little specific, eventually could look at making it more generic since there may be a scenario where more routing/paths have to be added. But for now this fixes the immediate issue, and avoids conflicts with resources loaded under ```client```.

updates #690 