### PR TITLE
Make ListPagination not require results

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -1242,7 +1242,6 @@ definitions:
       - count
       - next
       - previous
-      - results
     properties:
       count:
         type: "integer"


### PR DESCRIPTION
The new version changed validation rules in a way that makes
docs/swagger.yml fail validation. Stick with the old one for now.

Closes #1199 