### PR TITLE
Remove fields from Report Summary. Part of #951

### DIFF
--- a/quipucords/api/fingerprint/model.py
+++ b/quipucords/api/fingerprint/model.py
@@ -53,9 +53,6 @@ class SystemFingerprint(models.Model):
     subscription_manager_id = models.CharField(
         max_length=36, unique=False, null=True)
 
-    cpu_core_per_socket = models.PositiveIntegerField(unique=False, null=True)
-    cpu_siblings = models.PositiveIntegerField(unique=False, null=True)
-    cpu_hyperthreading = models.NullBooleanField()
     cpu_socket_count = models.PositiveIntegerField(unique=False, null=True)
     cpu_core_count = models.PositiveIntegerField(unique=False, null=True)
 
@@ -63,20 +60,13 @@ class SystemFingerprint(models.Model):
     system_last_checkin_date = models.DateField(null=True)
 
     virtualized_type = models.CharField(max_length=64, unique=False, null=True)
-    virtualized_num_guests = models.PositiveIntegerField(
-        unique=False, null=True)
-    virtualized_num_running_guests = models.PositiveIntegerField(
-        unique=False, null=True)
 
     # VCenter scan facts
     vm_state = models.CharField(max_length=24, unique=False, null=True)
     vm_uuid = models.CharField(max_length=36, unique=False, null=True)
-    vm_memory_size = models.PositiveIntegerField(unique=False, null=True)
     vm_dns_name = models.CharField(max_length=128, unique=False, null=True)
     vm_host = models.CharField(max_length=128, unique=False, null=True)
     vm_host_socket_count = models.PositiveIntegerField(unique=False, null=True)
-    vm_host_cpu_cores = models.PositiveIntegerField(unique=False, null=True)
-    vm_host_cpu_threads = models.PositiveIntegerField(unique=False, null=True)
     vm_cluster = models.CharField(max_length=128, unique=False, null=True)
     vm_datacenter = models.CharField(max_length=128, unique=False, null=True)
 
@@ -95,23 +85,15 @@ class SystemFingerprint(models.Model):
             'cpu_count:{}, '\
             'bios_uuid:{}, '\
             'subscription_manager_id:{}, '\
-            'cpu_core_per_socket:{}, '\
-            'cpu_siblings:{}, '\
-            'cpu_hyperthreading:{}, '\
             'cpu_socket_count:{}, '\
             'cpu_core_count:{}, '\
             'system_creation_date:{}, '\
             'infrastructure_type:{}, '\
             'virtualized_type:{}, '\
-            'virtualized_num_guests:{}, '\
-            'virtualized_num_running_guests:{}, '\
             'vm_state:{}, '\
             'vm_uuid:{}, '\
-            'vm_memory_size:{}, '\
             'vm_dns_name:{}, '\
             'vm_host:{}, '\
-            'vm_host_cpu_cores:{}, '\
-            'vm_host_cpu_threads:{}, '\
             'vm_host_socket_count:{}, '\
             'vm_datacenter:{}, '\
             'vm_cluster:{}, '\
@@ -126,23 +108,15 @@ class SystemFingerprint(models.Model):
                                   self.cpu_count,
                                   self.bios_uuid,
                                   self.subscription_manager_id,
-                                  self.cpu_core_per_socket,
-                                  self.cpu_siblings,
-                                  self.cpu_hyperthreading,
                                   self.cpu_socket_count,
                                   self.cpu_core_count,
                                   self.system_creation_date,
                                   self.infrastructure_type,
                                   self.virtualized_type,
-                                  self.virtualized_num_guests,
-                                  self.virtualized_num_running_guests,
                                   self.vm_state,
                                   self.vm_uuid,
-                                  self.vm_memory_size,
                                   self.vm_dns_name,
                                   self.vm_host,
-                                  self.vm_host_cpu_cores,
-                                  self.vm_host_cpu_threads,
                                   self.vm_host_socket_count,
                                   self.vm_datacenter,
                                   self.vm_cluster,

