### PR TITLE
Detect BRMS version in non-invasive scan

### DIFF
--- a/quipucords/fingerprinter/jboss_brms.py
+++ b/quipucords/fingerprinter/jboss_brms.py
@@ -11,12 +11,11 @@
 
 """Ingests raw facts to determine the status of JBoss BRMS for a system."""
 
-import os
 import logging
+import os
+import re
 from api.models import Product, Source
-from fingerprinter.utils import (strip_prefix,
-                                 strip_suffix,
-                                 product_entitlement_found,
+from fingerprinter.utils import (product_entitlement_found,
                                  generate_raw_fact_members)
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -37,7 +36,10 @@ JBOSS_BRMS_DROOLS_CORE_VER = 'jboss_brms_drools_core_ver'
 SUBMAN_CONSUMED = 'subman_consumed'
 ENTITLEMENTS = 'entitlements'
 
+# These classifications apply to both strings in kie filenames and
+# Implementation-Version strings in BRMS MANIFEST.MF files.
 BRMS_CLASSIFICATIONS = {
+    '6.5.0.Final-redhat-2': 'BRMS 6.4.0',
     '6.4.0.Final-redhat-3': 'BRMS 6.3.0',
     '6.3.0.Final-redhat-5': 'BRMS 6.2.0',
     '6.2.0.Final-redhat-4': 'BRMS 6.1.0',
@@ -56,6 +58,22 @@ BRMS_CLASSIFICATIONS = {
 }
 
 
+def classify_version_string(version_string):
+    """Classify a version string.
+
+    :param version_string: a BRMS version string, in MANIFEST.MF format.
+
+    :returns: a version string in our standard format.
+    """
+    if version_string in BRMS_CLASSIFICATIONS:
+        return BRMS_CLASSIFICATIONS[version_string]
+
+    if 'redhat' in version_string:
+        return 'Unknown-Release: ' + version_string
+
+    return None
+
+
 def classify_kie_file(pathname):
     """Classify a kie-api-* file.
 
@@ -69,15 +87,10 @@ def classify_kie_file(pathname):
 
     basename = os.path.basename(pathname)
 
-    version_string = strip_suffix(
-        strip_prefix(basename, 'kie-api-'),
-        '.jar')
-
-    if version_string in BRMS_CLASSIFICATIONS:
-        return BRMS_CLASSIFICATIONS[version_string]
-
-    if 'redhat' in version_string:
-        return version_string
+    # Filename format is 'kie-api-' + version + '.jar' + stuff.
+    match = re.match(r'kie-api-(.*)\.jar.*', basename)
+    if match:
+        return classify_version_string(match.group(1))
 
     return None
 
@@ -90,8 +103,6 @@ def detect_jboss_brms(source, facts):
     :param facts: facts for a system
     :returns: dictionary defining the product presence
     """
-    business_central_candidates = facts.get(BUSINESS_CENTRAL_CANDIDATES, [])
-    kie_server_candidates = facts.get(KIE_SERVER_CANDIDATES, [])
     manifest_mfs = facts.get(JBOSS_BRMS_MANIFEST_MF, {})
     kie_in_bc = facts.get(JBOSS_BRMS_KIE_IN_BC, [])
     locate_kie_api = facts.get(JBOSS_BRMS_LOCATE_KIE_API, [])
@@ -100,30 +111,8 @@ def detect_jboss_brms(source, facts):
     find_drools = facts.get(JBOSS_BRMS_DROOLS_CORE_VER, [])
     subman_consumed = facts.get(SUBMAN_CONSUMED, [])
     entitlements = facts.get(ENTITLEMENTS, [])
-    base_directories = set(business_central_candidates + kie_server_candidates)
     kie_files = kie_in_bc + locate_kie_api
-    ext_search_versions = list(set(find_kie_api + find_kie_war + find_drools))
-
-    kie_versions_by_directory = {}
-    for directory in base_directories:
-        versions_in_dir = set()
-        for filename in list(kie_files):
-            if filename.startswith(directory):
-                kie_files.remove(filename)
-                category = classify_kie_file(filename)
-                if category:
-                    versions_in_dir.add(category)
-                # Deliberately drop files if their category is falsey,
-                # because it means that they are not Red Hat files.
-        kie_versions_by_directory[directory] = versions_in_dir
-
-    found_manifest = any(('Red Hat' in manifest
-                          for _, manifest in manifest_mfs.items()))
-    found_versions = any((version
-                          for _, version in kie_versions_by_directory.items()))
-    found_redhat_brms = (found_manifest or
-                         found_versions or
-                         ext_search_versions)
+    ext_search_results = set(find_kie_api + find_kie_war + find_drools)
 
     source_object = Source.objects.filter(id=source.get('source_id')).first()
     if source_object:
@@ -138,10 +127,34 @@ def detect_jboss_brms(source, facts):
     }
     product_dict = {'name': PRODUCT}
 
+    versions = set()
+    found_kie_version = False
+    for filename in kie_files:
+        category = classify_kie_file(filename)
+        # categories that are falsey are not Red Hat files.
+        if category:
+            versions.add(category)
+            found_kie_version = True
+
+    found_manifest_version = False
+    for manifest_version in manifest_mfs.values():
+        category = classify_version_string(manifest_version)
+        if category:
+            versions.add(category)
+            found_manifest_version = True
+
+    for search_version in ext_search_results:
+        category = classify_version_string(search_version)
+        if category:
+            versions.add(category)
+
+    found_redhat_brms = bool(versions)
+
     if found_redhat_brms:
-        raw_facts_dict = {JBOSS_BRMS_MANIFEST_MF: found_manifest,
-                          JBOSS_BRMS_KIE_IN_BC: (found_versions and kie_in_bc),
-                          JBOSS_BRMS_LOCATE_KIE_API: (found_versions and
+        raw_facts_dict = {JBOSS_BRMS_MANIFEST_MF: found_manifest_version,
+                          JBOSS_BRMS_KIE_IN_BC: (found_kie_version and
+                                                 kie_in_bc),
+                          JBOSS_BRMS_LOCATE_KIE_API: (found_kie_version and
                                                       locate_kie_api),
                           JBOSS_BRMS_KIE_API_VER: find_kie_api,
                           JBOSS_BRMS_KIE_WAR_VER: find_kie_war,
@@ -149,14 +162,7 @@ def detect_jboss_brms(source, facts):
         raw_facts = generate_raw_fact_members(raw_facts_dict)
         metadata[RAW_FACT_KEY] = raw_facts
         product_dict[PRESENCE_KEY] = Product.PRESENT
-        versions = []
-        if ext_search_versions:
-            for version_data in ext_search_versions:
-                unknown_release = 'Unknown-Release: ' + version_data
-                versions.append(BRMS_CLASSIFICATIONS.get(version_data,
-                                                         unknown_release))
-            if versions:
-                product_dict[VERSION_KEY] = versions
+        product_dict[VERSION_KEY] = list(versions)
 
     elif product_entitlement_found(subman_consumed, PRODUCT):
         metadata[RAW_FACT_KEY] = SUBMAN_CONSUMED

--- a/quipucords/fingerprinter/jboss_brms.py
+++ b/quipucords/fingerprinter/jboss_brms.py
@@ -105,42 +105,31 @@ def detect_jboss_brms(source, facts):
 
     versions = set()
     found_kie_version = False
-    for directory, version_string in itertools.chain(kie_in_bc,
-                                                     locate_kie_api):
-        # directory, basename = posixpath.split(filename)
-        # category = classify_kie_file(basename)
+    for _, version_string in itertools.chain(kie_in_bc,
+                                             locate_kie_api):
         category = classify_version_string(version_string)
         # categories that are falsey are not Red Hat files.
         if category:
-            # directory = directory or 'Unknown directory'
-            # Make directory part of the version string so we will
-            # report when the same BRMS version is installed in two
-            # places on one host.
-            versions.add('{0}:{1}'.format(directory, category))
+            versions.add(category)
             found_kie_version = True
 
     found_manifest_version = False
-    for directory, manifest_version in manifest_mfs:
+    for _, manifest_version in manifest_mfs:
         category = classify_version_string(manifest_version)
         if category:
-            versions.add('{0}:{1}'.format(directory, category))
+            versions.add(category)
             found_manifest_version = True
 
-    for directory, filename in itertools.chain(find_kie_api,
-                                               find_drools):
+    for _, filename in itertools.chain(find_kie_api,
+                                       find_drools):
         category = classify_version_string(filename)
         if category:
-            versions.add('{0}:{1}'.format(directory, category))
+            versions.add(category)
 
     for search_version in find_kie_war:
         category = classify_version_string(search_version)
         if category:
-            # The find_kie_war task can't output directories, so these
-            # are always unknown. The issue is that it has some old
-            # code to handle compressed .war archives, and we have no
-            # test cases for this code, which makes changing it too
-            # risky.
-            versions.add('Unknown directory:' + category)
+            versions.add(category)
 
     found_redhat_brms = bool(versions)
 

--- a/quipucords/fingerprinter/tests_product_brms.py
+++ b/quipucords/fingerprinter/tests_product_brms.py
@@ -28,7 +28,7 @@ class ProductBRMSTest(TestCase):
         product = detect_jboss_brms(source, facts)
         expected = {'name': 'JBoss BRMS',
                     'presence': 'present',
-                    'version': ['/opt/brms:BRMS 6.3.0'],
+                    'version': ['BRMS 6.3.0'],
                     'metadata': {
                         'source_id': 1,
                         'source_name': None,

--- a/quipucords/fingerprinter/tests_product_brms.py
+++ b/quipucords/fingerprinter/tests_product_brms.py
@@ -21,7 +21,8 @@ class ProductBRMSTest(TestCase):
     def test_detect_jboss_brms_present(self):
         """Test the detect_jboss_brms method."""
         source = {'source_id': 1, 'source_type': 'network'}
-        facts = {'jboss_brms_manifest_mf': {'opt/brms/': 'Red Hat'},
+        facts = {'jboss_brms_manifest_mf': {'opt/brms/':
+                                            '6.4.0.Final-redhat-3'},
                  'jboss_brms_kie_api_ver': ['6.4.0.Final-redhat-3']}
         product = detect_jboss_brms(source, facts)
         expected = {'name': 'JBoss BRMS',

--- a/quipucords/fingerprinter/tests_product_brms.py
+++ b/quipucords/fingerprinter/tests_product_brms.py
@@ -21,13 +21,14 @@ class ProductBRMSTest(TestCase):
     def test_detect_jboss_brms_present(self):
         """Test the detect_jboss_brms method."""
         source = {'source_id': 1, 'source_type': 'network'}
-        facts = {'jboss_brms_manifest_mf': {'opt/brms/':
-                                            '6.4.0.Final-redhat-3'},
-                 'jboss_brms_kie_api_ver': ['6.4.0.Final-redhat-3']}
+        facts = {'jboss_brms_manifest_mf':
+                 {('/opt/brms', '6.4.0.Final-redhat-3')},
+                 'jboss_brms_kie_api_ver':
+                 {('/opt/brms', '6.4.0.Final-redhat-3')}}
         product = detect_jboss_brms(source, facts)
         expected = {'name': 'JBoss BRMS',
                     'presence': 'present',
-                    'version': ['BRMS 6.3.0'],
+                    'version': ['/opt/brms:BRMS 6.3.0'],
                     'metadata': {
                         'source_id': 1,
                         'source_name': None,

--- a/quipucords/scanner/network/processing/brms.py
+++ b/quipucords/scanner/network/processing/brms.py
@@ -19,15 +19,10 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 # #### Processors ####
 
 
-class ProcessJbossBRMSManifestMF(util.PerItemProcessor):
+class ProcessJbossBRMSManifestMF(util.ManifestVersionProcessor):
     """Process the MANIFEST.MF files."""
 
     KEY = 'jboss_brms_manifest_mf'
-
-    @staticmethod
-    def process_item(item):
-        """Return stdout if not empty."""
-        return item['stdout'] or None
 
 
 class ProcessJbossBRMSKieBusinessCentral(process.Processor):

--- a/quipucords/scanner/network/processing/brms.py
+++ b/quipucords/scanner/network/processing/brms.py
@@ -10,7 +10,10 @@
 """Initial processing of the shell output from the jboss_brms role."""
 
 import logging
-from scanner.network.processing import process, util
+import pathlib
+import posixpath
+import re
+from scanner.network.processing import process
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -18,52 +21,169 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 # #### Processors ####
 
+# All of the processors in this file (except for
+# ProcessFindBRMSKieWarVer; see its comment) return lists of
+# (directory, version_string) tuples. A version_string is a string
+# that comes from the Ansible task results and that can be mapped to a
+# BRMS version in the fingerprinter. The directory is the base
+# directory associated with this particular version string. Keeping
+# the base directory around makes the results more transparent to
+# users, by giving them a place to go look to see the installation we
+# found. It also lets us report the situation where there are multiple
+# BRMS installs with the same version on the same host.
 
-class ProcessJbossBRMSManifestMF(util.ManifestVersionProcessor):
-    """Process the MANIFEST.MF files."""
+# The (directory, version_string) lists are guaranteed to have unique
+# elements. Logically they are sets, not lists, but we need to be able
+# to JSON serialize them, so we build them as sets and then convert to
+# lists just before returning.
+
+
+def normalize_path(path):
+    """Normalize a path.
+
+    We need to normalize all of the directories we return so that they
+    will be deduplicated by Python's set class.
+    """
+    return pathlib.PurePath(path).as_posix()
+
+
+IMPLEMENTATION_VERSION_RE = re.compile(r'Implementation-Version:\s*(.*)\s*')
+
+
+class ProcessJbossBRMSManifestMF(process.Processor):
+    """Get the Implementation-Version from a MANIFEST.MF file."""
 
     KEY = 'jboss_brms_manifest_mf'
 
+    @staticmethod
+    def process_item(item):
+        """Get the implementation version from a MANIFEST.MF file."""
+        if item['rc']:
+            return None
+
+        directory = normalize_path(item['item'])
+        for line in item['stdout_lines']:
+            match = IMPLEMENTATION_VERSION_RE.match(line)
+            if match:
+                return (normalize_path(directory), match.group(1))
+
+        return None
+
+    @staticmethod
+    def process(output):
+        """Return a set of (directory, version string) pairs."""
+        results = set()
+        for item in output['results']:
+            val = ProcessJbossBRMSManifestMF.process_item(item)
+            if val:
+                results.add(val)
+
+        return list(results)
+
+
+def enclosing_war_archive(path):
+    """Find the BRMS war archive containing path.
+
+    :param path: a filesystem path
+
+    :returns: the path to the nearest BRMS war archive enclosing path,
+        or None if not in a war archive.
+    """
+    parts = pathlib.PurePath(path).parts
+
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i].startswith('kie-server') or \
+           parts[i].startswith('business-central'):
+            return pathlib.PurePath(*parts[:i + 1]).as_posix()
+
+
+KIE_FILENAME_RE = re.compile(r'kie-api-(.*)\.jar.*')
+
 
 class ProcessJbossBRMSKieBusinessCentral(process.Processor):
-    """Process ls results for kie-api files."""
+    """Return filenames and their enclosing BRMS war archive."""
 
     KEY = 'jboss_brms_kie_in_business_central'
 
     @staticmethod
     def process(output):
-        """Return the command's output."""
-        kie_api_files = []
-        for result in output['results']:
-            if 'rc' in result and result['rc'] == 0:
-                kie_api_files.extend(result['stdout_lines'])
-        return kie_api_files
+        """Return a list of (base war archive, version string) pairs."""
+        results = set()
+        for item in output['results']:
+            if item['rc']:
+                continue
+
+            directory = normalize_path(item['item'])
+            for line in item['stdout_lines']:
+                filename = posixpath.basename(line)
+                match = KIE_FILENAME_RE.match(filename)
+                if not match:
+                    continue
+                results.add((directory, match.group(1)))
+
+        return list(results)
 
 
-class ProcessFindBRMSKieApiVer(process.Processor):
-    """Process the results of a find command."""
+class ProcessLocateKieApiFiles(process.Processor):
+    """Process locate results for kie-api files."""
 
-    KEY = 'jboss_brms_kie_api_ver'
+    KEY = 'jboss_brms_locate_kie_api'
+    DEPS = ['have_locate']
 
     @staticmethod
     def process(output):
-        """Return the command's output."""
-        return output['stdout_lines']
+        """Return a list of (base war archive, version string) pairs."""
+        results = set()
+        for line in output['stdout_lines']:
+            filename = posixpath.basename(line)
+            directory = enclosing_war_archive(line)
+            match = KIE_FILENAME_RE.match(filename)
+            if not match:
+                continue
+            results.add((directory, match.group(1)))
+
+        return list(results)
 
 
-class ProcessFindBRMSDroolsCoreVer(process.Processor):
+class JarNameProcessor(process.Processor):
+    """Process the results of a find command."""
+
+    KEY = None
+
+    @staticmethod
+    def process(output):
+        """Split lines into directory / filename pairs."""
+        results = set()
+
+        for line in output['stdout_lines']:
+            directory, filename = posixpath.split(line)
+            if not directory or not filename:
+                continue
+            results.add((normalize_path(directory), filename))
+
+        return list(results)
+
+
+class ProcessFindBRMSKieApiVer(JarNameProcessor):
+    """Process a list of kie-api* files."""
+
+    KEY = 'jboss_brms_kie_api_ver'
+
+
+class ProcessFindBRMSDroolsCoreVer(JarNameProcessor):
     """Process the results of a find command."""
 
     KEY = 'jboss_brms_drools_core_ver'
 
-    @staticmethod
-    def process(output):
-        """Return the command's output."""
-        return output['stdout_lines']
-
 
 class ProcessFindBRMSKieWarVer(process.Processor):
     """Process the results of a find command."""
+
+    # This class can't return a list of (directory, version_string)
+    # pairs like the rest because its task processes compressed war
+    # archives, and we don't have a test case for those. I don't want
+    # to mess with the output until I have a way to verify that the
+    # changes work, so just pass this through for now.
 
     KEY = 'jboss_brms_kie_war_ver'
 

--- a/quipucords/scanner/network/processing/test_brms.py
+++ b/quipucords/scanner/network/processing/test_brms.py
@@ -83,15 +83,27 @@ class TestProcessJbossBRMSKieBusinessCentral(unittest.TestCase):
             {('/tmp/good', 'version-string')})
 
 
-class TestJarNameProcessor(unittest.TestCase):
-    """Test JarNameProcessor."""
+class TestFindBRMSKieApiVer(unittest.TestCase):
+    """Test FindBRMSKieApiVer."""
+
+    ansible_stdout = (
+        '/opt/jboss/jboss-eap-6.4/standalone/deployments/business-central.war/'
+        'WEB-INF/lib/kie-api-6.5.0.Final-redhat-2.jar\r\n'
+        '/opt/jboss/jboss-eap-6.4/standalone/deployments/kie-server.war/'
+        'WEB-INF/lib/kie-api-6.5.0.Final-redhat-2.jar\r\n')
+
+    expected = {('/opt/jboss/jboss-eap-6.4/standalone/'
+                 'deployments/business-central.war', '6.5.0.Final-redhat-2'),
+                ('/opt/jboss/jboss-eap-6.4/standalone/'
+                 'deployments/kie-server.war', '6.5.0.Final-redhat-2')}
 
     def test_success_case(self):
-        """Return stdout_lines in case of success."""
+        """Return the correct (directory, version string) pairs."""
         self.assertEqual(
-            set(brms.JarNameProcessor.process(
-                ansible_result('/a\n/b\n/foo/c'))),
-            {('/', 'a'), ('/', 'b'), ('/foo', 'c')})
+            set(
+                brms.ProcessFindBRMSKieApiVer.process(
+                    ansible_result(self.ansible_stdout))),
+            self.expected)
 
 
 class TestProcessFindBRMSKieWarVer(unittest.TestCase):

--- a/quipucords/scanner/network/processing/test_brms.py
+++ b/quipucords/scanner/network/processing/test_brms.py
@@ -22,14 +22,24 @@ from scanner.network.processing.util_for_test import (ansible_results,
 class TestProcessJbossBRMSManifestMF(unittest.TestCase):
     """Test ProcessJbossBRMSManifestMF."""
 
-    MANIFEST = 'This is manifest file output'
+    # This is a portion of the BRMS 6.4.0 MANIFEST.MF
+    MANIFEST = """Manifest-Version: 1.0
+Implementation-Title: KIE Drools Workbench - Distribution Wars
+Implementation-Version: 6.5.0.Final-redhat-2
+"""
 
-    def test_success_case(self):
-        """Return item's stdout."""
+    def test_success(self):
+        """Extract the Implementation_Version from a manifest."""
         self.assertEqual(
             brms.ProcessJbossBRMSManifestMF.process_item(
-                ansible_item('/tmp/good', self.MANIFEST)),
-            self.MANIFEST)
+                ansible_item('manifest', self.MANIFEST)),
+            '6.5.0.Final-redhat-2')
+
+    def test_no_version(self):
+        """Don't crash if the manifest is missing a version."""
+        self.assertIsNone(
+            brms.ProcessJbossBRMSManifestMF.process_item(
+                ansible_item('manifest', 'not\na\nmanifest')))
 
 
 class TestProcessJbossBRMSKieBusinessCentral(unittest.TestCase):

--- a/quipucords/scanner/network/processing/util.py
+++ b/quipucords/scanner/network/processing/util.py
@@ -10,6 +10,7 @@
 """Utilities for processing Ansible task outputs."""
 
 import logging
+import re
 from scanner.network.processing import process
 
 
@@ -194,3 +195,25 @@ class StdoutPassthroughProcessor(PerItemProcessor):
     def process_item(item):
         """Make sure item succeeded and pass stdout through."""
         return item['rc'] == 0 and item['stdout']
+
+
+IMPLEMENTATION_VERSION_RE = re.compile(r'Implementation-Version:\s*(.*)\s*')
+
+
+class ManifestVersionProcessor(PerItemProcessor):
+    """Get the Implementation-Version from a MANIFEST.MF file."""
+
+    KEY = None
+
+    @staticmethod
+    def process_item(item):
+        """Get the implementation version from a MANIFEST.MF file."""
+        if item['rc']:
+            return None
+
+        for line in item['stdout_lines']:
+            match = IMPLEMENTATION_VERSION_RE.match(line)
+            if match:
+                return match.group(1)
+
+        return None

--- a/quipucords/scanner/network/processing/util.py
+++ b/quipucords/scanner/network/processing/util.py
@@ -10,7 +10,6 @@
 """Utilities for processing Ansible task outputs."""
 
 import logging
-import re
 from scanner.network.processing import process
 
 
@@ -195,25 +194,3 @@ class StdoutPassthroughProcessor(PerItemProcessor):
     def process_item(item):
         """Make sure item succeeded and pass stdout through."""
         return item['rc'] == 0 and item['stdout']
-
-
-IMPLEMENTATION_VERSION_RE = re.compile(r'Implementation-Version:\s*(.*)\s*')
-
-
-class ManifestVersionProcessor(PerItemProcessor):
-    """Get the Implementation-Version from a MANIFEST.MF file."""
-
-    KEY = None
-
-    @staticmethod
-    def process_item(item):
-        """Get the implementation version from a MANIFEST.MF file."""
-        if item['rc']:
-            return None
-
-        for line in item['stdout_lines']:
-            match = IMPLEMENTATION_VERSION_RE.match(line)
-            if match:
-                return match.group(1)
-
-        return None

--- a/roles/jboss_brms/tasks/main.yml
+++ b/roles/jboss_brms/tasks/main.yml
@@ -87,13 +87,13 @@
 # Tasks that do filesystem scans. This will scan linux systems for
 # JBoss BRMS or Drools Installations
 - name: Gather jboss.brms.kie-api-ver
-  raw: find {{search_directories}} -xdev -name kie-api* 2> /dev/null | sed 's/.jar.*//g' | sort -u
+  raw: find {{search_directories}} -xdev -name kie-api* 2> /dev/null | sort -u
   register: jboss_brms_kie_api_ver
   ignore_errors: yes
   when: 'jboss_brms_ext'
 
 - name: Gather jboss.brms.drools-core-ver
-  raw: find {{search_directories}} -xdev -name drools-core* 2> /dev/null | sed 's/.jar.*//g' | sort -u
+  raw: find {{search_directories}} -xdev -name drools-core* 2> /dev/null | sort -u
   register: jboss_brms_drools_core_ver
   ignore_errors: yes
   when: 'jboss_brms_ext'

--- a/roles/jboss_brms/tasks/main.yml
+++ b/roles/jboss_brms/tasks/main.yml
@@ -30,6 +30,17 @@
   ignore_errors: yes
   when: 'jboss_brms'
 
+- name: search filesystem for kie-server candidates
+  raw: find {{search_directories}} -xdev -name kie*.war 2> /dev/null
+  register: internal_jboss_brms_kie_search_candidates
+  ignore_errors: yes
+  when: 'jboss_brms_ext'
+
+- name: set kie_search_candidates
+  set_fact:
+    kie_search_candidates: "{{ internal_jboss_brms_kie_search_candidates.get('stdout_lines', []) }}"
+  ignore_errors: yes
+
 # Combine the above with any EAP_HOME directories we've found
 - name: create list if eap_home_candidates is not empty
   set_fact:
@@ -57,7 +68,7 @@
   raw: cat '{{ item }}/META-INF/MANIFEST.MF' 2>/dev/null
   register: jboss_brms_manifest_mf
   ignore_errors: yes
-  with_items: "{{ business_central_candidates + kie_server_candidates }}"
+  with_items: "{{ business_central_candidates + kie_server_candidates + kie_search_candidates }}"
   when: 'jboss_brms'
 
 - name: look for kie-api files inside candidate directories
@@ -69,27 +80,20 @@
 
 - name: look for all kie-api files on the system
   raw: locate --basename 'kie-api*'
-  register: internal_jboss_brms_locate_kie_api
+  register: jboss_brms_locate_kie_api
   ignore_errors: yes
   when: 'have_locate and jboss_brms'
-
-- name: set jboss_brms_locate_kie_api
-  set_fact:
-    jboss_brms_locate_kie_api: "{{ internal_jboss_brms_locate_kie_api.get('stdout_lines', []) }}"
-  ignore_errors: yes
-  when: 'jboss_brms'
-
 
 # Tasks that do filesystem scans. This will scan linux systems for
 # JBoss BRMS or Drools Installations
 - name: Gather jboss.brms.kie-api-ver
-  raw: find {{search_directories}} -xdev -name kie-api* 2> /dev/null | sed 's/.*kie-api-//g' | sed 's/.jar.*//g' | sort -u
+  raw: find {{search_directories}} -xdev -name kie-api* 2> /dev/null | sed 's/.jar.*//g' | sort -u
   register: jboss_brms_kie_api_ver
   ignore_errors: yes
   when: 'jboss_brms_ext'
 
 - name: Gather jboss.brms.drools-core-ver
-  raw: find {{search_directories}} -xdev -name drools-core* 2> /dev/null | sed 's/.*drools-core-//g' | sed 's/.jar.*//g' | sort -u
+  raw: find {{search_directories}} -xdev -name drools-core* 2> /dev/null | sed 's/.jar.*//g' | sort -u
   register: jboss_brms_drools_core_ver
   ignore_errors: yes
   when: 'jboss_brms_ext'


### PR DESCRIPTION
We were already collecting the necessary data. This change plumbs it
through to the fingerprinter and update the version classification
logic.

Closes #1014 