### PR TITLE
Add check to make sure the subman_consumed value is not the empty string

### DIFF
--- a/quipucords/scanner/network/processing/subman.py
+++ b/quipucords/scanner/network/processing/subman.py
@@ -31,7 +31,9 @@ class ProcessSubmanConsumed(process.Processor):
         entitlements_data = []
         entitlements = output.get('stdout_lines', [])
         for entitlement in entitlements:
-            name, entitlement_id = entitlement.split(' - ')
-            entitlement_dict = {'name': name, 'entitlement_id': entitlement_id}
-            entitlements_data.append(entitlement_dict)
+            if entitlement:
+                name, entitlement_id = entitlement.split(' - ')
+                entitlement_dict = {'name': name,
+                                    'entitlement_id': entitlement_id}
+                entitlements_data.append(entitlement_dict)
         return entitlements_data

--- a/quipucords/scanner/network/processing/test_subman.py
+++ b/quipucords/scanner/network/processing/test_subman.py
@@ -35,3 +35,9 @@ class TestProcessSubmanConsumed(unittest.TestCase):
             subman.ProcessSubmanConsumed.process(
                 ansible_result('')),
             [])
+
+    def test_empty_string(self):
+        """Found empty string."""
+        self.assertEqual(
+            subman.ProcessSubmanConsumed.process(ansible_result('\n\r')),
+            [])


### PR DESCRIPTION
Closes #1278 

When running with become capabilities, the value of the std_out lines was a list containing an empty string in some cases. This was causing a traceback error when the processor attempted to split the value.
For example:
```
ERROR Task 2 (inspect, network, NBecomeSource, elapsed_time: 24s) - FAILED POST PROCESSING 10.10.181.154. Processor for subman_consumed got value {'rc': 0, 'stdout': '\r\n', 'stdout_lines': [''], 'stderr': 'Shared connection to 10.10.181.154 closed.\r\n', 'changed': True, '_ansible_no_log': False}, returned Traceback (most recent call last):
  File "/Users/ashleybaiken/quipucords/quipucords/scanner/network/processing/process.py", line 134, in process
    processor_out = processor.process(fact_value)
  File "/Users/ashleybaiken/quipucords/quipucords/scanner/network/processing/subman.py", line 34, in process
    name, entitlement_id = entitlement.split(' - ')
```
This was fixed by adding a simple check to make sure that each "entitlement" in the std_out list was not empty/None/etc.