### PR TITLE
Provide CLI flag for scans to enable extended product search. Closes #837

### DIFF
--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -146,6 +146,11 @@ SCAN_EDIT_SOURCES_NOT_FOUND = 'An error occurred while processing the '\
 SCAN_EDIT_SOURCES_PROCESS_ERR = 'An error occurred while processing the '\
     '"--sources" input values. Failed to edit scan "%s". For more '\
     'information, see the server log file.'
+SCAN_ENABLED_PRODUCT_HELP = \
+    'Contains the list of products to include for extended search. '\
+    'Valid values: jboss_eap, jboss_fuse, jboss_brms.'
+SCAN_EXT_SEARCH_DIRS_HELP = \
+    'The path to the search directories for extended search products.'
 
 REPORT_SCAN_JOB_ID_HELP = 'Scan job identifier.'
 REPORT_OUTPUT_JSON_HELP = 'Output as a JSON file.'

--- a/qpc/scan/add.py
+++ b/qpc/scan/add.py
@@ -17,7 +17,9 @@ from requests import codes
 from qpc.request import POST
 from qpc.clicommand import CliCommand
 import qpc.scan as scan
-from qpc.scan.utils import _get_source_ids, _get_optional_products
+from qpc.scan.utils import (get_source_ids,
+                            get_optional_products,
+                            get_extended_products)
 from qpc.translation import _
 import qpc.messages as messages
 
@@ -57,6 +59,20 @@ class ScanAddCommand(CliCommand):
                                  metavar='DISABLE_OPTIONAL_PRODUCTS',
                                  help=_(messages.DISABLE_OPT_PRODUCTS_HELP),
                                  required=False)
+        self.parser.add_argument('--enabled-extended-product-search',
+                                 dest='enabled_extended_product_search',
+                                 nargs='+',
+                                 choices=scan.OPTIONAL_PRODUCTS,
+                                 metavar='ENABLED_EXTENDED_PRODUCT_SEARCH',
+                                 help=_(messages.SCAN_ENABLED_PRODUCT_HELP),
+                                 required='--ext-product-search-dirs' in
+                                 sys.argv)
+        self.parser.add_argument('--ext-product-search-dirs',
+                                 dest='ext_product_search_dirs',
+                                 nargs='+',
+                                 metavar='EXT_PRODUCT_SEARCH_DIRS',
+                                 help=_(messages.SCAN_EXT_SEARCH_DIRS_HELP),
+                                 required=False)
         self.source_ids = []
 
     def _validate_args(self):
@@ -64,8 +80,8 @@ class ScanAddCommand(CliCommand):
         source_ids = []
         if self.args.sources:
             # check for existence of sources
-            not_found, source_ids = _get_source_ids(self.parser,
-                                                    self.args.sources)
+            not_found, source_ids = get_source_ids(self.parser,
+                                                   self.args.sources)
             if not_found is True:
                 sys.exit(1)
         self.source_ids = source_ids
@@ -83,10 +99,16 @@ class ScanAddCommand(CliCommand):
                 'max_concurrency': self.args.max_concurrency}
         }
         disabled_optional_products \
-            = _get_optional_products(self.args.disabled_optional_products)
+            = get_optional_products(self.args.disabled_optional_products)
+        enabled_extended_product_search \
+            = get_extended_products(self.args.enabled_extended_product_search,
+                                    self.args.ext_product_search_dirs, False)
         if disabled_optional_products is not None:
             self.req_payload['options']['disabled_optional_products']\
                 = disabled_optional_products
+        if enabled_extended_product_search is not None:
+            self.req_payload['options']['enabled_extended_product_search'] \
+                = enabled_extended_product_search
 
     def _handle_response_success(self):
         json_data = self.response.json()

--- a/qpc/scan/job.py
+++ b/qpc/scan/job.py
@@ -18,7 +18,7 @@ from requests import codes
 from qpc.utils import pretty_print
 from qpc.clicommand import CliCommand
 import qpc.scan as scan
-from qpc.scan.utils import _get_scan_object_id
+from qpc.scan.utils import get_scan_object_id
 from qpc.request import GET
 from qpc.translation import _
 import qpc.messages as messages
@@ -69,8 +69,8 @@ class ScanJobCommand(CliCommand):
     def _build_req_params(self):
         """Add filter by scan_type/state query param."""
         if 'name' in self.args and self.args.name:
-            found, scan_object_id = _get_scan_object_id(self.parser,
-                                                        self.args.name)
+            found, scan_object_id = get_scan_object_id(self.parser,
+                                                       self.args.name)
             if found:
                 self.req_path += scan_object_id + 'jobs/'
             else:

--- a/qpc/scan/start.py
+++ b/qpc/scan/start.py
@@ -17,7 +17,7 @@ from requests import codes
 from qpc.request import POST
 from qpc.clicommand import CliCommand
 import qpc.scan as scan
-from qpc.scan.utils import _get_scan_object_id
+from qpc.scan.utils import get_scan_object_id
 from qpc.translation import _
 import qpc.messages as messages
 
