### PR TITLE
Add network postprocessing for EAP 5 facts

### DIFF
--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -42,6 +42,7 @@ DEFAULT_ROLES = [
     'etc_release',
     'file_contents',
     'jboss_eap',
+    'jboss_eap5',
     'jboss_brms',
     'jboss_fuse',
     'jboss_fuse_on_karaf',

--- a/quipucords/scanner/network/processing/__init__.py
+++ b/quipucords/scanner/network/processing/__init__.py
@@ -11,6 +11,7 @@
 
 # flake8: noqa
 from . import eap
+from . import eap5
 from . import brms
 from . import fuse
 from . import karaf

--- a/quipucords/scanner/network/processing/eap5.py
+++ b/quipucords/scanner/network/processing/eap5.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+
+"""Initial processing of raw shell output from Ansible commands."""
+
+import logging
+from scanner.network.processing import util
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+# pylint: disable=too-few-public-methods
+
+
+class ProcessVersionTxt(util.StdoutSearchProcessor):
+    """Process the output of 'cat .../version.txt'."""
+
+    KEY = 'eap5_home_version_txt'
+    SEARCH_STRING = 'JBoss Enterprise Application Platform'
+
+
+class ProcessReadmeHtml(util.StdoutSearchProcessor):
+    """Process the output of 'cat .../readme.html'."""
+
+    KEY = 'eap5_home_readme_html'
+    SEARCH_STRING = 'JBoss Enterprise Application Platform'
+
+
+class ProcessLsJbossAs(util.IndicatorFileFinder):
+    """Process the output of 'ls -1 .../jboss-as'."""
+
+    KEY = 'eap5_home_ls_jboss_as'
+    INDICATOR_FILES = ['JBossEULA.txt']
+
+
+class ProcessRunJarVersion(util.StdoutSearchProcessor):
+    """Process the output of 'java -jar run.jar --version'."""
+
+    KEY = 'eap5_home_run_jar_version'
+    SEARCH_STRING = 'JBoss'

--- a/roles/jboss_eap5/tasks/main.yml
+++ b/roles/jboss_eap5/tasks/main.yml
@@ -15,7 +15,7 @@
 # make a determination.
 - name: locate --ignore-case jboss
   raw: locate JBossEULA.txt | sed -n -e "s/\(.*\)\/jboss-as\/\(.*\)/\1/gp" | uniq
-  register: jboss_eap5_locate_jboss_homes
+  register: internal_jboss_eap5_locate_jboss_homes
   ignore_errors: yes
   when: 'have_locate and jboss_eap'
 
@@ -27,7 +27,7 @@
 # candidate EAP_HOME directories.
 - name: gather jboss.eap.processes
   raw: ps -A -o comm -o args e --columns 10000 | egrep '^java.*(eap|jboss).*' | tr -s ' =:' '\n' | sed -n -e "s/\(.*\)\/jboss-as\/\(.*\)/\1/gp" | uniq
-  register: jboss_eap5_process_jboss_homes
+  register: internal_jboss_eap5_process_jboss_homes
   ignore_errors: yes
   when: 'jboss_eap'
 
@@ -37,8 +37,8 @@
 - name: combine EAP_HOME candidates into single list
   set_fact:
     eap5_home_candidates: "{{
-      (jboss_eap5_locate_jboss_homes.get('stdout_lines', []) +
-       jboss_eap5_process_jboss_homes.get('stdout_lines', [])) | unique }}"
+      (internal_jboss_eap5_locate_jboss_homes.get('stdout_lines', []) +
+       internal_jboss_eap5_process_jboss_homes.get('stdout_lines', [])) | unique }}"
   ignore_errors: yes
   when: 'jboss_eap'
 


### PR DESCRIPTION
In addition, this PR
  - Moves some common postprocessing code into `quipucords.scanner.network.processing.util`
  - Marks two tasks as internal, since we don't use their output outside of Ansible.

Here's some sample output from a scan of a host with EAP 5 installed. This is what's logged when the scanner creates a fact collection just before sending the fact collection to the fingerprinter. The output is pretty-printed and only has the EAP 5 facts, but otherwise is the raw debug logging:
```
{
  "eap5_home_candidates": [
    "/opt/jboss/jbosseap-5.2.0/jboss-eap-5.2"
  ],
  "eap5_home_version_txt": {
    "/opt/jboss/jbosseap-5.2.0/jboss-eap-5.2": true
  },
  "eap5_home_readme_html": {
    "/opt/jboss/jbosseap-5.2.0/jboss-eap-5.2": true
  },
  "eap5_home_ls_jboss_as": {
    "/opt/jboss/jbosseap-5.2.0/jboss-eap-5.2": [
      "JBossEULA.txt"
    ]
  },
  "eap5_home_run_jar_version": {
    "/opt/jboss/jbosseap-5.2.0/jboss-eap-5.2": true
  }
}
```