### PR TITLE
Remove joins from scan manager to fix scan job cancel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ db.sqlite3
 # node
 node_modules
 package-lock.json
+
+# symbolic link to roles
+quipucords/roles/

--- a/README.rst
+++ b/README.rst
@@ -122,10 +122,13 @@ You can run the server locally inside of gunicorn.  This can be a useful way to 
 3. Make symbolic link to ansible roles::
     ln -s ../roles/ roles
 
-4. Start gunicorn::
+4. Install gunicorn::
+    pip install gunicorn==19.7.1
+
+5. Start gunicorn::
     gunicorn quipucords.wsgi -c ./local_gunicorn.conf.py
 
-5. Configure the CLI by using the following commands::
+6. Configure the CLI by using the following commands::
     qpc server config --host 127.0.0.1 --port 8000
     qpc server login
 

--- a/README.rst
+++ b/README.rst
@@ -120,15 +120,19 @@ You can run the server locally inside of gunicorn.  This can be a useful way to 
     cd quipucords
 
 3. Make symbolic link to ansible roles::
+
     ln -s ../roles/ roles
 
 4. Install gunicorn::
+
     pip install gunicorn==19.7.1
 
 5. Start gunicorn::
+
     gunicorn quipucords.wsgi -c ./local_gunicorn.conf.py
 
 6. Configure the CLI by using the following commands::
+
     qpc server config --host 127.0.0.1 --port 8000
     qpc server login
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,27 @@ You must have `Docker installed <https://docs.docker.com/engine/installation/>`_
 
 6.  You can work with the APIs, the CLI, and UI (visit `<https://127.0.0.1/>`_ if you installed the UI in step 2 above).
 
+Running quipucords server in gunicorn
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+You can run the server locally inside of gunicorn.  This can be a useful way to debug.
+
+1. Clone the repository::
+
+    git clone git@github.com:quipucords/quipucords.git
+
+2. Switch to quipucords directory::
+
+    cd quipucords
+
+3. Make symbolic link to ansible roles::
+    ln -s ../roles/ roles
+
+4. Start gunicorn::
+    gunicorn quipucords.wsgi -c ./local_gunicorn.conf.py
+
+5. Configure the CLI by using the following commands::
+    qpc server config --host 127.0.0.1 --port 8000
+    qpc server login
 
 Command Syntax and Usage
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -187,8 +187,9 @@ You can run the server locally inside of gunicorn.  This can be a useful way to 
 1. Clone the repository::
 
     git clone git@github.com:quipucords/quipucords.git
+    cd quipucords
 
-2. Switch to quipucords directory::
+2. Switch to quipucords django app module::
 
     cd quipucords
 

--- a/README.rst
+++ b/README.rst
@@ -107,35 +107,6 @@ You must have `Docker installed <https://docs.docker.com/engine/installation/>`_
 
 6.  You can work with the APIs, the CLI, and UI (visit `<https://127.0.0.1/>`_ if you installed the UI in step 2 above).
 
-Running quipucords server in gunicorn
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-You can run the server locally inside of gunicorn.  This can be a useful way to debug.
-
-1. Clone the repository::
-
-    git clone git@github.com:quipucords/quipucords.git
-
-2. Switch to quipucords directory::
-
-    cd quipucords
-
-3. Make symbolic link to ansible roles::
-
-    ln -s ../roles/ roles
-
-4. Install gunicorn::
-
-    pip install gunicorn==19.7.1
-
-5. Start gunicorn::
-
-    gunicorn quipucords.wsgi -c ./local_gunicorn.conf.py
-
-6. Configure the CLI by using the following commands::
-
-    qpc server config --host 127.0.0.1 --port 8000
-    qpc server login
-
 Command Syntax and Usage
 ------------------------
 The complete list of options for each qpc command and subcommand are listed in the qpc man page. The man page information also contains usage examples and some best practice recommendations.
@@ -206,6 +177,36 @@ If you intend to run on Mac OS, there are several more steps that are required.
 - If you are running macOS 10.13 or later and you encounter unexpected crashes when running scans,
   set the environment variable ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`` before starting the server.
   See the explanation for this step `here <https://github.com/ansible/ansible/issues/31869#issuecomment-337769174>`_.
