### PR TITLE
UI: Fix branding title for HTML

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Red Hat Entitlements Reporting</title>
+    <title>Entitlements Reporting</title>
   </head>
   <body class="cards-pf">
     <noscript>

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Entitlements",
-  "name": "Red Hat Entitlements Reporting",
+  "name": "Entitlements Reporting",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
Removes the branding from the HTML UI title tag

* clean up UI displayed title

closes #1401 