### PR TITLE
UI: Migrate jobs to reports merge

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -5,6 +5,7 @@ REACT_APP_FACTS_SERVICE=http://localhost:5000/api/v1/facts/
 
 REACT_APP_REPORTS_SERVICE_DETAILS=http://localhost:5000/api/v1/reports/{0}/details/
 REACT_APP_REPORTS_SERVICE_DEPLOYMENTS=http://localhost:5000/api/v1/reports/{0}/deployments/
+REACT_APP_REPORTS_SERVICE_MERGE=http://localhost:5000/api/v1/reports/merge/
 
 REACT_APP_SCANS_SERVICE=http://localhost:5000/api/v1/scans/
 

--- a/client/.env.production
+++ b/client/.env.production
@@ -5,6 +5,7 @@ REACT_APP_FACTS_SERVICE=/api/v1/facts/
 
 REACT_APP_REPORTS_SERVICE_DETAILS=/api/v1/reports/{0}/details/
 REACT_APP_REPORTS_SERVICE_DEPLOYMENTS=/api/v1/reports/{0}/deployments/
+REACT_APP_REPORTS_SERVICE_MERGE=/api/v1/reports/merge/
 
 REACT_APP_SCANS_SERVICE=/api/v1/scans/
 

--- a/client/.env.staging
+++ b/client/.env.staging
@@ -5,6 +5,7 @@ REACT_APP_FACTS_SERVICE=/api/v1/facts/
 
 REACT_APP_REPORTS_SERVICE_DETAILS=/api/v1/reports/{0}/details/
 REACT_APP_REPORTS_SERVICE_DEPLOYMENTS=/api/v1/reports/{0}/deployments/
+REACT_APP_REPORTS_SERVICE_MERGE=/api/v1/reports/merge/
 
 REACT_APP_SCANS_SERVICE=/api/v1/scans/
 

--- a/client/src/components/mergeReportsDialog/mergeReportsDialog.js
+++ b/client/src/components/mergeReportsDialog/mergeReportsDialog.js
@@ -6,8 +6,11 @@ import _ from 'lodash';
 import helpers from '../../common/helpers';
 import Store from '../../redux/store';
 import { scansTypes, toastNotificationTypes } from '../../redux/constants';
-import { mergeScans } from '../../redux/actions/scansActions';
-import { getMergedScanReportDetailsCsv, getMergedScanReportSummaryCsv } from '../../redux/actions/reportsActions';
+import {
+  getMergedScanReportDetailsCsv,
+  getMergedScanReportSummaryCsv,
+  mergeScanReports
+} from '../../redux/actions/reportsActions';
 
 class MergeReportsDialog extends React.Component {
   constructor() {
@@ -36,8 +39,8 @@ class MergeReportsDialog extends React.Component {
     });
   }
 
