### PR TITLE
Fix if_config facts when using become-password

### DIFF
--- a/quipucords/scanner/network/processing/ifconfig.py
+++ b/quipucords/scanner/network/processing/ifconfig.py
@@ -35,3 +35,19 @@ class ProcessIPAddresses(process.Processor):
                         result.append(ip_line)
                     break
         return list(set(result))
+
+
+class ProcessMacAddresses(process.Processor):
+    """Process the mac addresses from ifconfig."""
+
+    KEY = 'ifconfig_mac_addresses'
+
+    @staticmethod
+    def process(output):
+        """Pass the output back through."""
+        result = []
+        addresses = output.get('stdout_lines', [])
+        for address in addresses:
+            if address:
+                result.append(address)
+        return list(set(result))

--- a/quipucords/scanner/network/processing/test_ifconfig.py
+++ b/quipucords/scanner/network/processing/test_ifconfig.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+"""Unit tests for initial processing of ifconfig facts."""
+
+
+import unittest
+
+from scanner.network.processing import ifconfig
+from scanner.network.processing.util_for_test import ansible_result
+
+
+class TestProcessIPAddresses(unittest.TestCase):
+    """Test ProcessIPAddresses."""
+
+    def test_success_case(self):
+        """Found IP."""
+        self.assertEqual(
+            ifconfig.ProcessIPAddresses.process(
+                ansible_result('inet addr: 1.2.3.4')),
+            ['1.2.3.4'])
+
+    def test_not_found(self):
+        """Did not find IP."""
+        self.assertEqual(
+            ifconfig.ProcessIPAddresses.process(
+                ansible_result('')),
+            [])
+
+
+class TestProcessMacAddresses(unittest.TestCase):
+    """Test ProcessMacAddresses."""
+
+    def test_success_case(self):
+        """Found mac address."""
+        self.assertEqual(
+            ifconfig.ProcessMacAddresses.process(
+                ansible_result('00:10:20:3a:40:b5')),
+            ['00:10:20:3a:40:b5'])
+
+    def test_not_found(self):
+        """Did not find mac address."""
+        self.assertEqual(
+            ifconfig.ProcessMacAddresses.process(
+                ansible_result('')),
+            [])

--- a/roles/check_dependencies/tasks/main.yml
+++ b/roles/check_dependencies/tasks/main.yml
@@ -121,6 +121,7 @@
   raw: command -v ifconfig
   register: internal_have_ifconfig_cmd
   ignore_errors: yes
+  become: yes
 
 - name: set internal_have_ifconfig
   set_fact:

--- a/roles/ifconfig/tasks/main.yml
+++ b/roles/ifconfig/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: extract result value for ifconfig.mac-addresses
   set_fact:
-    ifconfig_mac_addresses: "{{  internal_ifconfig_mac_addresses_cmd['stdout_lines'] | default(None) }}"
+    ifconfig_mac_addresses: "{{ internal_ifconfig_mac_addresses_cmd | default(None) }}"
   ignore_errors: yes
   when: '"stdout_lines" in internal_ifconfig_mac_addresses_cmd'
 


### PR DESCRIPTION
Closes #1281 


For the system `10.10.182.46`:
```
"ifconfig_mac_addresses": [
                        "00:50:56:9e:99:a8"
                    ],
                    "ifconfig_ip_addresses": [
                        "10.10.182.46"
                    ],
```