### PR TITLE
Detect EAP 5 in the fingerprint engine

### DIFF
--- a/quipucords/scanner/network/processing/eap5.py
+++ b/quipucords/scanner/network/processing/eap5.py
@@ -21,14 +21,14 @@ class ProcessVersionTxt(util.StdoutSearchProcessor):
     """Process the output of 'cat .../version.txt'."""
 
     KEY = 'eap5_home_version_txt'
-    SEARCH_STRING = 'JBoss Enterprise Application Platform'
+    SEARCH_STRING = 'JBoss Enterprise Application Platform - Version 5'
 
 
 class ProcessReadmeHtml(util.StdoutSearchProcessor):
     """Process the output of 'cat .../readme.html'."""
 
     KEY = 'eap5_home_readme_html'
-    SEARCH_STRING = 'JBoss Enterprise Application Platform'
+    SEARCH_STRING = 'JBoss Enterprise Application Platform 5'
 
 
 class ProcessLsJbossAs(util.IndicatorFileFinder):


### PR DESCRIPTION
Add EAP 5 support to the fingerprinting engine, using the network scan support from the previous PR.

Here's the output from a scan of an EAP 5 system, cleaned up:
```
{
  ...
  "products": [
    {
      "name": "JBoss EAP",
      "presence": "present",
      "version": [
        "EAP 5"
      ],
      "metadata": {
        "source_id": 2,
        "source_name": "sonar-jbosseap-rhel-5-vc",
        "source_type": "network",
        "raw_fact_key": "jboss_eap_running_paths/jboss_eap_packages/jboss_eap_locate_jboss_modules_jar/eap_home_ls/eap5_home_version_txt/eap5_home_readme_html"
      }
    },
    ...
  ],
  "report_id": 18
}
```

Closes #850 .