+
+
+Running quipucords server in gunicorn
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+You can run the server locally inside of gunicorn.  This can be a useful way to debug.
+
+1. Clone the repository::
+
+    git clone git@github.com:quipucords/quipucords.git
+
+2. Switch to quipucords directory::
+
+    cd quipucords
+
+3. Make symbolic link to ansible roles::
+
+    ln -s ../roles/ roles
+
+4. Install gunicorn::
+
+    pip install gunicorn==19.7.1
+
+5. Start gunicorn::
+
+    gunicorn quipucords.wsgi -c ./local_gunicorn.conf.py
+
+6. Configure the CLI by using the following commands::
+
+    qpc server config --host 127.0.0.1 --port 8000
+    qpc server login
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,7 @@ You must have `Docker installed <https://docs.docker.com/engine/installation/>`_
 
 6.  You can work with the APIs, the CLI, and UI (visit `<https://127.0.0.1/>`_ if you installed the UI in step 2 above).
 
+
 Command Syntax and Usage
 ------------------------
 The complete list of options for each qpc command and subcommand are listed in the qpc man page. The man page information also contains usage examples and some best practice recommendations.

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -88,6 +88,7 @@ class Manager(Thread):
                             SCAN_MANAGER_LOG_PREFIX,
                             self.current_task_runner.scan_job.id)
                 self.current_task_runner.start()
+                self.log_info()
             else:
                 error = '%s: Could not start job. Job was not in %s state.' % \
                     (SCAN_MANAGER_LOG_PREFIX, ScanTask.PENDING)
@@ -100,6 +101,7 @@ class Manager(Thread):
         :param task: Task to be performed.
         """
         self.scan_queue.insert(0, task)
+        self.log_info()
 
     def kill(self, job, command):
         """Kill a task or remove it from the running queue.
@@ -135,6 +137,7 @@ class Manager(Thread):
                 if queued_job.identifier == job_id:
                     self.scan_queue.remove(queued_job)
                     removed = True
+                    self.log_info()
                     break
             if removed:
                 killed = True
@@ -178,7 +181,7 @@ class Manager(Thread):
         while self.running:
             queue_len = len(self.scan_queue)
             if self.terminated_task_runner is not None:
-                # Occurs when current jobs was terminated
+                # Occurs when current job was terminated
                 killed = not self.terminated_task_runner.is_alive()
                 interrupt = self.terminated_task_runner.manager_interrupt
                 if killed:

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -64,7 +64,6 @@ class Manager(Thread):
             interval = DEFAULT_HEARTBEAT
         heartbeat = Timer(interval, self.log_info)
         current_scan_job = None
-        scan_job_message = None
         if self.current_task_runner:
             current_scan_job = self.current_task_runner.identifier
             scan_job_message = 'Currently running scan job %s' % \

--- a/quipucords/scanner/tests_manager.py
+++ b/quipucords/scanner/tests_manager.py
@@ -30,6 +30,7 @@ class MockTask(Thread):
         self.id = 1
         self.scan_job = Mock()
         self.scan_job.status = ScanTask.PENDING
+        self.identifier = 'TestScan'
 
     def log_message(self, message):
         """Fake log message."""

--- a/quipucords/scanner/tests_manager.py
+++ b/quipucords/scanner/tests_manager.py
@@ -61,9 +61,11 @@ class ScanManagerTest(TestCase):
     def test_work(self):
         """Test the work function."""
         task = MockTask()
+        self.assertIsNone(self.scan_manager.current_task_runner)
         self.scan_manager.put(task)
+        self.assertIsNone(self.scan_manager.current_task_runner)
         self.scan_manager.work()
-        self.assertIsNone(self.scan_manager.current_task)
+        self.assertEqual(task, self.scan_manager.current_task_runner)
 
     def test_kill_missing(self):
         """Test kill on missing id."""


### PR DESCRIPTION
This work intends to ensure that a job will:
- Cause gunicorn to timeout while canceling a job
- Really cancel a job (at least by the end of the inventory group)
- Everything else should work the same

Closes #1416 