### PR TITLE
Make sources sortable by latest connection scan job time

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -313,6 +313,10 @@ class ScanJob(models.Model):
         self.scan.most_recent_scanjob = self
         self.scan.save()
 
+        for source in self.sources.all():
+            source.most_recent_connect_scan = self
+            source.save()
+
         self.status = target_status
         self.status_message = _(messages.SJ_STATUS_MSG_PENDING)
         self.save()

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -292,14 +292,16 @@ class ScanJobTest(TestCase):
             json_response, {
                 'connection_results': {'task_results': [
                     {'source':
-                     {'id': 1, 'name': 'source1', 'source_type': 'network'},
+                     {'id': 1, 'name': 'source1', 'source_type': 'network',
+                      'most_recent_connect_scan': 1},
                      'systems':
                      [{'name': 'Foo', 'credential':
                        {'id': 1, 'name': 'cred1'},
                        'status': 'success'}]}]},
                 'inspection_results': {'task_results': [
                     {'source':
-                     {'id': 1, 'name': 'source1', 'source_type': 'network'},
+                     {'id': 1, 'name': 'source1', 'source_type': 'network',
+                      'most_recent_connect_scan': 1},
                      'systems':
                      [{'name': 'Foo', 'status': 'success',
                        'facts': [

--- a/quipucords/api/source/model.py
+++ b/quipucords/api/source/model.py
@@ -82,6 +82,9 @@ class Source(models.Model):
     credentials = models.ManyToManyField(Credential)
     hosts = models.TextField(unique=False, null=False)
 
+    most_recent_connect_scan = models.ForeignKey(
+        'api.ScanJob', null=True, on_delete=models.SET_NULL, related_name='+')
+
     def __str__(self):
         """Convert to string."""
         return '{ id:%s, '\

--- a/quipucords/api/source/tests_source.py
+++ b/quipucords/api/source/tests_source.py
@@ -144,6 +144,8 @@ class SourceTest(TestCase):
         scan_job.end_time = end
         scan_job.status = ScanTask.COMPLETED
         scan_job.save()
+        source.most_recent_connect_scan = scan_job
+        source.save()
 
         serializer = SourceSerializer(source)
         json_source = serializer.data
@@ -154,11 +156,15 @@ class SourceTest(TestCase):
                     'port': 22,
                     'hosts': ['1.2.3.4'],
                     'connection': {'id': 1, 'start_time': start,
-                                   'end_time': end, 'status': 'completed',
+                                   'end_time': end,
                                    'systems_count': 10,
                                    'systems_scanned': 9,
-                                   'systems_failed': 1}}
+                                   'systems_failed': 1,
+                                   'status': 'completed',
+                                   'status_details':
+                                   {'job_status_message': 'Job is pending.'}}}
 
+        print('***', out)
         self.assertEqual(out, expected)
 
     #################################################


### PR DESCRIPTION
Add a new memeber to Source, which tracks the latest connection scan
job. Update it when a connection scan job is queued, add its start
time to the source's sorting fields, and update tests appropriately.

Closes #984 .