### PR TITLE
fix typo that messes up extended product search

### DIFF
--- a/docs/source/man.rst
+++ b/docs/source/man.rst
@@ -365,7 +365,7 @@ The information in a scan might change as the structure of the network changes. 
 
 Although ``qpc scan`` options can accept more than one value, the ``qpc scan edit`` command is not additive. To edit a scan and add a new value for an option, you must enter both the current and the new values for that option. Include only the options that you want to change in the ``qpc scan edit`` command. Options that are not included are not changed.
 
-**qpc scan edit --name** *name* **[--sources=** *source_list* **]** **[--max-concurrency=** *concurrency* **]** **[--disabled-optional-products=** *products_list* **]** **[--enabled-extended-product-search=** *products_list* **]** **[--ext-product-search-dirs=** *search_dirs_list* **]**
+**qpc scan edit --name** *name* **[--sources=** *source_list* **]** **[--max-concurrency=** *concurrency* **]** **[--disabled-optional-products=** *products_list* **]** **[--enabled-ext-product-search=** *products_list* **]** **[--ext-product-search-dirs=** *search_dirs_list* **]**
 
 For example, if a scan contains a value of ``network1source`` for the ``--sources`` option, and you want to change that scan to use both the ``network1source`` and ``satellite1source`` sources, you would edit the scan as follows:
 


### PR DESCRIPTION
Confusing typo in the man page