### PR TITLE
Clean up CLI credential tests. #1221

### DIFF
--- a/qpc/cred/tests_cred_add.py
+++ b/qpc/cred/tests_cred_add.py
@@ -104,6 +104,7 @@ class CredentialAddCliTests(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
                     cac.main(args)
+                    cac.main(args)
 
     def test_add_cred_ssl_err(self):
         """Testing the add credential command with a connection error."""

--- a/qpc/cred/tests_cred_add.py
+++ b/qpc/cred/tests_cred_add.py
@@ -25,7 +25,6 @@ from qpc.cred import (CREDENTIAL_URI,
                       SATELLITE_CRED_TYPE,
                       VCENTER_CRED_TYPE)
 from qpc.cred.add import CredAddCommand
-from qpc.request import CONNECTION_ERROR_MSG, SSL_ERROR_MSG
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
@@ -96,7 +95,7 @@ class CredentialAddCliTests(unittest.TestCase):
         error = {'name': ['credential with this name already exists.']}
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=400, json=error)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='cred_dup', username='root',
                              type=NETWORK_CRED_TYPE,
                              filename=TMP_KEY,
@@ -104,10 +103,7 @@ class CredentialAddCliTests(unittest.TestCase):
                              ssh_passphrase=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aac.main(args)
-                    aac.main(args)
-                    self.assertTrue('credential with this name already exists.'
-                                    in cred_out.getvalue())
+                    cac.main(args)
 
     def test_add_cred_ssl_err(self):
         """Testing the add credential command with a connection error."""
@@ -115,7 +111,7 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, exc=requests.exceptions.SSLError)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1', username='root',
                              type=NETWORK_CRED_TYPE,
                              filename=TMP_KEY,
@@ -123,8 +119,7 @@ class CredentialAddCliTests(unittest.TestCase):
                              ssh_passphrase=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aac.main(args)
-                    self.assertEqual(cred_out.getvalue(), SSL_ERROR_MSG)
+                    cac.main(args)
 
     def test_add_cred_conn_err(self):
         """Testing the add credential command with a connection error."""
@@ -132,7 +127,7 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, exc=requests.exceptions.ConnectTimeout)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1', username='root',
                              type=NETWORK_CRED_TYPE,
                              filename=TMP_KEY,
@@ -140,8 +135,7 @@ class CredentialAddCliTests(unittest.TestCase):
                              ssh_passphrase=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aac.main(args)
-                    self.assertEqual(cred_out.getvalue(), CONNECTION_ERROR_MSG)
+                    cac.main(args)
 
     def test_add_host_cred(self):
         """Testing the add host cred command successfully."""
@@ -149,7 +143,7 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1', username='root',
                              type=NETWORK_CRED_TYPE,
                              filename=TMP_KEY,
@@ -157,7 +151,7 @@ class CredentialAddCliTests(unittest.TestCase):
                              become_method=None, become_user=None,
                              become_password=None)
             with redirect_stdout(cred_out):
-                aac.main(args)
+                cac.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  'Credential "credential1" was added.\n')
 
@@ -167,7 +161,7 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1', username='root',
                              type=NETWORK_CRED_TYPE,
                              filename=TMP_KEY,
@@ -175,7 +169,7 @@ class CredentialAddCliTests(unittest.TestCase):
                              become_method='sudo', become_user='root',
                              become_password=None)
             with redirect_stdout(cred_out):
-                aac.main(args)
+                cac.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CRED_ADDED % 'credential1' + '\n')
 
@@ -186,14 +180,14 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1',
                              type=VCENTER_CRED_TYPE,
                              username='root',
                              password='sdf')
             do_mock_raw_input.return_value = 'abc'
             with redirect_stdout(cred_out):
-                aac.main(args)
+                cac.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CONN_PASSWORD + '\n' +
                                  messages.CRED_ADDED % 'credential1' + '\n')
@@ -205,14 +199,14 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1',
                              type=SATELLITE_CRED_TYPE,
                              username='root',
                              password='sdf')
             do_mock_raw_input.return_value = 'abc'
             with redirect_stdout(cred_out):
-                aac.main(args)
+                cac.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CONN_PASSWORD + '\n' +
                                  messages.CRED_ADDED % 'credential1' + '\n')
