### PR TITLE
Add fingerprinting support for Red Hat Decision Manager 7.0.0

### DIFF
--- a/quipucords/fingerprinter/jboss_brms.py
+++ b/quipucords/fingerprinter/jboss_brms.py
@@ -38,6 +38,7 @@ ENTITLEMENTS = 'entitlements'
 # These classifications apply to both strings in kie filenames and
 # Implementation-Version strings in BRMS MANIFEST.MF files.
 BRMS_CLASSIFICATIONS = {
+    '7.5.0.Final-redhat-4': 'RHDM 7.0.0',
     '6.5.0.Final-redhat-2': 'BRMS 6.4.0',
     '6.4.0.Final-redhat-3': 'BRMS 6.3.0',
     '6.3.0.Final-redhat-5': 'BRMS 6.2.0',

--- a/roles/jboss_brms/tasks/main.yml
+++ b/roles/jboss_brms/tasks/main.yml
@@ -5,7 +5,7 @@
   set_fact:
     internal_host_started_processing_role: "jboss_brms"
 
-# Use locate to look for business-central and kie-server
+# Use locate to look for business-central, decision-central, and kie-server
 - name: find business-central candidates
   raw: locate --basename business-central | egrep '.*/business-central(.war)?/?$'
   register: internal_jboss_brms_business_central_candidates
@@ -15,6 +15,18 @@
 - name: set jboss_brms_business_central_candidates
   set_fact:
     jboss_brms_business_central_candidates: "{{ internal_jboss_brms_business_central_candidates.get('stdout_lines', []) }}"
+  ignore_errors: yes
+  when: 'jboss_brms'
+
+- name: find decision-central candidates
+  raw: locate --basename decision-central | egrep '.*/decision-central(.war)?/?$'
+  register: internal_jboss_brms_decision_central_candidates
+  ignore_errors: yes
+  when: 'have_locate and jboss_brms'
+
+- name: set jboss_brms_decision_central_candidates
+  set_fact:
+    jboss_brms_decision_central_candidates: "{{ internal_jboss_brms_decision_central_candidates.get('stdout_lines', []) }}"
   ignore_errors: yes
   when: 'jboss_brms'
 
@@ -45,6 +57,7 @@
 - name: create list if eap_home_candidates is not empty
   set_fact:
     business_central_candidates_eap: "{{ [] }}"
+    decision_central_candidates_eap: "{{ [] }}"
     kie_server_candidates_eap: "{{ [] }}"
   ignore_errors: yes
   when: 'jboss_brms'
@@ -52,6 +65,7 @@
 - name: add eap_home_candidates to lists
   set_fact:
     business_central_candidates_eap: "{{ business_central_candidates_eap + [item + '/standalone/deployments/business-central.war'] }}"
+    decision_central_candidates_eap: "{{ decision_central_candidates_eap + [item + '/standalone/deployments/decision-central.war'] }}"
     kie_server_candidates_eap: "{{ kie_server_candidates_eap + [item + '/standalone/deployments/kie-server.war'] }}"
   with_items: "{{ eap_home_candidates }}"
   ignore_errors: yes
@@ -60,6 +74,7 @@
 - name: combine special directory candidates into single list
   set_fact:
     business_central_candidates: "{{ (jboss_brms_business_central_candidates + business_central_candidates_eap) | unique }}"
+    decision_central_candidates: "{{ (jboss_brms_decision_central_candidates + decision_central_candidates_eap) | unique }}"
     kie_server_candidates: "{{ (jboss_brms_kie_server_candidates + kie_server_candidates_eap) | unique }}"
   ignore_errors: yes
   when: 'jboss_brms'
@@ -68,14 +83,14 @@
   raw: cat '{{ item }}/META-INF/MANIFEST.MF' 2>/dev/null
   register: jboss_brms_manifest_mf
   ignore_errors: yes
-  with_items: "{{ business_central_candidates + kie_server_candidates + kie_search_candidates }}"
+  with_items: "{{ business_central_candidates + decision_central_candidates + kie_server_candidates + kie_search_candidates }}"
   when: 'jboss_brms'
 
 - name: look for kie-api files inside candidate directories
   raw: ls -1 "{{ item }}"/WEB-INF/lib/kie-api* 2>/dev/null
   register: jboss_brms_kie_in_business_central
   ignore_errors: yes
-  with_items: "{{ business_central_candidates }}"
+  with_items: "{{ business_central_candidates + decision_central_candidates }}"
   when: 'jboss_brms'
 
 - name: look for all kie-api files on the system


### PR DESCRIPTION
Closes #1114 .

Output from scanning a BRMS system with extended search off:
```
{
  "name": "JBoss BRMS",
  "presence": "present",
  "version": [
    "RHDM 7.0.0"
  ],
  "metadata": {
    "source_id": 11,
    "source_name": "sonar-rhdm-rhel-7-vc",
    "source_type": "network",
    "raw_fact_key": "jboss_brms_kie_in_business_central/jboss_brms_locate_kie_api/jboss_brms_manifest_mf"
  }
}
```

And with extended search on:
```
{
  "name": "JBoss BRMS",
  "presence": "present",
  "version": [
    "RHDM 7.0.0"
  ],
  "metadata": {
    "source_id": 11,
    "source_name": "sonar-rhdm-rhel-7-vc",
    "source_type": "network",
    "raw_fact_key": "jboss_brms_drools_core_ver/jboss_brms_kie_api_ver/jboss_brms_kie_in_business_central/jboss_brms_kie_war_ver/jboss_brms_locate_kie_api/jboss_brms_manifest_mf"
  }
}
```

And an EAP system with no BRMS, for comparison:
```
{
  "name": "JBoss BRMS",
  "presence": "absent",
  "metadata": {
    "source_id": 2,
    "source_name": "sonar-jbosseap-rhel-7-vc",
    "source_type": "network",
    "raw_fact_key": null
  }
}
```