### PR TITLE
Record result for unreachable hosts

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -219,8 +219,7 @@ class ScanJob(models.Model):
         systems_count,\
             systems_scanned,\
             systems_failed,\
-            systems_unreachable = self._calculate_counts(
-                ScanTask.SCAN_TYPE_CONNECT)
+            systems_unreachable = self.calculate_counts()
 
         message = '%s Stats: systems_count=%d,'\
             ' systems_scanned=%d, systems_failed=%d, systems_unreachable=%d' %\

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -1006,7 +1006,7 @@ class ScanJobTest(TestCase):
                                     'name': 'source1',
                                     'source_type': 'network'},
                          'facts': [{'name': 'fact_key',
-                                    'value': '"fact_value"'}]}]}
+                                    'value': 'fact_value'}]}]}
         self.assertEqual(json_response, expected)
 
     def test_inspection_ordering_by_name(self):
@@ -1092,14 +1092,14 @@ class ScanJobTest(TestCase):
                                     'name': 'source1',
                                     'source_type': 'network'},
                          'facts': [{'name': 'fact_key',
-                                    'value': '"fact_value"'}]},
+                                    'value': 'fact_value'}]},
                         {'name': 'Foo1',
                          'status': 'success',
                          'source': {'id': 1,
                                     'name': 'source1',
                                     'source_type': 'network'},
                          'facts': [{'name': 'fact_key',
-                                    'value': '"fact_value"'}]}]}
+                                    'value': 'fact_value'}]}]}
         self.assertEqual(json_response, expected)
 
     def test_inspection_filter_by_source_id(self):
@@ -1263,14 +1263,14 @@ class ScanJobTest(TestCase):
                                     'name': 'source1',
                                     'source_type': 'network'},
                          'facts': [{'name': 'fact_key',
-                                    'value': '"fact_value"'}]},
+                                    'value': 'fact_value'}]},
                         {'name': 'Foo',
                          'status': 'success',
                          'source': {'id': 1,
                                     'name': 'source1',
                                     'source_type': 'network'},
                          'facts': [{'name': 'fact_key',
-                                    'value': '"fact_value"'}]}]}
+                                    'value': 'fact_value'}]}]}
         self.assertEqual(json_response, expected)
 
     def test_inspection_results_with_none(self):
@@ -1317,7 +1317,7 @@ class ScanJobTest(TestCase):
                                     'name': 'source1',
                                     'source_type': 'network'},
                          'facts': [{'name': 'fact_key',
-                                    'value': '"fact_value"'}]}]}
+                                    'value': 'fact_value'}]}]}
         self.assertEqual(json_response, expected)
 
     def test_inspection_delete_source(self):
@@ -1362,7 +1362,7 @@ class ScanJobTest(TestCase):
                          'status': 'success',
                          'source': 'deleted',
                          'facts': [{'name': 'fact_key',
-                                    'value': '"fact_value"'}]}]}
+                                    'value': 'fact_value'}]}]}
         self.assertEqual(json_response, expected)
 
     def test_inspection_not_found(self):

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -10,6 +10,7 @@
 #
 """Describes the views associated with the API models."""
 
+import json
 import logging
 import os
 
@@ -97,9 +98,11 @@ def expand_system_inspection(system):
         facts = []
         fact_ids = system['facts']
         for fact_id in fact_ids:
-            facts.append(RawFact.objects.filter(
-                id=fact_id).values('name',
-                                   'value').first())
+            raw_fact = RawFact.objects.filter(
+                id=fact_id).values('name', 'value').first()
+            if raw_fact.get('value') is not None:
+                raw_fact['value'] = json.loads(raw_fact['value'])
+            facts.append(raw_fact)
         system['facts'] = facts
 
 

--- a/quipucords/scanner/network/tests_network_inspect.py
+++ b/quipucords/scanner/network/tests_network_inspect.py
@@ -335,7 +335,7 @@ class NetworkInspectScannerTest(TestCase):
         _, result = scanner._inspect_scan(
             self.host_list,
             base_ssh_executable=path)
-        self.assertEqual(result, ScanTask.FAILED)
+        self.assertEqual(result, ScanTask.COMPLETED)
 
     def test_ssh_hang(self):
         """Simulate an ssh hang."""


### PR DESCRIPTION
- Added post processing to cleanup results that do not have enough information to identify the host.  Also, added an entry for each unreachable host.
- Tweak to jobs/{id}/inspection so that values are JSON not JSON strings.

Closes #345 