### PR TITLE
Avoid shell glob expansion in some cat commands

### DIFF
--- a/roles/jboss_brms/tasks/main.yml
+++ b/roles/jboss_brms/tasks/main.yml
@@ -54,7 +54,7 @@
   when: 'jboss_brms'
 
 - name: cat MANIFEST.MF files
-  raw: cat "{{ item }}"/META-INF/MANIFEST.MF 2>/dev/null
+  raw: cat '{{ item }}/META-INF/MANIFEST.MF' 2>/dev/null
   register: jboss_brms_manifest_mf
   ignore_errors: yes
   with_items: "{{ business_central_candidates + kie_server_candidates }}"

--- a/roles/jboss_eap/tasks/main.yml
+++ b/roles/jboss_eap/tasks/main.yml
@@ -44,14 +44,14 @@
   when: 'jboss_eap'
 
 - name: get version.txt from EAP_HOME candidates
-  raw: cat "{{ item }}"/version.txt 2>/dev/null
+  raw: cat '{{ item }}/version.txt' 2>/dev/null
   register: eap_home_version_txt
   ignore_errors: yes
   with_items: "{{ eap_home_candidates }}"
   when: 'jboss_eap'
 
 - name: get README.txt from EAP_HOME candidates
-  raw: cat "{{ item }}"/README.txt 2>/dev/null
+  raw: cat '{{ item }}/README.txt' 2>/dev/null
   register: eap_home_readme_txt
   ignore_errors: yes
   with_items: "{{ eap_home_candidates }}"
@@ -85,7 +85,7 @@
   when: 'jboss_eap'
 
 - name: check JBoss layers.conf
-  raw: cat "{{ item }}"/modules/layers.conf 2>/dev/null
+  raw: cat '{{ item }}/modules/layers.conf' 2>/dev/null
   register: eap_home_layers_conf
   ignore_errors: yes
   with_items: "{{ eap_home_candidates }}"

--- a/roles/jboss_eap5/tasks/main.yml
+++ b/roles/jboss_eap5/tasks/main.yml
@@ -45,28 +45,28 @@
 # Filters that will help us find true EAP_HOME directories
 
 - name: get version.txt from EAP_HOME candidates
-  raw: cat "{{ item }}"/version.txt 2>/dev/null
+  raw: cat '{{ item }}/version.txt' 2>/dev/null
   register: eap5_home_version_txt
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
   when: 'jboss_eap'
 
 - name: get readme.html from EAP_HOME candidates
-  raw: cat "{{ item }}"/readme.html 2>/dev/null
+  raw: cat '{{ item }}/readme.html' 2>/dev/null
   register: eap5_home_readme_html
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
   when: 'jboss_eap'
 
 - name: ls EAP_HOME/jboss-as
-  raw: ls -1 "{{ item }}"/jboss-as 2>/dev/null
+  raw: ls -1 '{{ item }}/jboss-as' 2>/dev/null
   register: eap5_home_ls_jboss_as
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
   when: 'jboss_eap'
 
 - name: EAP_HOME/jboss-as/bin/run.jar
-  raw: java -jar "{{ item }}"/jboss-as/bin/run.jar --version
+  raw: java -jar '{{ item }}/jboss-as/bin/run.jar' --version
   register: eap5_home_run_jar_version
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
@@ -75,7 +75,7 @@
 # This is similar to the previous command, but works even when the EAP
 # installation is broken.
 - name: run.jar manifest
-  raw: unzip -p "{{ item }}"/jboss-as/bin/run.jar META-INF/MANIFEST.MF
+  raw: unzip -p '{{ item }}/jboss-as/bin/run.jar' META-INF/MANIFEST.MF
   register: eap5_home_run_jar_manifest
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"


### PR DESCRIPTION
This prevents issues when the list of items to substitute in the
command gets corrupted with something that contains shell glob
characters.

Closes #1088 .