### PR TITLE
Add most_recent_scanjob to Scan model

### DIFF
--- a/quipucords/api/scan/model.py
+++ b/quipucords/api/scan/model.py
@@ -201,6 +201,9 @@ class Scan(models.Model):
     options = models.ForeignKey(
         ScanOptions, null=True, on_delete=models.CASCADE)
 
+    most_recent_scanjob = models.ForeignKey(
+        'api.ScanJob', null=True, on_delete=models.SET_NULL, related_name='+')
+
     def __str__(self):
         """Convert to string."""
         return '{' + 'id:{}, '\

--- a/quipucords/api/scan/serializer.py
+++ b/quipucords/api/scan/serializer.py
@@ -137,7 +137,8 @@ class ScanSerializer(NotEmptySerializer):
         """Metadata for serializer."""
 
         model = Scan
-        fields = ['id', 'name', 'sources', 'scan_type', 'options', 'jobs']
+        fields = ['id', 'name', 'sources', 'scan_type', 'options', 'jobs',
+                  'most_recent_scanjob']
 
     @transaction.atomic
     def create(self, validated_data):

--- a/quipucords/api/scan/tests_scan.py
+++ b/quipucords/api/scan/tests_scan.py
@@ -16,7 +16,6 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 from api.models import (Credential,
                         Scan,
-                        ScanOptions,
                         ScanJob,
                         Source,
                         ScanTask)
@@ -489,7 +488,6 @@ class TestScanList(TestCase):
 
     def test_list_by_scanjob_end_time(self):
         """List all scan objects, ordered by ScanJob start time."""
-
         # self.test1 will not have a most_recent_scanjob, self.test2
         # will.
         job = ScanJob(

--- a/quipucords/api/scan/tests_scan.py
+++ b/quipucords/api/scan/tests_scan.py
@@ -449,7 +449,7 @@ class TestScanList(TestCase):
         self.source.credentials.add(self.cred)
         self.source.save()
 
-       self.test1 = Scan(
+        self.test1 = Scan(
             name='test1',
             scan_type=ScanTask.SCAN_TYPE_INSPECT)
         self.test1.save()

--- a/quipucords/api/scan/view.py
+++ b/quipucords/api/scan/view.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 SOURCES_KEY = 'sources'
 MOST_RECENT = 'most_recent'
-JOBS_KEY = 'jobs'
+MOST_RECENT_SCANJOB_KEY = 'most_recent_scanjob'
 
 ##################################################
 # Independent jobs route
@@ -149,13 +149,9 @@ def expand_scan(json_scan):
     if slim_sources:
         json_scan[SOURCES_KEY] = slim_sources
 
-    scan_jobs = json_scan.get(JOBS_KEY)
-    latest_job = None
-    if bool(scan_jobs):
-        latest_job = scan_jobs[0]
-        latest_job = ScanJob.objects.filter(id=latest_job['id']).first()
-
-    if latest_job is not None:
+    most_recent_scanjob = json_scan.pop(MOST_RECENT_SCANJOB_KEY, None)
+    if most_recent_scanjob:
+        latest_job = ScanJob.objects.get(pk=most_recent_scanjob)
         systems_count, \
             systems_scanned, \
             systems_failed = latest_job.calculate_counts()

--- a/quipucords/api/scan/view.py
+++ b/quipucords/api/scan/view.py
@@ -226,7 +226,8 @@ class ScanViewSet(ModelViewSet):
     serializer_class = ScanSerializer
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filter_class = ScanFilter
-    ordering_fields = ('id', 'name', 'scan_type')
+    ordering_fields = ('id', 'name', 'scan_type',
+                       'most_recent_scanjob__start_time')
     ordering = ('name',)
 
     # pylint: disable=unused-argument

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -310,6 +310,9 @@ class ScanJob(models.Model):
 
                 count += 1
 
+        self.scan.most_recent_scanjob = self
+        self.scan.save()
+
         self.status = target_status
         self.status_message = _(messages.SJ_STATUS_MSG_PENDING)
         self.save()


### PR DESCRIPTION
Update tests and make ScanJob keep the reference up to date.

Closes #982 .