### PR TITLE
Make the req params dictionary in the init instead of in build_req_params. Closes #1023

### DIFF
--- a/qpc/scan/list.py
+++ b/qpc/scan/list.py
@@ -44,11 +44,12 @@ class ScanListCommand(CliCommand):
                                  metavar='TYPE',
                                  help=_(messages.SCAN_TYPE_FILTER_HELP),
                                  required=False)
+        self.req_params = {}
 
     def _build_req_params(self):
         """Add filter by scan_type/state query param."""
         if 'type' in self.args and self.args.type:
-            self.req_params = {'scan_type': self.args.type}
+            self.req_params['scan_type'] = self.args.type
 
     def _handle_response_success(self):
         json_data = self.response.json()


### PR DESCRIPTION
Since the self.req_params was being built by `_build_req_params`, when the page was getting added to the dictionary in `_handle_response_success`, it was getting overwritten when `_build_req_params` was called. 