### PR TITLE
Add network postprocessing for EAP 4 and 5 run.jar MANIFEST files

### DIFF
--- a/quipucords/scanner/network/processing/eap5.py
+++ b/quipucords/scanner/network/processing/eap5.py
@@ -10,7 +10,8 @@
 """Initial processing of raw shell output from Ansible commands."""
 
 import logging
-from scanner.network.processing import util
+import re
+from scanner.network.processing import process, util
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -43,3 +44,101 @@ class ProcessRunJarVersion(util.StdoutSearchProcessor):
 
     KEY = 'eap5_home_run_jar_version'
     SEARCH_STRING = 'JBoss'
+
+
+# Classifications for the Implementation-Version field of the
+# MANIFEST.MF file inside of a run.jar. This dict is from
+# https://github.com/mdvickst/ansible-scan-jboss/blob/master/scan-jboss.py
+# . According to the project, it is up to date through EAP 6.4 CP04
+# and WildFly 10.0.0.CR3.
+VERSION_CLASSIFICATIONS = {
+    'JBoss_4_0_0': 'JBossAS-4',
+    'JBoss_4_0_1_SP1': 'JBossAS-4',
+    'JBoss_4_0_2': 'JBossAS-4',
+    'JBoss_4_0_3_SP1': 'JBossAS-4',
+    'JBoss_4_0_4_GA': 'JBossAS-4',
+    'Branch_4_0': 'JBossAS-4',
+    'JBoss_4_2_0_GA': 'JBossAS-4',
+    'JBoss_4_2_1_GA': 'JBossAS-4',
+    'JBoss_4_2_2_GA': 'JBossAS-4',
+    'JBoss_4_2_3_GA': 'JBossAS-4',
+    'JBoss_5_0_0_GA': 'JBossAS-5',
+    'JBoss_5_0_1_GA': 'JBossAS-5',
+    'JBoss_5_1_0_GA': 'JBossAS-5',
+    'JBoss_6.0.0.Final': 'JBossAS-6',
+    'JBoss_6.1.0.Final': 'JBossAS-6',
+    '1.0.1.GA': 'JBossAS-7',
+    '1.0.2.GA': 'JBossAS-7',
+    '1.1.1.GA': 'JBossAS-7',
+    '1.2.0.CR1': 'JBossAS-7',
+    '1.2.0.Final': 'WildFly-8',
+    '1.2.2.Final': 'WildFly-8',
+    '1.2.4.Final': 'WildFly-8',
+    '1.3.0.Beta3': 'WildFly-8',
+    '1.3.0.Final': 'WildFly-8',
+    '1.3.3.Final': 'WildFly-8',
+    '1.3.4.Final': 'WildFly-9',
+    '1.4.2.Final': 'WildFly-9',
+    '1.4.3.Final': 'WildFly-10',
+    '1.4.4.Final': 'WildFly-10',
+    'JBPAPP_4_2_0_GA': 'EAP-4.2',
+    'JBPAPP_4_2_0_GA_C': 'EAP-4.2',
+    'JBPAPP_4_3_0_GA': 'EAP-4.3',
+    'JBPAPP_4_3_0_GA_C': 'EAP-4.3',
+    'JBPAPP_5_0_0_GA': 'EAP-5.0.0',
+    'JBPAPP_5_0_1': 'EAP-5.0.1',
+    'JBPAPP_5_1_0': 'EAP-5.1.0',
+    'JBPAPP_5_1_1': 'EAP-5.1.1',
+    'JBPAPP_5_1_2': 'EAP-5.1.2',
+    'JBPAPP_5_2_0': 'EAP-5.2.0',
+    '1.1.2.GA-redhat-1': 'EAP-6.0.0',
+    '1.1.3.GA-redhat-1': 'EAP-6.0.1',
+    '1.2.0.Final-redhat-1': 'EAP-6.1.0',
+    '1.2.2.Final-redhat-1': 'EAP-6.1.1',
+    '1.3.0.Final-redhat-2': 'EAP-6.2',
+    '1.3.3.Final-redhat-1': 'EAP-6.3',
+    '1.3.4.Final-redhat-1': 'EAP-6.3',
+    '1.3.5.Final-redhat-1': 'EAP-6.3',
+    '1.3.6.Final-redhat-1': 'EAP-6.4',
+    '1.3.7.Final-redhat-1': 'EAP-6.4'
+}
+
+
+class ProcessRunJarManifest(process.Processor):
+    """Process the MANIFEST.MF file from run.jar."""
+
+    KEY = 'eap5_home_run_jar_manifest'
+
+    # Find the line that contains 'Implementation-Version:', then pull
+    # out the first non-whitespace token after '(CVS|SVN)Tag=' on that
+    # same line.
+
+    VERSION_REGEXP = re.compile(
+        r'Implementation-Version:.*(CVS|SVN)Tag=(\S+)\s*.*')
+
+    @classmethod
+    def process(cls, output):
+        """Process the contents of a MANIFEST.MF file.
+
+        :param output: an Ansible task result dictionary.
+
+        :returns: a dictionary mapping EAP_HOME candidate directory to
+            EAP version. If we can't detect an EAP version for a
+            candidate, it won't be in the dictionary.
+        """
+        results = {}
+
+        for item in output['results']:
+            directory = item['item']
+            for line in item['stdout_lines']:
+                match = cls.VERSION_REGEXP.match(line)
+                if match:
+                    raw_version = match.group(2)
+                    if raw_version in VERSION_CLASSIFICATIONS:
+                        results[directory] = VERSION_CLASSIFICATIONS[
+                            raw_version]
+                    else:
+                        results[directory] = 'Unknown EAP version: {0}'.format(
+                            raw_version)
+
+        return results


### PR DESCRIPTION
The postprocessing step mimics the code in https://github.com/mdvickst/ansible-scan-jboss/blob/master/scan-jboss.py , but works a slightly different way. The format of the line we care about is `Implementation-Version: <short-version> (SVNTag=<long-version> ...`. `SVNTag` can also be `CVSTag`.

We look for the `Implementation-Version:` line in the `MANIFEST.MF`, pull out the `<long-version>`, then use a lookup table to find the version of `JBoss EAP` it corresponds to.

When I scan my EAP 4 test VM, I get `'eap5_home_run_jar_manifest': {'/opt/jboss/jboss-eap-4.3': 'EAP-4.3'}` in the network facts dictionary.

Closes #935 .