@@ -47,8 +47,8 @@ class ScanStartCommand(CliCommand):
         CliCommand._validate_args(self)
         if self.args.name:
             # check for existence of scan object
-            found, scan_object_id = _get_scan_object_id(self.parser,
-                                                        self.args.name)
+            found, scan_object_id = get_scan_object_id(self.parser,
+                                                       self.args.name)
             if found is False:
                 sys.exit(1)
             else:

--- a/qpc/scan/tests_scan_edit.py
+++ b/qpc/scan/tests_scan_edit.py
@@ -91,7 +91,9 @@ class SourceEditCliTests(unittest.TestCase):
             aec = ScanEditCommand(SUBPARSER)
             args = Namespace(name='scan1', sources=['source1'],
                              max_concurrency=50,
-                             disabled_optional_products=None)
+                             disabled_optional_products=None,
+                             enabled_extended_product_search=None,
+                             ext_product_search_dirs=None)
             with redirect_stdout(scan_out):
                 aec.main(args)
                 self.assertEqual(scan_out.getvalue(),
@@ -118,7 +120,62 @@ class SourceEditCliTests(unittest.TestCase):
             aec = ScanEditCommand(SUBPARSER)
             args = Namespace(name='scan1', sources=['source1'],
                              max_concurrency=50,
-                             disabled_optional_products=None)
+                             disabled_optional_products=None,
+                             enabled_extended_product_search=None,
+                             ext_product_search_dirs=None)
+            with redirect_stdout(scan_out):
+                aec.main(args)
+                self.assertEqual(scan_out.getvalue(),
+                                 messages.SCAN_UPDATED % 'scan1' + '\n')
+
+    def test_edit_scan_ext_products(self):
+        """Testing the edit scanvcommand with enabled products successfully."""
+        scan_out = StringIO()
+        url_get_scan = get_server_location() + SCAN_URI + '?name=scan1'
+        url_patch = get_server_location() + SCAN_URI + '1/'
+        scan_entry = {'id': 1, 'name': 'scan1', 'sources': ['source1']}
+        updated_entry = {'id': 1, 'name': 'scan1', 'sources': ['source1'],
+                         'options': {'enabled_extended_product_search':
+                                     {'jboss_eap': True,
+                                      'jboss_fuse': False,
+                                      'jboss_brms': True}}}
+        results = [scan_entry]
+        scan_data = {'count': 1, 'results': results}
+        with requests_mock.Mocker() as mocker:
+            mocker.get(url_get_scan, status_code=200, json=scan_data)
+            mocker.patch(url_patch, status_code=200, json=updated_entry)
+            aec = ScanEditCommand(SUBPARSER)
+            args = Namespace(name='scan1', sources=None,
+                             max_concurrency=50,
+                             disabled_optional_products=None,
+                             enabled_extended_product_search=['jboss_eap',
+                                                              'jboss_brms'],
+                             ext_product_search_dirs=None)
+            with redirect_stdout(scan_out):
+                aec.main(args)
+                self.assertEqual(scan_out.getvalue(),
+                                 messages.SCAN_UPDATED % 'scan1' + '\n')
+
+    def test_edit_scan_search_dirs(self):
+        """Testing the edit scan command with search dirs successfully."""
+        scan_out = StringIO()
+        url_get_scan = get_server_location() + SCAN_URI + '?name=scan1'
+        url_patch = get_server_location() + SCAN_URI + '1/'
+        scan_entry = {'id': 1, 'name': 'scan1', 'sources': ['source1']}
+        updated_entry = {'id': 1, 'name': 'scan1', 'sources': ['source1'],
+                         'options': {'enabled_extended_product_search':
+                                     {'search_directories': '/foo/bar/'}}}
+        results = [scan_entry]
+        scan_data = {'count': 1, 'results': results}
+        with requests_mock.Mocker() as mocker:
+            mocker.get(url_get_scan, status_code=200, json=scan_data)
+            mocker.patch(url_patch, status_code=200, json=updated_entry)
+            aec = ScanEditCommand(SUBPARSER)
+            args = Namespace(name='scan1', sources=None,
+                             max_concurrency=50,
+                             disabled_optional_products=None,
+                             enabled_extended_product_search=None,
+                             ext_product_search_dirs='/foo/bar/')
             with redirect_stdout(scan_out):
                 aec.main(args)
                 self.assertEqual(scan_out.getvalue(),
@@ -133,7 +190,9 @@ class SourceEditCliTests(unittest.TestCase):
             aec = ScanEditCommand(SUBPARSER)
             args = Namespace(name='scan1', sources=['source1'],
                              max_concurrency=50,
-                             disabled_optional_products=None)
+                             disabled_optional_products=None,
+                             enabled_extended_product_search=None,
+                             ext_product_search_dirs=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
                     aec.main(args)


### PR DESCRIPTION
Add CLI flags for extended product search & search dirs 