### PR TITLE
Commas Present in virt field for RHV host and other fields

### DIFF
--- a/quipucords/api/report/renderer.py
+++ b/quipucords/api/report/renderer.py
@@ -165,7 +165,7 @@ class DeploymentCSVRenderer(renderers.BaseRenderer):
             headers += self.source_headers
             headers = sorted(list(set(headers)))
 
-        # Add source heaaders
+        # Add source headers
         csv_writer.writerow(headers)
         for system in systems_list:
             row = []

--- a/quipucords/api/report/renderer.py
+++ b/quipucords/api/report/renderer.py
@@ -30,6 +30,12 @@ SATELLITE_DETECTION_KEY = 'detection-satellite'
 SOURCES_KEY = 'sources'
 
 
+def sanitize_row(row):
+    """Replace commas in fact values to prevent false csv parsing."""
+    return [fact.replace(',', ';')
+            if isinstance(fact, str) else fact for fact in row]
+
+
 class DetailsCSVRenderer(renderers.BaseRenderer):
     """Class to render detailed report as CSV."""
 
@@ -102,7 +108,7 @@ class DetailsCSVRenderer(renderers.BaseRenderer):
                     fact_value = fact.get(header)
                     row.append(csv_helper.serialize_value(header, fact_value))
 
-                csv_writer.writerow(row)
+                csv_writer.writerow(sanitize_row(row))
 
             csv_writer.writerow([])
             csv_writer.writerow([])
@@ -180,7 +186,7 @@ class DeploymentCSVRenderer(renderers.BaseRenderer):
                 else:
                     fact_value = system.get(header)
                 row.append(csv_helper.serialize_value(header, fact_value))
-            csv_writer.writerow(row)
+            csv_writer.writerow(sanitize_row(row))
 
         csv_writer.writerow([])
 

--- a/quipucords/api/report/tests_report.py
+++ b/quipucords/api/report/tests_report.py
@@ -412,7 +412,6 @@ class DeploymentReportTest(TestCase):
 
         csv_result = renderer.render(report)
 
-        self.maxDiff = None
         expected = 'Report\r\n1\r\n\r\n\r\nReport:\r\narchitecture,bios_uuid,cpu_core_count,cpu_count,cpu_socket_count,detection-network,detection-satellite,detection-vcenter,entitlements,infrastructure_type,ip_addresses,is_redhat,jboss brms,jboss eap,jboss fuse,mac_addresses,name,os_name,os_release,os_version,redhat_certs,redhat_package_count,sources,subscription_manager_id,system_creation_date,system_last_checkin_date,virtualized_type,vm_cluster,vm_datacenter,vm_dns_name,vm_host,vm_host_socket_count,vm_state,vm_uuid\r\n,,2.0,2,2,True,False,False,,virtualized,,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,,[test_source],,2017-07-18,,vmware,,,,,,,\r\n,,2.0,2,2,True,False,False,,virtualized,,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,,[test_source],,2017-07-18,,vmware,,,,,,,\r\n,,2.0,2,2,True,False,False,,virtualized,,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.5,7.5,,,[test_source],,2017-07-18,,vmware,,,,,,,\r\n\r\n'  # noqa
         self.assertEqual(csv_result, expected)
 

--- a/quipucords/api/report/tests_report.py
+++ b/quipucords/api/report/tests_report.py
@@ -19,7 +19,9 @@ from api.models import (Credential,
                         FactCollection,
                         ServerInformation,
                         Source)
-from api.report.renderer import DeploymentCSVRenderer, DetailsCSVRenderer
+from api.report.renderer import (DeploymentCSVRenderer,
+                                 DetailsCSVRenderer,
+                                 sanitize_row)
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -382,6 +384,11 @@ class DeploymentReportTest(TestCase):
     ##############################################################
     # Test CSV Renderer
     ##############################################################
+    def test_sanitize_row(self):
+        """Test sanitize_row function."""
+        self.assertEqual(sanitize_row(['data', None, 'data,data']),
+                         ['data', None, 'data;data'])
+
     def test_csv_renderer(self):
         """Test DeploymentCSVRenderer."""
         renderer = DeploymentCSVRenderer()
@@ -405,6 +412,7 @@ class DeploymentReportTest(TestCase):
 
         csv_result = renderer.render(report)
 
+        self.maxDiff = None
         expected = 'Report\r\n1\r\n\r\n\r\nReport:\r\narchitecture,bios_uuid,cpu_core_count,cpu_count,cpu_socket_count,detection-network,detection-satellite,detection-vcenter,entitlements,infrastructure_type,ip_addresses,is_redhat,jboss brms,jboss eap,jboss fuse,mac_addresses,name,os_name,os_release,os_version,redhat_certs,redhat_package_count,sources,subscription_manager_id,system_creation_date,system_last_checkin_date,virtualized_type,vm_cluster,vm_datacenter,vm_dns_name,vm_host,vm_host_socket_count,vm_state,vm_uuid\r\n,,2.0,2,2,True,False,False,,virtualized,,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,,[test_source],,2017-07-18,,vmware,,,,,,,\r\n,,2.0,2,2,True,False,False,,virtualized,,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.4,7.4,,,[test_source],,2017-07-18,,vmware,,,,,,,\r\n,,2.0,2,2,True,False,False,,virtualized,,,absent,absent,absent,,1.2.3.4,RHEL,RHEL 7.5,7.5,,,[test_source],,2017-07-18,,vmware,,,,,,,\r\n\r\n'  # noqa
         self.assertEqual(csv_result, expected)
 


### PR DESCRIPTION
Commas are replaced by semicolons in all gathered facts.

closes #1384 