### PR TITLE
Restructure satellite scans to isolate threading to http requests

### DIFF
--- a/quipucords/api/scantasks/model.py
+++ b/quipucords/api/scantasks/model.py
@@ -148,17 +148,15 @@ class ScanTask(models.Model):
              sys_unreachable)
         self.log_message(message)
 
-    # pylint: disable=too-many-arguments
     def log_message(self, message, log_level=logging.INFO,
-                    inspect_task_id=None, scan_type=None,
-                    source_type=None, source_name=None):
+                    static_options=None):
         """Log a message for this task."""
-        if inspect_task_id is not None and scan_type is not None and \
-                source_type is not None and source_name is not None:
-            actual_message = 'Task %d (%s, %s, %s) - ' % (inspect_task_id,
-                                                          scan_type,
-                                                          source_type,
-                                                          source_name)
+        if static_options is not None:
+            actual_message = 'Task %d (%s, %s, %s) - ' % \
+                (static_options['inspect_task_id'],
+                 static_options['scan_type'],
+                 static_options['source_type'],
+                 static_options['source_name'])
         else:
             elapsed_time = self._compute_elapsed_time()
             actual_message = 'Task %d (%s, %s, %s, elapsed_time: %ds) - ' % \

--- a/quipucords/api/scantasks/model.py
+++ b/quipucords/api/scantasks/model.py
@@ -148,6 +148,7 @@ class ScanTask(models.Model):
              sys_unreachable)
         self.log_message(message)
 
+    # pylint: disable=too-many-arguments
     def log_message(self, message, log_level=logging.INFO,
                     inspect_task_id=None, scan_type=None,
                     source_type=None, source_name=None):

--- a/quipucords/api/scantasks/model.py
+++ b/quipucords/api/scantasks/model.py
@@ -148,15 +148,24 @@ class ScanTask(models.Model):
              sys_unreachable)
         self.log_message(message)
 
-    def log_message(self, message, log_level=logging.INFO):
+    def log_message(self, message, log_level=logging.INFO,
+                    inspect_task_id=None, scan_type=None,
+                    source_type=None, source_name=None):
         """Log a message for this task."""
-        elapsed_time = self._compute_elapsed_time()
-        actual_message = 'Task %d (%s, %s, %s, elapsed_time: %ds) - ' % \
-            (self.id,
-             self.scan_type,
-             self.source.source_type,
-             self.source.name,
-             elapsed_time)
+        if inspect_task_id is not None and scan_type is not None and \
+                source_type is not None and source_name is not None:
+            actual_message = 'Task %d (%s, %s, %s) - ' % (inspect_task_id,
+                                                          scan_type,
+                                                          source_type,
+                                                          source_name)
+        else:
+            elapsed_time = self._compute_elapsed_time()
+            actual_message = 'Task %d (%s, %s, %s, elapsed_time: %ds) - ' % \
+                (self.id,
+                 self.scan_type,
+                 self.source.source_type,
+                 self.source.name,
+                 elapsed_time)
         actual_message += message.strip()
         logger.log(log_level, actual_message)
 

--- a/quipucords/scanner/satellite/six.py
+++ b/quipucords/scanner/satellite/six.py
@@ -266,10 +266,10 @@ def host_subscriptions(response):
 
 
 # pylint: disable=too-many-arguments
