### PR TITLE
Cast the job id as a string. Closes #864

### DIFF
--- a/qpc/scan/job.py
+++ b/qpc/scan/job.py
@@ -72,7 +72,7 @@ class ScanJobCommand(CliCommand):
             found, scan_object_id = _get_scan_object_id(self.parser,
                                                         self.args.name)
             if found:
-                self.req_path += str(scan_object_id) + 'jobs/'
+                self.req_path += scan_object_id + 'jobs/'
             else:
                 sys.exit(1)
         if 'id' in self.args and self.args.id:

--- a/qpc/scan/job.py
+++ b/qpc/scan/job.py
@@ -72,11 +72,11 @@ class ScanJobCommand(CliCommand):
             found, scan_object_id = _get_scan_object_id(self.parser,
                                                         self.args.name)
             if found:
-                self.req_path += scan_object_id + 'jobs/'
+                self.req_path += str(scan_object_id) + 'jobs/'
             else:
                 sys.exit(1)
         if 'id' in self.args and self.args.id:
-            self.req_path = scan.SCAN_JOB_URI + self.args.id + '/'
+            self.req_path = scan.SCAN_JOB_URI + str(self.args.id) + '/'
         if 'status' in self.args and self.args.status:
             self.req_params = {'status': self.args.status}
 


### PR DESCRIPTION
When making the path in job.py, we need to cast the id as a string. 