@@ -224,7 +218,7 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=401)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1',
                              type=SATELLITE_CRED_TYPE,
                              username='root',
@@ -232,7 +226,7 @@ class CredentialAddCliTests(unittest.TestCase):
             do_mock_raw_input.return_value = 'abc'
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aac.main(args)
+                    cac.main(args)
 
     @patch('getpass._raw_input')
     def test_add_cred_expired(self, do_mock_raw_input):
@@ -242,7 +236,7 @@ class CredentialAddCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             expired = {'detail': 'Token has expired'}
             mocker.post(url, status_code=400, json=expired)
-            aac = CredAddCommand(SUBPARSER)
+            cac = CredAddCommand(SUBPARSER)
             args = Namespace(name='credential1',
                              type=SATELLITE_CRED_TYPE,
                              username='root',
@@ -250,4 +244,4 @@ class CredentialAddCliTests(unittest.TestCase):
             do_mock_raw_input.return_value = 'abc'
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aac.main(args)
+                    cac.main(args)

--- a/qpc/cred/tests_cred_edit.py
+++ b/qpc/cred/tests_cred_edit.py
@@ -22,7 +22,6 @@ from qpc.cred import (CREDENTIAL_URI,
                       SATELLITE_CRED_TYPE,
                       VCENTER_CRED_TYPE)
 from qpc.cred.edit import CredEditCommand
-from qpc.request import CONNECTION_ERROR_MSG, SSL_ERROR_MSG
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
@@ -65,9 +64,6 @@ class CredentialEditCliTests(unittest.TestCase):
                 sys.argv = ['/bin/qpc', 'credential',
                             'edit', '--name', 'credential1']
                 CLI().main()
-                self.assertEqual(cred_out.getvalue(),
-                                 'No arguments provided to edit '
-                                 'credential credential1')
 
     def test_edit_bad_key(self):
         """Testing the credential edit command.
@@ -81,9 +77,6 @@ class CredentialEditCliTests(unittest.TestCase):
                             '--name', 'cred1',
                             '--sshkeyfile', 'bad_path']
                 CLI().main()
-                self.assertTrue('Please provide a valid location for the '
-                                '"--sshkeyfile" argument.'
-                                in cred_out.getvalue())
 
     def test_edit_cred_none(self):
         """Testing the edit credential command for non-existing credential."""
@@ -91,15 +84,13 @@ class CredentialEditCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + '?name=cred_none'
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json={'count': 0})
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred_none', username='root',
                              filename=TMP_KEY,
                              password=None, become_password=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aec.main(args)
-                    self.assertTrue('credential "cred_none" does not exist'
-                                    in cred_out.getvalue())
+                    cec.main(args)
 
     def test_edit_cred_ssl_err(self):
         """Testing the edit credential command with a connection error."""
@@ -107,14 +98,13 @@ class CredentialEditCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.SSLError)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='credential1', username='root',
                              filename=TMP_KEY,
                              password=None, become_password=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aec.main(args)
-                    self.assertEqual(cred_out.getvalue(), SSL_ERROR_MSG)
+                    cec.main(args)
 
     def test_edit_cred_conn_err(self):
         """Testing the edit credential command with a connection error."""
@@ -122,14 +112,13 @@ class CredentialEditCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.ConnectTimeout)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='credential1', username='root',
                              filename=TMP_KEY,
                              password=None, become_password=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aec.main(args)
-                    self.assertEqual(cred_out.getvalue(), CONNECTION_ERROR_MSG)
+                    cec.main(args)
 
     def test_edit_host_cred(self):
         """Testing the edit credential command successfully."""
@@ -143,12 +132,12 @@ class CredentialEditCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get, status_code=200, json=data)
             mocker.patch(url_patch, status_code=200)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred1', username='root', filename=TMP_KEY,
                              sshkeyfile='/woot/ness', become_password=None,
                              ssh_passphrase=None)
             with redirect_stdout(cred_out):
-                aec.main(args)
+                cec.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CRED_UPDATED % 'cred1' + '\n')
 
@@ -163,12 +152,12 @@ class CredentialEditCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get, status_code=200, json=data)
             mocker.patch(url_patch, status_code=200)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred1', username='root', filename=TMP_KEY,
                              password=None, become_password=None,
                              ssh_passphrase=None)
             with redirect_stdout(cred_out):
-                aec.main(args)
+                cec.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CRED_UPDATED % 'cred1' + '\n')
 
@@ -184,11 +173,11 @@ class CredentialEditCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get, status_code=200, json=data)
             mocker.patch(url_patch, status_code=200)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred1', username='root',
                              password=None)
             with redirect_stdout(cred_out):
-                aec.main(args)
+                cec.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CRED_UPDATED % 'cred1' + '\n')
 
@@ -204,11 +193,11 @@ class CredentialEditCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get, status_code=200, json=data)
             mocker.patch(url_patch, status_code=200)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred1', username='root',
                              password=None)
             with redirect_stdout(cred_out):
-                aec.main(args)
+                cec.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CRED_UPDATED % 'cred1' + '\n')
 
@@ -218,14 +207,12 @@ class CredentialEditCliTests(unittest.TestCase):
         url_get = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get, status_code=500, json=None)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred1', username='root', filename=TMP_KEY,
                              password=None, become_password=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    aec.main(args)
-                    self.assertEqual(cred_out.getvalue(),
-                                     messages.SERVER_INTERNAL_ERROR)
+                    cec.main(args)
 
     def test_edit_sat_cred(self):
         """Testing the edit credential command successfully."""
@@ -239,11 +226,11 @@ class CredentialEditCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get, status_code=200, json=data)
             mocker.patch(url_patch, status_code=200)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred1', username='root',
                              password=None)
             with redirect_stdout(cred_out):
-                aec.main(args)
+                cec.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CRED_UPDATED % 'cred1' + '\n')
 
@@ -259,10 +246,10 @@ class CredentialEditCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get, status_code=200, json=data)
             mocker.patch(url_patch, status_code=200)
-            aec = CredEditCommand(SUBPARSER)
+            cec = CredEditCommand(SUBPARSER)
             args = Namespace(name='cred1', username='root',
                              password=None)
             with redirect_stdout(cred_out):
-                aec.main(args)
+                cec.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  messages.CRED_UPDATED % 'cred1' + '\n')

--- a/qpc/cred/tests_cred_list.py
+++ b/qpc/cred/tests_cred_list.py
@@ -17,7 +17,6 @@ from io import StringIO
 
 from qpc.cred import CREDENTIAL_URI
 from qpc.cred.list import CredListCommand
-from qpc.request import CONNECTION_ERROR_MSG, SSL_ERROR_MSG
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
@@ -52,12 +51,11 @@ class CredentialListCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.SSLError)
-            alc = CredListCommand(SUBPARSER)
+            clc = CredListCommand(SUBPARSER)
             args = Namespace()
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    alc.main(args)
-                    self.assertEqual(cred_out.getvalue(), SSL_ERROR_MSG)
+                    clc.main(args)
 
     def test_list_cred_conn_err(self):
         """Testing the list credential command with a connection error."""
@@ -65,12 +63,11 @@ class CredentialListCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.ConnectTimeout)
-            alc = CredListCommand(SUBPARSER)
+            clc = CredListCommand(SUBPARSER)
             args = Namespace()
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    alc.main(args)
-                    self.assertEqual(cred_out.getvalue(), CONNECTION_ERROR_MSG)
+                    clc.main(args)
 
     def test_list_cred_internal_err(self):
         """Testing the list credential command with an internal error."""
@@ -78,12 +75,11 @@ class CredentialListCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=500, json={'error': ['Server Error']})
-            alc = CredListCommand(SUBPARSER)
+            clc = CredListCommand(SUBPARSER)
             args = Namespace()
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    alc.main(args)
-                    self.assertEqual(cred_out.getvalue(), 'Server Error')
+                    clc.main(args)
 
     def test_list_cred_empty(self):
         """Testing the list credential command successfully with empty data."""
@@ -91,10 +87,10 @@ class CredentialListCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json={'count': 0})
-            alc = CredListCommand(SUBPARSER)
+            clc = CredListCommand(SUBPARSER)
             args = Namespace()
             with redirect_stdout(cred_out):
-                alc.main(args)
+                clc.main(args)
                 self.assertEqual(cred_out.getvalue(),
                                  'No credentials exist yet.\n')
 
@@ -120,10 +116,10 @@ class CredentialListCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json=data)
             mocker.get(next_link, status_code=200, json=data2)
-            alc = CredListCommand(SUBPARSER)
+            clc = CredListCommand(SUBPARSER)
             args = Namespace()
             with redirect_stdout(cred_out):
-                alc.main(args)
+                clc.main(args)
                 expected = '[{"id":1,"name":"cred1","password":"********",' \
                     '"username":"root"}]'
                 self.assertEqual(cred_out.getvalue().replace('\n', '')
@@ -146,10 +142,10 @@ class CredentialListCliTests(unittest.TestCase):
         }
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json=data)
-            alc = CredListCommand(SUBPARSER)
+            clc = CredListCommand(SUBPARSER)
             args = Namespace(type='network')
             with redirect_stdout(cred_out):
-                alc.main(args)
+                clc.main(args)
                 expected = '[{"cred_type":"network","id":1,'\
                     '"name":"cred1","password":"********",' \
                     '"username":"root"}]'

--- a/qpc/cred/tests_cred_show.py
+++ b/qpc/cred/tests_cred_show.py
@@ -17,7 +17,6 @@ from io import StringIO
 
 from qpc.cred import CREDENTIAL_URI
 from qpc.cred.show import CredShowCommand
-from qpc.request import CONNECTION_ERROR_MSG, SSL_ERROR_MSG
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
@@ -52,12 +51,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + '?name=credential1'
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.SSLError)
-            asc = CredShowCommand(SUBPARSER)
+            csc = CredShowCommand(SUBPARSER)
             args = Namespace(name='credential1')
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    asc.main(args)
-                    self.assertEqual(cred_out.getvalue(), SSL_ERROR_MSG)
+                    csc.main(args)
 
     def test_show_cred_conn_err(self):
         """Testing the show credential command with a connection error."""
@@ -65,12 +63,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + '?name=credential1'
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.ConnectTimeout)
-            asc = CredShowCommand(SUBPARSER)
+            csc = CredShowCommand(SUBPARSER)
             args = Namespace(name='credential1')
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    asc.main(args)
-                    self.assertEqual(cred_out.getvalue(), CONNECTION_ERROR_MSG)
+                    csc.main(args)
 
     def test_show_cred_internal_err(self):
         """Testing the show credential command with an internal error."""
@@ -78,12 +75,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + '?name=credential1'
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=500, json={'error': ['Server Error']})
-            asc = CredShowCommand(SUBPARSER)
+            csc = CredShowCommand(SUBPARSER)
             args = Namespace(name='credential1')
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    asc.main(args)
-                    self.assertEqual(cred_out.getvalue(), 'Server Error')
+                    csc.main(args)
 
     def test_show_cred_empty(self):
         """Testing the show credential command successfully with empty data."""
@@ -91,13 +87,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + '?name=cred1'
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json={'count': 0})
-            asc = CredShowCommand(SUBPARSER)
+            csc = CredShowCommand(SUBPARSER)
             args = Namespace(name='cred1')
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    asc.main(args)
-                    self.assertEqual(cred_out.getvalue(),
-                                     'credential "cred1" does not exist\n')
+                    csc.main(args)
 
     def test_show_cred_data(self):
         """Testing the show credential command with stubbed data."""
@@ -109,10 +103,10 @@ class CredentialShowCliTests(unittest.TestCase):
         data = {'count': 1, 'results': results}
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json=data)
-            asc = CredShowCommand(SUBPARSER)
+            csc = CredShowCommand(SUBPARSER)
             args = Namespace(name='cred1')
             with redirect_stdout(cred_out):
-                asc.main(args)
+                csc.main(args)
                 expected = '{"id":1,"name":"cred1","password":"********",' \
                     '"username":"root"}'
                 self.assertEqual(cred_out.getvalue().replace('\n', '')


### PR DESCRIPTION
Remove fake assert statements & rename variables to match command. Closes #1221 