-  getValidJobsId() {
-    return this.getValidScans().map(scan => scan.most_recent.id);
+  getValidReportId() {
+    return this.getValidScans().map(scan => scan.most_recent.report_id);
   }
 
   notifyDownloadStatus(error, results) {
@@ -60,9 +63,9 @@ class MergeReportsDialog extends React.Component {
   }
 
   mergeScanResults() {
-    const { scans, mergeScans, details, getMergedScanReportDetailsCsv, getMergedScanReportSummaryCsv } = this.props;
+    const { mergeScans, details, getMergedScanReportDetailsCsv, getMergedScanReportSummaryCsv } = this.props;
+    const data = { reports: this.getValidReportId() };
 
-    const data = { jobs: this.getValidJobsId(scans) };
     mergeScans(data).then(
       response => {
         if (details) {
@@ -211,7 +214,7 @@ MergeReportsDialog.propTypes = {
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  mergeScans: data => dispatch(mergeScans(data)),
+  mergeScans: data => dispatch(mergeScanReports(data)),
   getMergedScanReportDetailsCsv: id => dispatch(getMergedScanReportDetailsCsv(id)),
   getMergedScanReportSummaryCsv: id => dispatch(getMergedScanReportSummaryCsv(id))
 });

--- a/client/src/components/scans/scanListItem.js
+++ b/client/src/components/scans/scanListItem.js
@@ -51,9 +51,10 @@ class ScanListItem extends React.Component {
   closeExpandIfNoData(expandType) {
     const { item } = this.props;
 
-    let successHosts = _.get(item, 'most_recent.systems_scanned', 0);
-    let failedHosts = _.get(item, 'most_recent.systems_failed', 0);
-    let prevCount = Math.max(_.get(item, 'jobs', []).length - 1, 0);
+    const successHosts = _.get(item, 'most_recent.systems_scanned', 0);
+    const failedHosts = _.get(item, 'most_recent.systems_failed', 0);
+    const prevCount = Math.max(_.get(item, 'jobs', []).length - 1, 0);
+
     if (
       (expandType === 'systemsScanned' && successHosts === 0) ||
       (expandType === 'systemsFailed' && failedHosts === 0) ||
@@ -144,11 +145,11 @@ class ScanListItem extends React.Component {
   renderStatusItems() {
     const { item } = this.props;
 
-    let expandType = this.expandType();
-    let sourcesCount = item.sources ? item.sources.length : 0;
-    let prevCount = Math.max(_.get(item, 'jobs', []).length - 1, 0);
-    let successHosts = _.get(item, 'most_recent.systems_scanned', 0);
-    let failedHosts = _.get(item, 'most_recent.systems_failed', 0);
+    const expandType = this.expandType();
+    const sourcesCount = item.sources ? item.sources.length : 0;
+    const prevCount = Math.max(_.get(item, 'jobs', []).length - 1, 0);
+    const successHosts = _.get(item, 'most_recent.systems_scanned', 0);
+    const failedHosts = _.get(item, 'most_recent.systems_failed', 0);
 
     return [
       <ListStatusItem

--- a/client/src/redux/actions/reportsActions.js
+++ b/client/src/redux/actions/reportsActions.js
@@ -32,7 +32,7 @@ const getReportDetailsCsv = id => dispatch => {
 const getMergedScanReportSummaryCsv = id => dispatch => {
   return dispatch({
     type: reportsTypes.GET_REPORT,
-    payload: reportsService.getMergedScanReporSummaryCsv(id)
+    payload: reportsService.getMergedScanReportSummaryCsv(id)
   });
 };
 
@@ -43,11 +43,19 @@ const getMergedScanReportDetailsCsv = id => dispatch => {
   });
 };
 
+const mergeScanReports = data => dispatch => {
+  return dispatch({
+    type: reportsTypes.GET_MERGE_REPORT,
+    payload: reportsService.mergeScanReports(data)
+  });
+};
+
 export {
   getReportSummary,
   getReportSummaryCsv,
   getReportDetails,
   getReportDetailsCsv,
   getMergedScanReportSummaryCsv,
-  getMergedScanReportDetailsCsv
+  getMergedScanReportDetailsCsv,
+  mergeScanReports
 };

--- a/client/src/redux/actions/scansActions.js
+++ b/client/src/redux/actions/scansActions.js
@@ -99,13 +99,6 @@ const restartScan = id => dispatch => {
   });
 };
 
-const mergeScans = data => dispatch => {
-  return dispatch({
-    type: scansTypes.GET_MERGE_SCAN_RESULTS,
-    payload: scansService.mergeScans(data)
-  });
-};
-
 export {
   addScan,
   getScan,
@@ -120,6 +113,5 @@ export {
   getInspectionScanResults,
   pauseScan,
   cancelScan,
-  restartScan,
-  mergeScans
+  restartScan
 };

--- a/client/src/redux/constants/reportsConstants.js
+++ b/client/src/redux/constants/reportsConstants.js
@@ -1,3 +1,4 @@
 const GET_REPORT = 'GET_REPORT';
+const GET_MERGE_REPORT = 'GET_MERGE_REPORT';
 
-export { GET_REPORT };
+export { GET_REPORT, GET_MERGE_REPORT };

--- a/client/src/redux/reducers/__tests__/reportsReducer.test.js
+++ b/client/src/redux/reducers/__tests__/reportsReducer.test.js
@@ -3,11 +3,20 @@ import { reportsTypes } from '../../constants/index';
 import reportsReducer from '../reportsReducer';
 
 const initialState = {
-  error: false,
-  errorMessage: '',
-  pending: false,
-  fulfilled: false,
-  reports: []
+  report: {
+    error: false,
+    errorMessage: '',
+    pending: false,
+    fulfilled: false,
+    reports: []
+  },
+
+  merge: {
+    error: false,
+    errorMessage: '',
+    pending: false,
+    fulfilled: false
+  }
 };
 
 describe('ReportsReducer', function() {
@@ -30,13 +39,13 @@ describe('ReportsReducer', function() {
     };
 
     let resultState = reportsReducer(undefined, dispatched);
-    expect(resultState.error).toBeTruthy();
-    expect(resultState.errorMessage).toEqual('GET ERROR');
-    expect(resultState.pending).toBeFalsy();
-    expect(resultState.fulfilled).toBeFalsy();
-    expect(resultState.reports).toHaveLength(0);
+    expect(resultState.report.error).toBeTruthy();
+    expect(resultState.report.errorMessage).toEqual('GET ERROR');
+    expect(resultState.report.pending).toBeFalsy();
+    expect(resultState.report.fulfilled).toBeFalsy();
+    expect(resultState.report.reports).toHaveLength(0);
 
-    expect(resultState.persist).toEqual(initialState.persist);
+    expect(resultState.report.persist).toEqual(initialState.report.persist);
   });
 
   it('should handle GET_REPORT_PENDING', () => {
@@ -46,11 +55,11 @@ describe('ReportsReducer', function() {
 
     let resultState = reportsReducer(undefined, dispatched);
 
-    expect(resultState.error).toBeFalsy();
-    expect(resultState.errorMessage).toEqual('');
-    expect(resultState.pending).toBeTruthy();
-    expect(resultState.fulfilled).toBeFalsy();
-    expect(resultState.reports).toHaveLength(0);
+    expect(resultState.report.error).toBeFalsy();
+    expect(resultState.report.errorMessage).toEqual('');
+    expect(resultState.report.pending).toBeTruthy();
+    expect(resultState.report.fulfilled).toBeFalsy();
+    expect(resultState.report.reports).toHaveLength(0);
   });
 
   it('should handle GET_REPORT_FULFILLED', () => {
@@ -80,10 +89,10 @@ describe('ReportsReducer', function() {
 
     let resultState = reportsReducer(undefined, dispatched);
 
-    expect(resultState.error).toBeFalsy();
-    expect(resultState.errorMessage).toEqual('');
-    expect(resultState.pending).toBeFalsy();
-    expect(resultState.fulfilled).toBeTruthy();
-    expect(resultState.reports).toHaveLength(4);
+    expect(resultState.report.error).toBeFalsy();
+    expect(resultState.report.errorMessage).toEqual('');
+    expect(resultState.report.pending).toBeFalsy();
+    expect(resultState.report.fulfilled).toBeTruthy();
+    expect(resultState.report.reports).toHaveLength(4);
   });
 });

--- a/client/src/redux/reducers/__tests__/scansReducer.test.js
+++ b/client/src/redux/reducers/__tests__/scansReducer.test.js
@@ -64,13 +64,6 @@ const initialState = {
     delete: false
   },
 
-  merge: {
-    error: false,
-    errorMessage: '',
-    pending: false,
-    fulfilled: false
-  },
-
   merge_dialog: {
     show: false,
     scans: [],
@@ -1008,65 +1001,5 @@ describe('scansReducer', function() {
     expect(resultState.connectionResults).toEqual(initialState.connectionResults);
     expect(resultState.inspectionResults).toEqual(initialState.inspectionResults);
     expect(resultState.detail).toEqual(initialState.detail);
-  });
-
-  it('should handle GET_MERGE_SCAN_RESULTS_REJECTED', () => {
-    let dispatched = {
-      type: helpers.REJECTED_ACTION(scansTypes.GET_MERGE_SCAN_RESULTS),
-      error: true,
-      payload: {
-        message: 'BACKUP MESSAGE',
-        response: {
-          data: {
-            detail: 'MERGE ERROR'
-          }
-        }
-      }
-    };
-
-    let resultState = scansReducer(undefined, dispatched);
-
-    expect(resultState.merge.error).toBeTruthy();
-    expect(resultState.merge.errorMessage).toEqual('MERGE ERROR');
-    expect(resultState.merge.pending).toBeFalsy();
-    expect(resultState.merge.fulfilled).toBeFalsy();
-
-    expect(resultState.persist).toEqual(initialState.persist);
-    expect(resultState.deployments).toEqual(initialState.deployments);
-    expect(resultState.details).toEqual(initialState.details);
-  });
-
-  it('should handle GET_MERGE_SCAN_RESULTS_PENDING', () => {
-    let dispatched = {
-      type: helpers.PENDING_ACTION(scansTypes.GET_MERGE_SCAN_RESULTS)
-    };
-
-    let resultState = scansReducer(undefined, dispatched);
-
-    expect(resultState.merge.error).toBeFalsy();
-    expect(resultState.merge.errorMessage).toEqual('');
-    expect(resultState.merge.pending).toBeTruthy();
-    expect(resultState.merge.fulfilled).toBeFalsy();
-
-    expect(resultState.persist).toEqual(initialState.persist);
-    expect(resultState.deployments).toEqual(initialState.deployments);
-    expect(resultState.details).toEqual(initialState.details);
-  });
-
-  it('should handle GET_MERGE_SCAN_RESULTS_FULFILLED', () => {
-    let dispatched = {
-      type: helpers.FULFILLED_ACTION(scansTypes.GET_MERGE_SCAN_RESULTS)
-    };
-
-    let resultState = scansReducer(undefined, dispatched);
-
-    expect(resultState.merge.error).toBeFalsy();
-    expect(resultState.merge.errorMessage).toEqual('');
-    expect(resultState.merge.pending).toBeFalsy();
-    expect(resultState.merge.fulfilled).toBeTruthy();
-
-    expect(resultState.persist).toEqual(initialState.persist);
-    expect(resultState.deployments).toEqual(initialState.deployments);
-    expect(resultState.details).toEqual(initialState.details);
   });
 });

--- a/client/src/redux/reducers/reportsReducer.js
+++ b/client/src/redux/reducers/reportsReducer.js
@@ -2,29 +2,101 @@ import helpers from '../../common/helpers';
 import { reportsTypes } from '../constants';
 
 const initialState = {
-  error: false,
-  errorMessage: '',
-  pending: false,
-  fulfilled: false,
-  reports: []
+  report: {
+    error: false,
+    errorMessage: '',
+    pending: false,
+    fulfilled: false,
+    reports: []
+  },
+
+  merge: {
+    error: false,
+    errorMessage: '',
+    pending: false,
+    fulfilled: false
+  }
 };
 
 const reportsReducer = function(state = initialState, action) {
   switch (action.type) {
     // Error/Rejected
     case helpers.REJECTED_ACTION(reportsTypes.GET_REPORT):
-      return Object.assign({}, initialState, {
-        error: action.error,
-        errorMessage: helpers.getErrorMessageFromResults(action.payload)
-      });
+      return helpers.setStateProp(
+        'report',
+        {
+          error: action.error,
+          errorMessage: helpers.getErrorMessageFromResults(action.payload)
+        },
+        {
+          state,
+          initialState
+        }
+      );
+
+    case helpers.REJECTED_ACTION(reportsTypes.GET_MERGE_REPORT):
+      return helpers.setStateProp(
+        'merge',
+        {
+          error: action.error,
+          errorMessage: helpers.getErrorMessageFromResults(action.payload)
+        },
+        {
+          state,
+          initialState
+        }
+      );
 
     // Loading/Pending
     case helpers.PENDING_ACTION(reportsTypes.GET_REPORT):
-      return Object.assign({}, initialState, { pending: true });
+      return helpers.setStateProp(
+        'report',
+        {
+          pending: true
+        },
+        {
+          state,
+          initialState
+        }
+      );
+
+    case helpers.PENDING_ACTION(reportsTypes.GET_MERGE_REPORT):
+      return helpers.setStateProp(
+        'merge',
+        {
+          pending: true
+        },
+        {
+          state,
+          initialState
+        }
+      );
 
     // Success/Fulfilled
     case helpers.FULFILLED_ACTION(reportsTypes.GET_REPORT):
-      return Object.assign({}, initialState, { reports: action.payload.data, fulfilled: true });
+      return helpers.setStateProp(
+        'report',
+        {
+          fulfilled: true,
+          reports: action.payload.data
+        },
+        {
+          state,
+          initialState
+        }
+      );
+
+    case helpers.FULFILLED_ACTION(reportsTypes.GET_MERGE_REPORT):
+      return helpers.setStateProp(
+        'merge',
+        {
+          fulfilled: true
+        },
+        {
+          state,
+          initialState
+        }
+      );
 
     default:
       return state;

--- a/client/src/redux/reducers/scansReducer.js
+++ b/client/src/redux/reducers/scansReducer.js
@@ -64,13 +64,6 @@ const initialState = {
     delete: false
   },
 
-  merge: {
-    error: false,
-    errorMessage: '',
-    pending: false,
-    fulfilled: false
-  },
-
   merge_dialog: {
     show: false,
     scans: [],
@@ -586,43 +579,6 @@ const scansReducer = function(state = initialState, action) {
         {
           fulfilled: true,
           delete: true
-        },
-        {
-          state,
-          initialState
-        }
-      );
-
-    case helpers.REJECTED_ACTION(scansTypes.GET_MERGE_SCAN_RESULTS):
-      return helpers.setStateProp(
-        'merge',
-        {
-          error: action.error,
-          errorMessage: helpers.getErrorMessageFromResults(action.payload)
-        },
-        {
-          state,
-          initialState
-        }
-      );
-
-    case helpers.PENDING_ACTION(scansTypes.GET_MERGE_SCAN_RESULTS):
-      return helpers.setStateProp(
-        'merge',
-        {
-          pending: true
-        },
-        {
-          state,
-          initialState
-        }
-      );
-
-    case helpers.FULFILLED_ACTION(scansTypes.GET_MERGE_SCAN_RESULTS):
-      return helpers.setStateProp(
-        'merge',
-        {
-          fulfilled: true
         },
         {
           state,

--- a/client/src/services/credentialsService.js
+++ b/client/src/services/credentialsService.js
@@ -12,7 +12,7 @@ class CredentialsService {
     });
   }
 
-  deleteCredential(id) {
+  static deleteCredential(id) {
     return axios({
       method: 'delete',
       url: `${process.env.REACT_APP_CREDENTIALS_SERVICE}${id}/`,
@@ -22,15 +22,15 @@ class CredentialsService {
     });
   }
 
-  deleteCredentials(data = []) {
+  static deleteCredentials(data = []) {
     return Promise.all.apply(this, data.map(id => this.deleteCredential(id)));
   }
 
-  getCredential(id) {
+  static getCredential(id) {
     return this.getCredentials(id);
   }
 
-  getCredentials(id = '', query = {}) {
+  static getCredentials(id = '', query = {}) {
     return axios({
       url: `${process.env.REACT_APP_CREDENTIALS_SERVICE}${id}`,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
@@ -50,4 +50,4 @@ class CredentialsService {
   }
 }
 
-export default new CredentialsService();
+export default CredentialsService;

--- a/client/src/services/reportsService.js
+++ b/client/src/services/reportsService.js
@@ -3,11 +3,11 @@ import axios from 'axios';
 import moment from 'moment';
 
 class ReportsService {
-  getTimeStampFromResults(results) {
+  static getTimeStampFromResults(results) {
     return moment(_.get(results, 'headers.date', Date.now())).format('YYYYMMDD_HHmmss');
   }
 
-  downloadCSV(data = '', fileName = 'report.csv') {
+  static downloadCSV(data = '', fileName = 'report.csv') {
     return new Promise((resolve, reject) => {
       try {
         const blob = new Blob([data], { type: 'text/csv' });
@@ -38,7 +38,7 @@ class ReportsService {
     });
   }
 
-  getReportDetails(id, query = {}) {
+  static getReportDetails(id, query = {}) {
     let apiPath = process.env.REACT_APP_REPORTS_SERVICE_DETAILS.replace('{0}', id);
 
     return axios({
@@ -48,13 +48,13 @@ class ReportsService {
     });
   }
 
-  getReportDetailsCsv(id) {
+  static getReportDetailsCsv(id) {
     return this.getReportDetails(id, { format: 'csv' }).then(success => {
       return this.downloadCSV(success.data, `report_${id}_details_${this.getTimeStampFromResults(success)}.csv`);
     });
   }
 
-  getReportSummary(id, query = {}) {
+  static getReportSummary(id, query = {}) {
     let apiPath = process.env.REACT_APP_REPORTS_SERVICE_DEPLOYMENTS.replace('{0}', id);
 
     return axios({
@@ -64,22 +64,34 @@ class ReportsService {
     });
   }
 
-  getReportSummaryCsv(id, query = {}) {
+  static getReportSummaryCsv(id, query = {}) {
     return this.getReportSummary(id, Object.assign(query, { format: 'csv' })).then(success => {
       return this.downloadCSV(success.data, `report_${id}_summary_${this.getTimeStampFromResults(success)}.csv`);
     });
   }
 
-  getMergedScanReportDetailsCsv(id) {
+  static getMergedScanReportDetailsCsv(id) {
     return this.getReportDetails(id, { format: 'csv' }).then(success => {
       return this.downloadCSV(success.data, `merged_report_details_${this.getTimeStampFromResults(success)}.csv`);
     });
   }
-  getMergedScanReporSummaryCsv(id) {
+
+  static getMergedScanReportSummaryCsv(id) {
     return this.getReportSummary(id, { format: 'csv' }).then(success => {
       return this.downloadCSV(success.data, `merged_report_summary_${this.getTimeStampFromResults(success)}.csv`);
     });
   }
+
+  static mergeScanReports(data = {}) {
+    return axios({
+      method: 'put',
+      url: process.env.REACT_APP_REPORTS_SERVICE_MERGE,
+      data: data,
+      xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
+      xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
+      timeout: process.env.REACT_APP_AJAX_TIMEOUT
+    });
+  }
 }
 
-export default new ReportsService();
+export default ReportsService;

--- a/client/src/services/scansService.js
+++ b/client/src/services/scansService.js
@@ -12,11 +12,11 @@ class ScansService {
     });
   }
 
-  getScan(id) {
+  static getScan(id) {
     return this.getScans(id);
   }
 
-  getScans(id = '', query = {}) {
+  static getScans(id = '', query = {}) {
     return axios({
       url: `${process.env.REACT_APP_SCANS_SERVICE}${id}`,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
@@ -125,17 +125,6 @@ class ScansService {
       timeout: process.env.REACT_APP_AJAX_TIMEOUT
     });
   }
-
-  static mergeScans(data) {
-    return axios({
-      method: 'put',
-      url: process.env.REACT_APP_SCAN_JOBS_SERVICE_MERGE,
-      data: data,
-      xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
-      xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
-      timeout: process.env.REACT_APP_AJAX_TIMEOUT
-    });
-  }
 }
 
-export default new ScansService();
+export default ScansService;

--- a/client/src/services/sourcesService.js
+++ b/client/src/services/sourcesService.js
@@ -13,7 +13,7 @@ class SourcesService {
     });
   }
 
-  deleteSource(id) {
+  static deleteSource(id) {
     return axios({
       method: 'delete',
       url: `${process.env.REACT_APP_SOURCES_SERVICE}${id}/`,
@@ -23,15 +23,15 @@ class SourcesService {
     });
   }
 
-  deleteSources(data = []) {
+  static deleteSources(data = []) {
     return Promise.all.apply(this, data.map(id => this.deleteSource(id)));
   }
 
-  getSource(id) {
+  static getSource(id) {
     return this.getSources(id);
   }
 
-  getSources(id = '', query = {}) {
+  static getSources(id = '', query = {}) {
     return axios({
       url: `${process.env.REACT_APP_SOURCES_SERVICE}${id}`,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
@@ -51,4 +51,4 @@ class SourcesService {
   }
 }
 
-export default new SourcesService();
+export default SourcesService;


### PR DESCRIPTION
### Changes
* Dotenv updates
* Service method name revert, static vs instantiation
* Minor clean up let to const
* Add Redux constant, action, reducer for report merge
* Report merge service
* Clean up, remove scan merge
* Component switch to using report_id
* Reports reducer clean up
* Minor test clean up

### Fixes
* Had to revert the services back to the original JS/Ecma use of `static methods due to issues in how the classes are imported. At some point they need to be flipped over to just using a `const` setup.

### What's missing
* Switching the unit tests for the reducer from Scans to Reports.

closes #1250 
updates #1244