-def get_http_responses(scan_task, inspect_task_id,
-                       scan_type, source_type, source_name,
-                       host_id, host_name,
-                       fields_url, subs_url, request_options):
+def request_host_details(scan_task, inspect_task_id,
+                         scan_type, source_type, source_name,
+                         host_id, host_name,
+                         fields_url, subs_url, request_options):
     """Execute both http responses to gather satallite data.
 
     :param scan_task: The current scan task
@@ -294,8 +294,8 @@ def get_http_responses(scan_task, inspect_task_id,
     results = {}
     try:
         message = 'REQUESTING HOST DETAILS: %s' % unique_name
-        scan_task.log_message(message, inspect_task_id, scan_type, source_type,
-                              source_name)
+        scan_task.log_message(message, logging.INFO, inspect_task_id,
+                              scan_type, source_type, source_name)
         host_fields_response, host_fields_url = \
             utils.execute_request(scan_task,
                                   url=fields_url,
@@ -571,7 +571,8 @@ class SatelliteSixV1(SatelliteInterface):
                             raise SatellitePauseException()
 
                         host_params = self.prepare_host(chunk)
-                        results = pool.starmap(get_http_responses, host_params)
+                        results = pool.starmap(request_host_details,
+                                               host_params)
                         for each in results:
                             if each:
                                 result = post_processing_results(
@@ -712,7 +713,7 @@ class SatelliteSixV2(SatelliteInterface):
                     if manager_interrupt.value == ScanJob.JOB_TERMINATE_PAUSE:
                         raise SatellitePauseException()
                     host_params = self.prepare_host(chunk)
-                    results = pool.starmap(get_http_responses,
+                    results = pool.starmap(request_host_details,
                                            host_params)
                     for each in results:
                         if each:

--- a/quipucords/scanner/satellite/tests_sat_six.py
+++ b/quipucords/scanner/satellite/tests_sat_six.py
@@ -253,21 +253,21 @@ class SatelliteSixV1Test(TestCase):
 
     def test_prepare_host_s61(self):
         """Test the prepare host method for satellite 6.1."""
-        HOSTS_FIELDS_V1_URL = \
+        url1 = \
             'https://{sat_host}:{port}/katello/api' \
             '/v2/organizations/{org_id}/systems/{host_id}'
-        HOSTS_SUBS_V1_URL = \
+        url2 = \
             'https://{sat_host}:{port}/katello/api' \
             '/v2/organizations/{org_id}/systems/{host_id}/subscriptions'
         expected = [(self.scan_task, self.scan_task.id,
-                    self.scan_task.scan_type,
-                    self.scan_task.source.source_type,
-                    self.scan_task.source.name, 1, 'sys',
-                    HOSTS_FIELDS_V1_URL, HOSTS_SUBS_V1_URL,
-                    {'host': {'id': 1, 'name': 'sys'}, 'port': '443',
-                     'user': self.cred.username,
-                     'password': self.cred.password,
-                     'ssl_cert_verify': True})]
+                     self.scan_task.scan_type,
+                     self.scan_task.source.source_type,
+                     self.scan_task.source.name, 1, 'sys',
+                     url1, url2,
+                     {'host': {'id': 1, 'name': 'sys'}, 'port': '443',
+                      'user': self.cred.username,
+                      'password': self.cred.password,
+                      'ssl_cert_verify': True})]
         host = {'id': 1, 'name': 'sys'}
         chunk = [host]
         port = '443'
@@ -278,6 +278,7 @@ class SatelliteSixV1Test(TestCase):
                    return_value=connect_data_return_value) as mock_connect:
             host_params = SatelliteSixV1.prepare_host(self.api, chunk)
             self.assertEqual(expected, host_params)
+            mock_connect.assert_called_once_with(ANY)
 
     def test_get_http_responses_err(self):
         """Test get_http_responses for error mark a failed system."""

--- a/quipucords/scanner/satellite/tests_sat_six.py
+++ b/quipucords/scanner/satellite/tests_sat_six.py
@@ -251,6 +251,34 @@ class SatelliteSixV1Test(TestCase):
                 'os_name': 'RedHat', 'os_version': '7.4'}
             self.assertEqual(host_info, expected)
 
+    def test_prepare_host_s61(self):
+        """Test the prepare host method for satellite 6.1."""
+        HOSTS_FIELDS_V1_URL = \
+            'https://{sat_host}:{port}/katello/api' \
+            '/v2/organizations/{org_id}/systems/{host_id}'
+        HOSTS_SUBS_V1_URL = \
+            'https://{sat_host}:{port}/katello/api' \
+            '/v2/organizations/{org_id}/systems/{host_id}/subscriptions'
+        expected = [(self.scan_task, self.scan_task.id,
+                    self.scan_task.scan_type,
+                    self.scan_task.source.source_type,
+                    self.scan_task.source.name, 1, 'sys',
+                    HOSTS_FIELDS_V1_URL, HOSTS_SUBS_V1_URL,
+                    {'host': {'id': 1, 'name': 'sys'}, 'port': '443',
+                     'user': self.cred.username,
+                     'password': self.cred.password,
+                     'ssl_cert_verify': True})]
+        host = {'id': 1, 'name': 'sys'}
+        chunk = [host]
+        port = '443'
+        user = self.cred.username
+        password = self.cred.password
+        connect_data_return_value = host, port, user, password
+        with patch('scanner.satellite.utils.get_connect_data',
+                   return_value=connect_data_return_value) as mock_connect:
+            host_params = SatelliteSixV1.prepare_host(self.api, chunk)
+            self.assertEqual(expected, host_params)
+
     def test_get_http_responses_err(self):
         """Test get_http_responses for error mark a failed system."""
         host_field_url = 'https://{sat_host}:{port}/api/v2/hosts/{host_id}'
@@ -259,7 +287,9 @@ class SatelliteSixV1Test(TestCase):
                                 host_id=1)
             mocker.get(url, status_code=500)
             result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type, 1, 'sys',
+                                        self.scan_task.scan_type,
+                                        self.scan_task.source.source_type,
+                                        self.scan_task.source.name, 1, 'sys',
                                         url, url, {})
             expected = {'unique_name': 'sys_1',
                         'system_inspection_result': 'failed',
@@ -523,7 +553,9 @@ class SatelliteSixV2Test(TestCase):
                                 host_id=1)
             mocker.get(url, status_code=500)
             result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type, 1, 'sys',
+                                        self.scan_task.scan_type,
+                                        self.scan_task.source.source_type,
+                                        self.scan_task.source.name, 1, 'sys',
                                         url, url, {})
             expected = {'unique_name': 'sys_1',
                         'system_inspection_result': 'failed',
@@ -611,7 +643,9 @@ class SatelliteSixV2Test(TestCase):
                                 host_id=1)
             mocker.get(url, status_code=500)
             result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type, 1, 'sys',
+                                        self.scan_task.scan_type,
+                                        self.scan_task.source.source_type,
+                                        self.scan_task.source.name, 1, 'sys',
                                         url, url, {})
             expected = {'unique_name': 'sys_1',
                         'system_inspection_result': 'failed',
@@ -629,7 +663,9 @@ class SatelliteSixV2Test(TestCase):
                                 host_id=1)
             mocker.get(url, status_code=404, text='error message')
             result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type, 1, 'sys',
+                                        self.scan_task.scan_type,
+                                        self.scan_task.source.source_type,
+                                        self.scan_task.source.name, 1, 'sys',
                                         url, url, {})
             response = post_processing_results(
                 result['unique_name'],
@@ -653,7 +689,9 @@ class SatelliteSixV2Test(TestCase):
                 }  # noqa
             mocker.get(url, status_code=400, json=err_msg)
             result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type, 1, 'sys',
+                                        self.scan_task.scan_type,
+                                        self.scan_task.source.source_type,
+                                        self.scan_task.source.name, 1, 'sys',
                                         url, url, {})
         response = post_processing_results(
             result['unique_name'],

--- a/quipucords/scanner/satellite/tests_sat_six.py
+++ b/quipucords/scanner/satellite/tests_sat_six.py
@@ -27,9 +27,9 @@ import requests_mock
 
 from scanner.satellite.api import SatelliteException
 from scanner.satellite.six import (SatelliteSixV1, SatelliteSixV2,
-                                   get_http_responses,
                                    host_fields, host_subscriptions,
-                                   post_processing_results)
+                                   post_processing_results,
+                                   request_host_details,)
 from scanner.satellite.utils import construct_url
 from scanner.test_util import create_scan_job
 
@@ -280,18 +280,18 @@ class SatelliteSixV1Test(TestCase):
             self.assertEqual(expected, host_params)
             mock_connect.assert_called_once_with(ANY)
 
-    def test_get_http_responses_err(self):
-        """Test get_http_responses for error mark a failed system."""
+    def test_request_host_details_err(self):
+        """Test request_host_details for error mark a failed system."""
         host_field_url = 'https://{sat_host}:{port}/api/v2/hosts/{host_id}'
         with requests_mock.Mocker() as mocker:
             url = construct_url(url=host_field_url, sat_host='1.2.3.4',
                                 host_id=1)
             mocker.get(url, status_code=500)
-            result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type,
-                                        self.scan_task.source.source_type,
-                                        self.scan_task.source.name, 1, 'sys',
-                                        url, url, {})
+            result = request_host_details(self.scan_task, self.scan_task.id,
+                                          self.scan_task.scan_type,
+                                          self.scan_task.source.source_type,
+                                          self.scan_task.source.name, 1, 'sys',
+                                          url, url, {})
             expected = {'unique_name': 'sys_1',
                         'system_inspection_result': 'failed',
                         'host_fields_response': {},
@@ -421,7 +421,7 @@ class SatelliteSixV1Test(TestCase):
             '/v2/organizations/{org_id}/systems'
         with patch.object(SatelliteSixV1, 'get_orgs',
                           return_value=[1]):
-            with patch('scanner.satellite.six.get_http_responses',
+            with patch('scanner.satellite.six.request_host_details',
                        return_value={}):
                 with requests_mock.Mocker() as mocker:
                     url = construct_url(url=hosts_url,
@@ -553,11 +553,11 @@ class SatelliteSixV2Test(TestCase):
             url = construct_url(url=host_field_url, sat_host='1.2.3.4',
                                 host_id=1)
             mocker.get(url, status_code=500)
-            result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type,
-                                        self.scan_task.source.source_type,
-                                        self.scan_task.source.name, 1, 'sys',
-                                        url, url, {})
+            result = request_host_details(self.scan_task, self.scan_task.id,
+                                          self.scan_task.scan_type,
+                                          self.scan_task.source.source_type,
+                                          self.scan_task.source.name, 1, 'sys',
+                                          url, url, {})
             expected = {'unique_name': 'sys_1',
                         'system_inspection_result': 'failed',
                         'host_fields_response': {},
@@ -643,11 +643,11 @@ class SatelliteSixV2Test(TestCase):
             url = construct_url(url=sub_url, sat_host='1.2.3.4',
                                 host_id=1)
             mocker.get(url, status_code=500)
-            result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type,
-                                        self.scan_task.source.source_type,
-                                        self.scan_task.source.name, 1, 'sys',
-                                        url, url, {})
+            result = request_host_details(self.scan_task, self.scan_task.id,
+                                          self.scan_task.scan_type,
+                                          self.scan_task.source.source_type,
+                                          self.scan_task.source.name, 1, 'sys',
+                                          url, url, {})
             expected = {'unique_name': 'sys_1',
                         'system_inspection_result': 'failed',
                         'host_fields_response': {},
@@ -663,11 +663,11 @@ class SatelliteSixV2Test(TestCase):
             url = construct_url(url=sub_url, sat_host='1.2.3.4',
                                 host_id=1)
             mocker.get(url, status_code=404, text='error message')
-            result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type,
-                                        self.scan_task.source.source_type,
-                                        self.scan_task.source.name, 1, 'sys',
-                                        url, url, {})
+            result = request_host_details(self.scan_task, self.scan_task.id,
+                                          self.scan_task.scan_type,
+                                          self.scan_task.source.source_type,
+                                          self.scan_task.source.name, 1, 'sys',
+                                          url, url, {})
             response = post_processing_results(
                 result['unique_name'],
                 result['system_inspection_result'],
@@ -689,11 +689,11 @@ class SatelliteSixV2Test(TestCase):
                            ' with subscription-manager']
                 }  # noqa
             mocker.get(url, status_code=400, json=err_msg)
-            result = get_http_responses(self.scan_task, self.scan_task.id,
-                                        self.scan_task.scan_type,
-                                        self.scan_task.source.source_type,
-                                        self.scan_task.source.name, 1, 'sys',
-                                        url, url, {})
+            result = request_host_details(self.scan_task, self.scan_task.id,
+                                          self.scan_task.scan_type,
+                                          self.scan_task.source.source_type,
+                                          self.scan_task.source.name, 1, 'sys',
+                                          url, url, {})
         response = post_processing_results(
             result['unique_name'],
             result['system_inspection_result'],

--- a/quipucords/scanner/satellite/utils.py
+++ b/quipucords/scanner/satellite/utils.py
@@ -97,8 +97,7 @@ def construct_url(url, sat_host, port='443', org_id=None, host_id=None):
 
 # pylint: disable=too-many-arguments
 def execute_request(scan_task, url, org_id=None, host_id=None,
-                    query_params=None, ssl_cert_verify=None, host=None,
-                    port=None, user=None, password=None):
+                    query_params=None, options=None):
     """Execute a request to the Satellite server.
 
     :param scan_task: The scan task
