### PR TITLE
Enhance the is_redhat fact to report for satellite & vcenter. #1196

### DIFF
--- a/quipucords/fingerprinter/__init__.py
+++ b/quipucords/fingerprinter/__init__.py
@@ -899,8 +899,8 @@ def _process_satellite_fact(source, fact):
                                 fact_value=is_redhat)
     else:
         # if the os name indicates redhat, set is_redhat to true
-        rhel_os_names = ['rhel', 'red', 'redhat']
-        if satellite_os_name.lower() in rhel_os_names:
+        rhel_os_names = ['rhel', 'redhat']
+        if satellite_os_name.lower().strip() in rhel_os_names:
             is_redhat = True
         add_fact_to_fingerprint(source, 'os_name',
                                 fact, 'is_redhat', fingerprint,

--- a/quipucords/fingerprinter/__init__.py
+++ b/quipucords/fingerprinter/__init__.py
@@ -811,6 +811,7 @@ def _process_vcenter_fact(source, fact):
         for rhel_release in rhel_os_releases:
             if rhel_release in vcenter_os_release.lower():
                 is_redhat = True
+                break
     add_fact_to_fingerprint(source, 'vm.os',
                             fact, 'is_redhat', fingerprint,
                             fact_value=is_redhat)

--- a/quipucords/fingerprinter/tests_engine.py
+++ b/quipucords/fingerprinter/tests_engine.py
@@ -168,7 +168,8 @@ class EngineTest(TestCase):
             vm_host_cpu_count=8,
             vm_datacenter='NY',
             vm_cluster='23sd',
-            architecture='x86_64'):
+            architecture='x86_64',
+            is_redhat=True):
         """Create an in memory FactCollection for tests."""
         fact = {}
         if source_id:
@@ -208,7 +209,9 @@ class EngineTest(TestCase):
             fact['vm.cluster'] = vm_cluster
         if architecture:
             fact['uname_processor'] = architecture
-
+        if 'red hat enterprise linux' in vm_os.lower() or \
+                'rhel' in vm_os.lower():
+            fact['is_redhat'] = is_redhat
         fact_collection = {'id': report_id, 'facts': [fact]}
         return fact_collection
 
@@ -231,7 +234,8 @@ class EngineTest(TestCase):
             virtual_host='9.3.4.6',
             num_sockets=8,
             entitlements=SAT_ENTITLEMENTS,
-            architecture='x86_64'):
+            architecture='x86_64',
+            is_redhat=True):
         """Create an in memory FactCollection for tests."""
         fact = {}
         if source_id:
@@ -276,6 +280,9 @@ class EngineTest(TestCase):
             fact['entitlements'] = entitlements
         if architecture:
             fact['architecture'] = architecture
+        if 'red hat enterprise linux' in os_name.lower() or \
+                'rhel' in os_name.lower():
+            fact['is_redhat'] = is_redhat
 
         fact_collection = {'id': report_id, 'facts': [fact]}
         return fact_collection
@@ -362,6 +369,8 @@ class EngineTest(TestCase):
                          fingerprint.get('vm_cluster'))
         self.assertEqual(fact.get('uname_processor'),
                          fingerprint.get('architecture'))
+        self.assertEqual(fact.get('is_redhat'),
+                         fingerprint.get('is_redhat'))
 
     def _validate_satellite_result(self, fingerprint, fact):
         """Help to validate fields."""
@@ -388,6 +397,8 @@ class EngineTest(TestCase):
                          fingerprint.get('cpu_socket_count'))
         self.assertEqual(fact.get('architecture'),
                          fingerprint.get('architecture'))
+        self.assertEqual(fact.get('is_redhat'),
+                         fingerprint.get('is_redhat'))
 
     def _create_network_fingerprint(self, *args, **kwargs):
         """Create test network fingerprint."""


### PR DESCRIPTION
Closes #1196. 

Example for one system in deployments report for Satellite 6.2 source:
```
{
            "id": 3253,
            "report_id": 2,
            "name": "sles12.prov.lan",
            "os_name": "John's",
            "os_release": "John's SUSE OS",
            "os_version": "OS",
            "infrastructure_type": "unknown",
            "mac_addresses": [],
            "ip_addresses": [],
            "cpu_count": null,
            "architecture": null,
            "bios_uuid": null,
            "subscription_manager_id": null,
            "cpu_socket_count": null,
            "cpu_core_count": null,
            "system_creation_date": null,
            "virtualized_type": null,
            "vm_state": null,
            "vm_uuid": null,
            "vm_dns_name": null,
            "vm_host": null,
            "vm_host_socket_count": null,
            "vm_cluster": null,
            "vm_datacenter": null,
            "products": [
                {
                    "name": "JBoss EAP",
                    "version": null,
                    "presence": "absent",
                    "metadata": {
                        "source_id": 5,
                        "source_name": "S62Source",
                        "source_type": "satellite",
                        "raw_fact_key": null
                    }
                },
                {
                    "name": "JBoss Fuse",
                    "version": null,
                    "presence": "absent",
                    "metadata": {
                        "source_id": 5,
                        "source_name": "S62Source",
                        "source_type": "satellite",
                        "raw_fact_key": null
                    }
                },
                {
                    "name": "JBoss BRMS",
                    "version": null,
                    "presence": "absent",
                    "metadata": {
                        "source_id": 5,
                        "source_name": "S62Source",
                        "source_type": "satellite",
                        "raw_fact_key": null
                    }
                }
            ],
            "entitlements": [],
            "is_redhat": false,
            "redhat_certs": null,
            "redhat_package_count": null,
            "metadata": {
                "name": {
                    "source_id": 5,
                    "source_name": "S62Source",
                    "source_type": "satellite",
                    "raw_fact_key": "hostname"
                },
                "os_name": {
                    "source_id": 5,
                    "source_name": "S62Source",
                    "source_type": "satellite",
                    "raw_fact_key": "os_name"
                },
                "is_redhat": {
                    "source_id": 5,
                    "source_name": "S62Source",
                    "source_type": "satellite",
                    "raw_fact_key": "os_name"
                },
```