### PR TITLE
Replaced carriage return with a ; for certs on network scans (#1522)

### DIFF
--- a/roles/redhat_packages/tasks/main.yml
+++ b/roles/redhat_packages/tasks/main.yml
@@ -70,7 +70,7 @@
     internal_have_rpm and redhat_packages_gpg_is_redhat
 
 - name: gather redhat-packages.certs fact
-  raw: ls /etc/pki/product/ 2> /dev/null| grep '.pem'
+  raw: ls /etc/pki/product/ 2> /dev/null |grep '.pem' | tr '\n' ';'
   register: internal_redhat_packages_certs_cmd
   ignore_errors: yes
 


### PR DESCRIPTION
Closes #1522 