@@ -106,24 +105,21 @@ def execute_request(scan_task, url, org_id=None, host_id=None,
     :param org_id: The organization id being queried
     :param host_id: The identifier of a satellite host
     :param query_params: A dictionary to use for query_params in the url
-    :param ssl_cert_verify: The value defined for ssl_cert_verify
-            via source options.
-    :param host: The host defined by the inspect scan task source.
-    :param port: The port defined by the inspect scan task source.
-    :param user: The user defined by the credential of the inspect
-        scan task source.
-    :param: password: The password defined by the credential of the
-        inspect scan task source.
+    :param options: A dictionary containing the values for ssl_cert_verify,
+        host, port, user, and password.
     :returns: The response object
     """
-    ssl_verify = True
-    if ssl_cert_verify is not None:
-        ssl_verify = ssl_cert_verify
+    if options:
+        ssl_verify = options.get('ssl_cert_verify')
+        host = options.get('host')
+        port = options.get('port')
+        user = options.get('user')
+        password = options.get('password')
     else:
+        ssl_verify = True
         source_options = scan_task.source.options
         if source_options:
             ssl_verify = source_options.ssl_cert_verify
-    if not host:
         host, port, user, password = get_connect_data(scan_task)
     url = construct_url(url, host, port, org_id, host_id)
     response = requests.get(url, auth=(user, password),


### PR DESCRIPTION
Restructures sat61 & sat62 scans. 
TODO: 
  - Fix tests 
  - Rename a few things 
  - Restructure Sat5