--- a/quipucords/api/fingerprint/serializer.py
+++ b/quipucords/api/fingerprint/serializer.py
@@ -16,7 +16,6 @@ from rest_framework.serializers import (PrimaryKeyRelatedField,
                                         CharField,
                                         ChoiceField,
                                         DateField,
-                                        NullBooleanField,
                                         ModelSerializer)
 from api.models import (SystemFingerprint,
                         FactCollection,
@@ -76,29 +75,20 @@ class FingerprintSerializer(ModelSerializer):
     bios_uuid = CharField(required=False, max_length=36)
     subscription_manager_id = CharField(required=False, max_length=36)
 
-    cpu_core_per_socket = IntegerField(required=False, min_value=0)
-    cpu_siblings = IntegerField(required=False, min_value=0)
-    cpu_hyperthreading = NullBooleanField(required=False)
     cpu_socket_count = IntegerField(required=False, min_value=0)
     cpu_core_count = IntegerField(required=False, min_value=0)
 
     system_creation_date = DateField(required=False)
 
     virtualized_type = CharField(required=False, max_length=64)
-    virtualized_num_guests = IntegerField(required=False, min_value=0)
-    virtualized_num_running_guests = IntegerField(required=False, min_value=0)
 
     # VCenter scan facts
     vm_state = CharField(required=False, max_length=24)
     vm_uuid = CharField(required=False, max_length=36)
-    vm_memory_size = IntegerField(required=False, min_value=0)
     vm_dns_name = CharField(required=False, max_length=128)
 
     vm_host = CharField(required=False, max_length=128)
     vm_host_socket_count = IntegerField(required=False, min_value=0)
-    vm_host_cpu_cores = IntegerField(required=False, min_value=0)
-
-    vm_host_cpu_threads = IntegerField(required=False, min_value=0)
 
     vm_cluster = CharField(required=False, max_length=128)
     vm_datacenter = CharField(required=False, max_length=128)

--- a/quipucords/api/report/tests_report.py
+++ b/quipucords/api/report/tests_report.py
@@ -272,7 +272,7 @@ class DeploymentReportTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         report = response.json()
         self.assertIsInstance(report, dict)
-        self.assertEqual(len(report['report'][0].keys()), 35)
+        self.assertEqual(len(report['report'][0].keys()), 27)
 
     def test_get_fact_collection_filter_report(self):
         """Get a specific group count report with filter."""
@@ -379,7 +379,7 @@ class DeploymentReportTest(TestCase):
         csv_result = renderer.render(report)
 
         # pylint: disable=line-too-long
-        expected = 'Report\r\n1\r\n\r\n\r\nReport:\r\nbios_uuid,cpu_core_count,cpu_core_per_socket,cpu_count,cpu_hyperthreading,cpu_siblings,cpu_socket_count,infrastructure_type,ip_addresses,jboss brms,jboss eap,jboss fuse,mac_addresses,name,os_name,os_release,os_version,subscription_manager_id,system_creation_date,system_last_checkin_date,virtualized_num_guests,virtualized_num_running_guests,virtualized_type,vm_cluster,vm_datacenter,vm_dns_name,vm_host,vm_host_cpu_cores,vm_host_cpu_threads,vm_host_socket_count,vm_memory_size,vm_state,vm_uuid\r\n,2,1,2,False,1,2,virtualized,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,2017-07-18,,1,1,vmware,,,,,,,,,,\r\n,2,1,2,False,1,2,virtualized,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,2017-07-18,,1,1,vmware,,,,,,,,,,\r\n,2,1,2,False,1,2,virtualized,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.5,7.5,,2017-07-18,,1,1,vmware,,,,,,,,,,\r\n\r\n'  # noqa
+        expected = 'Report\r\n1\r\n\r\n\r\nReport:\r\nbios_uuid,cpu_core_count,cpu_count,cpu_socket_count,infrastructure_type,ip_addresses,jboss brms,jboss eap,jboss fuse,mac_addresses,name,os_name,os_release,os_version,subscription_manager_id,system_creation_date,system_last_checkin_date,virtualized_type,vm_cluster,vm_datacenter,vm_dns_name,vm_host,vm_host_socket_count,vm_state,vm_uuid\r\n,2,2,2,virtualized,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,2017-07-18,,vmware,,,,,,,\r\n,2,2,2,virtualized,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,2017-07-18,,vmware,,,,,,,\r\n,2,2,2,virtualized,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.5,7.5,,2017-07-18,,vmware,,,,,,,\r\n\r\n' # noqa
         self.assertEqual(csv_result, expected)
 
     def test_csv_renderer_only_name(self):

--- a/quipucords/fingerprinter/__init__.py
+++ b/quipucords/fingerprinter/__init__.py
@@ -639,12 +639,6 @@ def _process_network_fact(source, fact):
                             fact, 'subscription_manager_id', fingerprint)
 
     # System information
