### PR TITLE
jboss amq no longer mistaken for fuse amq

### DIFF
--- a/quipucords/fingerprinter/jboss_fuse.py
+++ b/quipucords/fingerprinter/jboss_fuse.py
@@ -76,7 +76,7 @@ def detect_jboss_fuse(source, facts):
     """Detect if JBoss Fuse is present based on system facts.
 
     :param source: The source of the facts
-    :param facts: facts for a system
+    :param facts: dictionary of facts for a system
     :returns: dictionary defining the product presence
     """
     eap_home_bin = facts.get(EAP_HOME_BIN)

--- a/roles/jboss_fuse_on_karaf/tasks/main.yml
+++ b/roles/jboss_fuse_on_karaf/tasks/main.yml
@@ -101,7 +101,7 @@
   when: 'user_has_sudo and jboss_fuse and internal_have_chkconfig'
 
 - name: Use locate to look for camel-ver
-  raw: locate camel-core | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: locate camel-core | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: jboss_fuse_camel_ver
   ignore_errors: yes
   become: yes
@@ -124,7 +124,7 @@
   when: 'jboss_fuse'
 
 - name: Use locate to look for activemq-ver
-  raw: locate activemq | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: locate activemq | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: jboss_fuse_activemq_ver
   ignore_errors: yes
   become: yes
@@ -147,7 +147,7 @@
   when: 'jboss_fuse'
 
 - name: Use locate to look for cxf-rt-ver
-  raw: locate cxf-rt| sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: locate cxf-rt | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: jboss_fuse_cxf_ver
   ignore_errors: yes
   become: yes


### PR DESCRIPTION
The facts `fuse_activemq_version  fuse_camel_version  fuse_cxf_version` were detected even if fuse was not installed on the system. Amq, camel, and cxf can be installed independently of fuse. If amq/camel/cxf are a part of fuse they should be under a fuse subdirectory, so I added a `grep fuse` to the ansible commands after locating the files. 

This appears to work when running scans on test servers: 
sonar-jbossamq-rhel-5-vc             -> no detection of amq, camel or cxf
sonar-jbosseap-fuse-rhel-6-vc      -> same detection of fuse, camel, and cxf as before

Closes #1361 