### PR TITLE
Fix false identification of Wildfly as EAP

### DIFF
--- a/quipucords/fingerprinter/jboss_eap.py
+++ b/quipucords/fingerprinter/jboss_eap.py
@@ -80,6 +80,7 @@ EAP_CLASSIFICATIONS = {
     '1.5.0.Final': 'WildFly-10',
     '1.5.1.Final': 'WildFly-10',
     '1.5.2.Final': 'WildFly-10',
+    '1.6.0.Final': 'WildFly-11',
     '1.6.1.Final': 'WildFly-11',
     '1.7.0.Final': 'WildFly-12',
     'JBPAPP_4_2_0_GA': '4.2',

--- a/quipucords/fingerprinter/jboss_eap.py
+++ b/quipucords/fingerprinter/jboss_eap.py
@@ -247,12 +247,12 @@ def get_eap_jar_version(version_dict):
 # information respectively. PRESENCE can also be a literal presence
 # value and VERSION can be a literal set, as a convenience.
 FACTS = [
-    {NAME: JBOSS_EAP_RUNNING_PATHS, PRESENCE: Product.PRESENT},
+    {NAME: JBOSS_EAP_RUNNING_PATHS, PRESENCE: Product.POTENTIAL},
     {NAME: JBOSS_EAP_JBOSS_USER, PRESENCE: Product.POTENTIAL},
     {NAME: JBOSS_EAP_COMMON_FILES, PRESENCE: Product.POTENTIAL},
     {NAME: JBOSS_EAP_PROCESSES, PRESENCE: Product.POTENTIAL},
     {NAME: JBOSS_EAP_PACKAGES, PRESENCE: Product.PRESENT},
-    {NAME: JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR, PRESENCE: Product.PRESENT},
+    {NAME: JBOSS_EAP_LOCATE_JBOSS_MODULES_JAR, PRESENCE: Product.POTENTIAL},
     {NAME: JBOSS_EAP_SYSTEMCTL_FILES, PRESENCE: Product.POTENTIAL},
     {NAME: JBOSS_EAP_CHKCONFIG, PRESENCE: Product.POTENTIAL},
     {NAME: JBOSS_EAP_EAP_HOME,
@@ -264,7 +264,7 @@ FACTS = [
      PRESENCE: Product.PRESENT,
      VERSION: classify_jar_versions},
     {NAME: EAP_HOME_VERSION_TXT,
-     PRESENCE: Product.PRESENT,
+     PRESENCE: any_value_true,
      VERSION: process_version_txt},
     {NAME: EAP_HOME_README_TXT,
      PRESENCE: Product.ABSENT},

--- a/quipucords/scanner/network/processing/eap.py
+++ b/quipucords/scanner/network/processing/eap.py
@@ -170,8 +170,7 @@ class ProcessEapHomeLs(util.IndicatorFileFinder):
 
     KEY = 'eap_home_ls'
 
-    INDICATOR_FILES = ['appclient', 'standalone', 'JBossEULA.txt',
-                       'modules', 'jboss-modules.jar', 'version.txt']
+    INDICATOR_FILES = ['JBossEULA.txt', 'version.txt']
 
 
 class ProcessEapHomeVersionTxt(util.PerItemProcessor):


### PR DESCRIPTION
There were several separate issues that lead to this:

  - We considered jboss_eap_running_paths to be conclusive evidence of
    EAP presence. This commit changes that to be potential, because
    that fact can also find Wildfly.
  - We considered jboss-modules.jar to be conclusive evidence of EAP,
    when it is present for Wildfly too.
  - We used several other indicator files as evidence for EAP, even
    though they are present for Wildfly too.
  - We had a typing error that lead to us treating version.txt as
    present (which is evidence for EAP) when it was in fact absent.

We don't detect the version of Wildfly with this PR because we specifically added code to this fingerprinter to disable detecting Wildfly versions. It should be possible to detect the Wildfly version if we remove that, but that's a separate discussion.

Closes #1217 .