-    add_fact_to_fingerprint(source, 'cpu_core_per_socket',
-                            fact, 'cpu_core_per_socket', fingerprint)
-    add_fact_to_fingerprint(source, 'cpu_siblings',
-                            fact, 'cpu_siblings', fingerprint)
-    add_fact_to_fingerprint(source, 'cpu_hyperthreading',
-                            fact, 'cpu_hyperthreading', fingerprint)
     add_fact_to_fingerprint(source, 'cpu_socket_count',
                             fact, 'cpu_socket_count', fingerprint)
     add_fact_to_fingerprint(source, 'cpu_core_count',
@@ -717,11 +711,6 @@ def _process_network_fact(source, fact):
     # Determine if VM facts
     add_fact_to_fingerprint(source, 'virt_type', fact,
                             'virtualized_type', fingerprint)
-    add_fact_to_fingerprint(source, 'virt_num_guests',
-                            fact, 'virtualized_num_guests', fingerprint)
-    add_fact_to_fingerprint(source, 'virt_num_running_guests',
-                            fact, 'virtualized_num_running_guests',
-                            fingerprint)
 
     add_entitlements_to_fingerprint(source, 'subman_consumed',
                                     fact, fingerprint)
@@ -773,16 +762,10 @@ def _process_vcenter_fact(source, fact):
             logger.error('Could not parse date %s: %s',
                          fact['vm.last_check_in'], date_err)
 
-    add_fact_to_fingerprint(source, 'vm.memory_size',
-                            fact, 'vm_memory_size', fingerprint)
     add_fact_to_fingerprint(source, 'vm.dns_name', fact,
                             'vm_dns_name', fingerprint)
     add_fact_to_fingerprint(source, 'vm.host.name',
                             fact, 'vm_host', fingerprint)
-    add_fact_to_fingerprint(source, 'vm.host.cpu_cores',
-                            fact, 'vm_host_cpu_cores', fingerprint)
-    add_fact_to_fingerprint(source, 'vm.host.cpu_threads',
-                            fact, 'vm_host_cpu_threads', fingerprint)
     add_fact_to_fingerprint(source, 'vm.host.cpu_count',
                             fact, 'vm_host_socket_count', fingerprint)
     add_fact_to_fingerprint(source, 'vm.datacenter',

--- a/quipucords/fingerprinter/tests_engine.py
+++ b/quipucords/fingerprinter/tests_engine.py
@@ -57,9 +57,6 @@ class EngineTest(TestCase):
             connection_uuid='a037f26f-2988-57bd-85d8-de7617a3aab0',
             connection_host='1.2.3.4',
             connection_port=22,
-            cpu_core_per_socket=1,
-            cpu_siblings=1,
-            cpu_hyperthreading=False,
             cpu_socket_count=2,
             cpu_core_count=2,
             date_anaconda_log='2017-06-17',
@@ -108,12 +105,6 @@ class EngineTest(TestCase):
             fact['uname_hostname'] = connection_host
         if connection_port:
             fact['connection_port'] = connection_port
-        if cpu_core_per_socket:
-            fact['cpu_core_per_socket'] = cpu_core_per_socket
-        if cpu_siblings:
-            fact['cpu_siblings'] = cpu_siblings
-        if cpu_hyperthreading is not None:
-            fact['cpu_hyperthreading'] = cpu_hyperthreading
         if cpu_socket_count:
             fact['cpu_socket_count'] = cpu_socket_count
         if cpu_core_count:
@@ -148,11 +139,8 @@ class EngineTest(TestCase):
             vm_name='TestMachine',
             vm_state='On',
             vm_uuid='a037f26f-2988-57bd-85d8-de7617a3aab0',
-            vm_memory_size=1024,
             vm_dns_name='site.com',
             vm_host_name='1.2.3.4',
-            vm_host_cpu_cores=2,
-            vm_host_cpu_threads=4,
             vm_host_cpu_count=8,
             vm_datacenter='NY',
             vm_cluster='23sd'):
@@ -183,16 +171,10 @@ class EngineTest(TestCase):
             fact['vm.state'] = vm_state
         if vm_uuid:
             fact['vm.uuid'] = vm_uuid
-        if vm_memory_size:
-            fact['vm.memory_size'] = vm_memory_size
         if vm_dns_name:
             fact['vm.dns_name'] = vm_dns_name
         if vm_host_name:
             fact['vm.host.name'] = vm_host_name
-        if vm_host_cpu_cores:
-            fact['vm.host.cpu_cores'] = vm_host_cpu_cores
-        if vm_host_cpu_threads:
-            fact['vm.host.cpu_threads'] = vm_host_cpu_threads
         if vm_host_cpu_count:
             fact['vm.host.cpu_count'] = vm_host_cpu_count
         if vm_datacenter:
@@ -288,12 +270,6 @@ class EngineTest(TestCase):
         self.assertEqual(fact.get('subman_virt_uuid'),
                          fingerprint.get('subscription_manager_id'))
 
-        self.assertEqual(fact.get('cpu_core_per_socket'),
-                         fingerprint.get('cpu_core_per_socket'))
-        self.assertEqual(fact.get('cpu_siblings'),
-                         fingerprint.get('cpu_siblings'))
-        self.assertEqual(fact.get('cpu_hyperthreading'),
-                         fingerprint.get('cpu_hyperthreading'))
         self.assertEqual(fact.get('cpu_socket_count'),
                          fingerprint.get('cpu_socket_count'))
         self.assertEqual(fact.get('cpu_core_count'),
@@ -308,10 +284,6 @@ class EngineTest(TestCase):
 
         self.assertEqual(fact.get('virt_type'),
                          fingerprint.get('virtualized_type'))
-        self.assertEqual(fact.get('virt_num_guests'),
-                         fingerprint.get('virtualized_num_guests'))
-        self.assertEqual(fact.get('virt_num_running_guests'),
-                         fingerprint.get('virtualized_num_running_guests'))
 
     def _validate_vcenter_result(self, fingerprint, fact):
         """Help to validate fields."""
@@ -330,17 +302,11 @@ class EngineTest(TestCase):
                          fingerprint.get('vm_state'))
 
         self.assertEqual(fact.get('vm.uuid'), fingerprint.get('vm_uuid'))
-        self.assertEqual(fact.get('vm.memory_size'),
-                         fingerprint.get('vm_memory_size'))
 
         self.assertEqual(fact.get('vm.dns_name'),
                          fingerprint.get('vm_dns_name'))
         self.assertEqual(fact.get('vm.host.name'),
                          fingerprint.get('vm_host'))
-        self.assertEqual(fact.get('vm.host.cpu_cores'),
-                         fingerprint.get('vm_host_cpu_cores'))
-        self.assertEqual(fact.get('vm.host.cpu_threads'),
-                         fingerprint.get('vm_host_cpu_threads'))
 
         self.assertEqual(fact.get('vm.host.cpu_count'),
                          fingerprint.get('vm_host_socket_count'))
@@ -640,10 +606,7 @@ class EngineTest(TestCase):
 
         self.assertIsNone(nfingerprint.get('vm_state'))
         self.assertIsNone(nfingerprint.get('vm_uuid'))
-        self.assertIsNone(nfingerprint.get('vm_memory_size'))
         self.assertIsNone(nfingerprint.get('vm_dns_name'))
-        self.assertIsNone(nfingerprint.get('vm_host_cpu_cores'))
-        self.assertIsNone(nfingerprint.get('vm_host_cpu_threads'))
         self.assertIsNone(nfingerprint.get('vm_host_socket_count'))
         self.assertIsNone(nfingerprint.get('vm_datacenter'))
         self.assertIsNone(nfingerprint.get('vm_cluster'))
@@ -652,9 +615,6 @@ class EngineTest(TestCase):
         self.assertIsNone(vfingerprint.get('os_version'))
         self.assertIsNone(vfingerprint.get('bios_uuid'))
         self.assertIsNone(vfingerprint.get('subscription_manager_id'))
-        self.assertIsNone(vfingerprint.get('cpu_core_per_socket'))
-        self.assertIsNone(vfingerprint.get('cpu_siblings'))
-        self.assertIsNone(vfingerprint.get('cpu_hyperthreading'))
         self.assertIsNone(vfingerprint.get('cpu_socket_count'))
         self.assertIsNone(vfingerprint.get('cpu_core_count'))
 
@@ -662,10 +622,7 @@ class EngineTest(TestCase):
 
         self.assertIsNotNone(new_fingerprint.get('vm_state'))
         self.assertIsNotNone(new_fingerprint.get('vm_uuid'))
-        self.assertIsNotNone(new_fingerprint.get('vm_memory_size'))
         self.assertIsNotNone(new_fingerprint.get('vm_dns_name'))
-        self.assertIsNotNone(new_fingerprint.get('vm_host_cpu_cores'))
-        self.assertIsNotNone(new_fingerprint.get('vm_host_cpu_threads'))
         self.assertIsNotNone(new_fingerprint.get('vm_host_socket_count'))
         self.assertIsNotNone(new_fingerprint.get('vm_datacenter'))
         self.assertIsNotNone(new_fingerprint.get('vm_cluster'))
@@ -675,9 +632,6 @@ class EngineTest(TestCase):
         self.assertIsNotNone(new_fingerprint.get('os_version'))
         self.assertIsNotNone(new_fingerprint.get('bios_uuid'))
         self.assertIsNotNone(new_fingerprint.get('subscription_manager_id'))
-        self.assertIsNotNone(new_fingerprint.get('cpu_core_per_socket'))
-        self.assertIsNotNone(new_fingerprint.get('cpu_siblings'))
-        self.assertIsNotNone(new_fingerprint.get('cpu_hyperthreading'))
         self.assertIsNotNone(new_fingerprint.get('cpu_socket_count'))
         self.assertIsNotNone(new_fingerprint.get('cpu_core_count'))
 


### PR DESCRIPTION
Remove: 
- vm_host_cpu_cores
- vm_host_cpu_threads
- vm_memory_size
- cpu_core_per_socket
- cpu_hyperthreading
- cpu_siblings
- virtualized_num_guests
- virtualized_num_running_guests