### PR TITLE
Add a task to gather version from run.jar without java

### DIFF
--- a/roles/jboss_eap5/tasks/main.yml
+++ b/roles/jboss_eap5/tasks/main.yml
@@ -71,3 +71,12 @@
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
   when: 'have_java and jboss_eap'
+
+# This is similar to the previous command, but works even when the EAP
+# installation is broken.
+- name: run.jar manifest
+  raw: unzip -p "{{ item }}"/jboss-as/bin/run.jar META-INF/MANIFEST.MF
+  register: eap5_home_run_jar_manifest
+  ignore_errors: yes
+  with_items: "{{ eap5_home_candidates }}"
+  when: 'jboss_eap'


### PR DESCRIPTION
Closes #934 .

Adding one more role to the EAP 5 playbook to allow us to detect EAP 4 as well. We're actually getting at the same information at the same directory offset as before. What's new here is that we can extract the EAP version from the `run.jar` file even if we can't run the jar, by extracting just the part we need.

Sample output from an EAP 4 machine:
```
{
  "host": "10.10.182.109",
  "result": {
    "results": [
      {
        "rc": 0,
        "stdout": "Manifest-Version: 1.0\r\r\nSpecification-Title: JBoss\r\r\nCreated-By: 1.5.0_18-b02 (Sun Microsystems Inc.)\r\r\nSpecification-Version: 4.3.0.GA_CP10\r\r\nImplementation-Vendor-Id: http://www.jboss.org/\r\r\nImplementation-URL: http://www.jboss.org/\r\r\nClass-Path: ../client/getopt.jar\r\r\nAnt-Version: Apache Ant 1.6.5\r\r\nMain-Class: org.jboss.Main\r\r\nImplementation-Title: JBoss [EAP]\r\r\nSpecification-Vendor: JBoss (http://www.jboss.org/)\r\r\nImplementation-Version: 4.3.0.GA_CP10 (build: SVNTag=JBPAPP_4_3_0_GA_C\r\r\n P10 date=201107201825)\r\r\nImplementation-Vendor: JBoss Inc.\r\r\n\r\r\n",
        "stdout_lines": [
          "Manifest-Version: 1.0",
          "",
          "Specification-Title: JBoss",
          "",
          "Created-By: 1.5.0_18-b02 (Sun Microsystems Inc.)",
          "",
          "Specification-Version: 4.3.0.GA_CP10",
          "",
          "Implementation-Vendor-Id: http://www.jboss.org/",
          "",
          "Implementation-URL: http://www.jboss.org/",
          "",
          "Class-Path: ../client/getopt.jar",
          "",
          "Ant-Version: Apache Ant 1.6.5",
          "",
          "Main-Class: org.jboss.Main",
          "",
          "Implementation-Title: JBoss [EAP]",
          "",
          "Specification-Vendor: JBoss (http://www.jboss.org/)",
          "",
          "Implementation-Version: 4.3.0.GA_CP10 (build: SVNTag=JBPAPP_4_3_0_GA_C",
          "",
          " P10 date=201107201825)",
          "",
          "Implementation-Vendor: JBoss Inc.",
          "",
          "",
          ""
        ],
        "stderr": "Shared connection to 10.10.182.109 closed.\r\n",
        "changed": true,
        "_ansible_no_log": false,
        "item": "/opt/jboss/jboss-eap-4.3",
        "_ansible_item_result": true
      }
    ],
    "changed": true,
    "msg": "All items completed"
  },
  "key": "eap5_home_run_jar_manifest"
}
```

The `Implementation-Version:` part is what we want. I'll extract that in the network postprocessing step.