### PR TITLE
Add logging to determine if scan manager is alive

### DIFF
--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -12,6 +12,7 @@
 """Queue Manager module."""
 
 import logging
+import os
 from threading import Thread, Timer
 from time import sleep
 
@@ -41,11 +42,14 @@ class Manager(Thread):
 
     def log_info(self):
         """Log the status of the scan manager."""
-        interval = 60
+        try:
+            interval = int(os.environ.get('QUIPUCORDS_MANAGER_HEARTBEAT', '60'))
+        except ValueError:
+            interval = 60
         heartbeat = Timer(interval, self.log_info)
-        logger.debug('Scan manager running: %s. '
-                     'Current task: %s. '
-                     'Number of scans in queue: %s.',
+        logger.info('Scan manager running: %s. '
+                    'Current task: %s. '
+                    'Number of scan jobs in queue: %s.',
                      self.running, self.current_task, len(self.scan_queue))
         if self.running:
             heartbeat.start()

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -48,15 +48,15 @@ class Manager(Thread):
         except ValueError:
             interval = 60
         heartbeat = Timer(interval, self.log_info)
-        logger.info('Scan manager running: %s. '
-                    'Current task: %s. '
-                    'Number of scan jobs in queue: %s.',
-                    self.running, self.current_task, len(self.scan_queue))
+        current_scan_job = None
+        if self.current_task:
+            current_scan_job = self.current_task.identifier
+        logger.info('Scan Manager Stats: '
+                    'current_scan_job=%s. '
+                    'queue_length=%s.',
+                    current_scan_job, len(self.scan_queue))
         if self.running:
             heartbeat.start()
-        else:
-            if heartbeat.is_alive():
-                heartbeat.cancel()
 
     def work(self):
         """Start to excute scans in the queue."""

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -12,7 +12,7 @@
 """Queue Manager module."""
 
 import logging
-from threading import Thread
+from threading import Thread, Timer
 from time import sleep
 
 
@@ -38,6 +38,20 @@ class Manager(Thread):
         self.current_task = None
         self.running = True
         logger.debug('Scan manager created.')
+
+    def log_info(self):
+        """Log the status of the scan manager."""
+        interval = 60
+        heartbeat = Timer(interval, self.log_info)
+        logger.debug('Scan manager running: %s. '
+                     'Current task: %s. '
+                     'Number of scans in queue: %s.',
+                     self.running, self.current_task, len(self.scan_queue))
+        if self.running:
+            heartbeat.start()
+        else:
+            if heartbeat.is_alive():
+                heartbeat.cancel()
 
     def work(self):
         """Start to excute scans in the queue."""
@@ -126,6 +140,7 @@ class Manager(Thread):
         """Trigger thread execution."""
         self.restart_incomplete_scansjobs()
         logger.debug('Scan manager started.')
+        self.log_info()
         while self.running:
             queue_len = len(self.scan_queue)
             if queue_len > 0 and self.current_task is None:

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -43,14 +43,15 @@ class Manager(Thread):
     def log_info(self):
         """Log the status of the scan manager."""
         try:
-            interval = int(os.environ.get('QUIPUCORDS_MANAGER_HEARTBEAT', '60'))
+            interval = int(os.environ.get('QUIPUCORDS_MANAGER_HEARTBEAT',
+                                          '60'))
         except ValueError:
             interval = 60
         heartbeat = Timer(interval, self.log_info)
         logger.info('Scan manager running: %s. '
                     'Current task: %s. '
                     'Number of scan jobs in queue: %s.',
-                     self.running, self.current_task, len(self.scan_queue))
+                    self.running, self.current_task, len(self.scan_queue))
         if self.running:
             heartbeat.start()
         else:


### PR DESCRIPTION
Closes #1236 
I know that this is a silly thing to not know but what file are these logs being saved too (I have always relied on reading the server terminal print outs) and when I looked in the settings.py file it seemed like the default was app.log (but mine is empty)? 

Anyways, as an example, this is what the output looks like. The annoying thing (or maybe it's helpful) is that this will continue to log if there are no jobs as long as the scan manager is still alive:

ie. While running scan jobs:
```
INFO Task 18 (inspect, network, NSmallSource, elapsed_time: 5s) - PROCESSING 10.10.182.81 - ANSIBLE ROLE virt
INFO Scan Manager Stats: current_scan_job=3. queue_length=3.
INFO Task 18 (inspect, network, NSmallSource, elapsed_time: 8s) - PROCESSING 10.10.181.132 - ANSIBLE ROLE cpu
```

After finishing (with two minutes gone by):
```
INFO Job 2 (inspect, elapsed_time: 120s) - STATE UPDATE (completed)
INFO Scan Manager Stats: current_scan_job=None. queue_length=0.
INFO Scan Manager Stats: current_scan_job=None. queue_length=0.
```
