### PR TITLE
UI: Activate select linter rules

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -26,6 +26,12 @@
     "comma-dangle": 0,
     "import/first": 0,
     "import/newline-after-import": 0,
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ],
     "import/no-named-as-default": 0,
     "import/no-named-as-default-member": 0,
     "jest/prefer-to-have-length": 0,
@@ -58,27 +64,9 @@
         "some": [ "nesting", "id" ]
       }
     }],
-    "arrow-body-style": 0,
-    "class-methods-use-this": 0,
-    "consistent-return": 0,
-    "func-names": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-useless-path-segments": 0,
-    "import/order": 0,
-    "import/prefer-default-export": 0,
     "jsx-a11y/label-has-associated-control": 0,
     "no-param-reassign": 0,
-    "no-return-assign": 0,
     "no-shadow": 0,
-    "no-unused-expressions": 0,
-    "no-unused-vars": 0,
-    "object-shorthand": 0,
-    "prefer-arrow-callback": 0,
-    "prefer-destructuring": 0,
-    "prefer-const": 0,
-    "prefer-rest-params": 0,
-    "react/button-has-type": 0,
-    "react/default-props-match-prop-types": 0,
     "react/destructuring-assignment": 0,
     "react/jsx-curly-brace-presence": 0,
     "react/jsx-wrap-multilines": 0,

--- a/client/src/common/helpers.js
+++ b/client/src/common/helpers.js
@@ -119,8 +119,8 @@ const authorizationTypeString = authorizationType => {
 };
 
 const setStateProp = (prop, data, options) => {
-  let { state = {}, initialState = {}, reset = true } = options;
-  let obj = { ...state };
+  const { state = {}, initialState = {}, reset = true } = options;
+  const obj = { ...state };
 
   if (!state[prop]) {
     console.error(`Error: Property ${prop} does not exist within the passed state.`, state);
@@ -146,18 +146,15 @@ const setStateProp = (prop, data, options) => {
   return obj;
 };
 
-const viewPropsChanged = (nextViewOptions, currentViewOptions) => {
-  return (
-    nextViewOptions.currentPage !== currentViewOptions.currentPage ||
-    nextViewOptions.pageSize !== currentViewOptions.pageSize ||
-    nextViewOptions.sortField !== currentViewOptions.sortField ||
-    nextViewOptions.sortAscending !== currentViewOptions.sortAscending ||
-    nextViewOptions.activeFilters !== currentViewOptions.activeFilters
-  );
-};
+const viewPropsChanged = (nextViewOptions, currentViewOptions) =>
+  nextViewOptions.currentPage !== currentViewOptions.currentPage ||
+  nextViewOptions.pageSize !== currentViewOptions.pageSize ||
+  nextViewOptions.sortField !== currentViewOptions.sortField ||
+  nextViewOptions.sortAscending !== currentViewOptions.sortAscending ||
+  nextViewOptions.activeFilters !== currentViewOptions.activeFilters;
 
 const createViewQueryObject = (viewOptions, queryObj) => {
-  let queryObject = {
+  const queryObject = {
     ...queryObj
   };
 
@@ -180,28 +177,26 @@ const createViewQueryObject = (viewOptions, queryObj) => {
 };
 
 const getErrorMessageFromResults = results => {
-  let responseData = _.get(results, 'response.data', results.message);
+  const responseData = _.get(results, 'response.data', results.message);
 
   if (typeof responseData === 'string') {
     return responseData;
   }
 
-  const getMessages = messageObject => {
-    return _.map(messageObject, next => {
-      if (_.isString(next)) {
-        return next;
-      }
+  const getMessages = messageObject =>
+    _.map(messageObject, next => {
       if (_.isArray(next)) {
         return getMessages(next);
       }
+
+      return next;
     });
-  };
 
   return _.join(getMessages(responseData), '\n');
 };
 
 const isIpAddress = name => {
-  let vals = name.split('.');
+  const vals = name.split('.');
   if (vals.length === 4) {
     return _.find(vals, val => Number.isNaN(val)) === undefined;
   }

--- a/client/src/components/about/__tests__/about.test.js
+++ b/client/src/components/about/__tests__/about.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import About from '../about';
 
-describe('About Component', function() {
+describe('About Component', () => {
   it('should render a basic display', () => {
     const props = {
       user: { currentUser: { username: 'admin' } },

--- a/client/src/components/about/about.js
+++ b/client/src/components/about/about.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { detect } from 'detect-browser';
 import { AboutModal } from 'patternfly-react';
-import helpers from '../../common/helpers';
 import _ from 'lodash';
+import helpers from '../../common/helpers';
 import logo from '../../styles/images/logo.svg';
 import productTitle from '../../styles/images/title.svg';
 import rhLogo from '../../styles/images/brand/logo.svg';
@@ -13,10 +13,10 @@ const About = ({ user, status, shown, onClose }) => {
   const versionText = `${_.get(status, 'api_version', 'unknown')} (Build: ${_.get(status, 'build', 'unknown')})`;
   const browser = detect();
 
-  let props = {
+  const props = {
     show: shown,
     onHide: onClose,
-    logo: logo,
+    logo,
     productTitle: <img src={productTitle} alt="Entitlements Reporting" />,
     altLogo: 'ER'
   };
@@ -50,4 +50,4 @@ About.propTypes = {
   onClose: PropTypes.func
 };
 
-export default About;
+export { About as default, About };

--- a/client/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizard.test.js.snap
+++ b/client/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizard.test.js.snap
@@ -42,6 +42,7 @@ exports[`AddSourceWizard Component should shallow render a basic component 1`] =
           aria-label="Close"
           className="close"
           onClick={[Function]}
+          type="button"
         >
           <Icon
             name="close"

--- a/client/src/components/addSourceWizard/__tests__/addSourceWizard.test.js
+++ b/client/src/components/addSourceWizard/__tests__/addSourceWizard.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import AddSourceWizard from '../addSourceWizard';
 
-describe('AddSourceWizard Component', function() {
+describe('AddSourceWizard Component', () => {
   const generateEmptyStore = () => configureMockStore()({ addSourceWizard: {} });
 
   it('should shallow render a basic component', () => {

--- a/client/src/components/addSourceWizard/addSourceWizard.js
+++ b/client/src/components/addSourceWizard/addSourceWizard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, Icon, Wizard } from 'patternfly-react';
-import helpers from '../../common/helpers';
 import { connect } from 'react-redux';
 import Store from '../../redux/store';
 import { confirmationModalTypes, sourcesTypes } from '../../redux/constants';
@@ -19,8 +18,6 @@ class AddSourceWizard extends React.Component {
     };
 
     this.state = { ...this.initialState };
-
-    helpers.bindMethods(this, ['onCancel', 'onStep', 'onNext', 'onBack', 'onSubmit']);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -42,7 +39,7 @@ class AddSourceWizard extends React.Component {
     }
   }
 
-  onCancel() {
+  onCancel = () => {
     const { fulfilled, error } = this.props;
 
     const closeWizard = () => {
@@ -67,13 +64,13 @@ class AddSourceWizard extends React.Component {
         onConfirm: closeWizard
       });
     }
-  }
+  };
 
-  onStep(stepIndex) {
+  onStep = () => {
     // ToDo: wizard step map/breadcrumb/trail click, or leave disabled
-  }
+  };
 
-  onNext() {
+  onNext = () => {
     const { activeStepIndex } = this.state;
     const { edit } = this.props;
     const numberSteps = edit ? editSourceWizardSteps.length : addSourceWizardSteps.length;
@@ -81,17 +78,17 @@ class AddSourceWizard extends React.Component {
     if (activeStepIndex < numberSteps - 1) {
       this.setState({ activeStepIndex: activeStepIndex + 1 });
     }
-  }
+  };
 
-  onBack() {
-    let { activeStepIndex } = this.state;
+  onBack = () => {
+    const { activeStepIndex } = this.state;
 
     if (activeStepIndex >= 1) {
       this.setState({ activeStepIndex: activeStepIndex - 1 });
     }
-  }
+  };
 
-  onSubmit(event) {
+  onSubmit = () => {
     const { addSource, updateSource, source, edit } = this.props;
     const { stepOneValid, stepTwoValid } = this.state;
 
@@ -114,7 +111,7 @@ class AddSourceWizard extends React.Component {
         });
       }
     }
-  }
+  };
 
   renderWizardSteps() {
     const { activeStepIndex } = this.state;
@@ -122,19 +119,17 @@ class AddSourceWizard extends React.Component {
     const wizardSteps = edit ? editSourceWizardSteps : addSourceWizardSteps;
     const activeStep = wizardSteps[activeStepIndex];
 
-    return wizardSteps.map((step, stepIndex) => {
-      return (
-        <Wizard.Step
-          key={stepIndex}
-          stepIndex={stepIndex}
-          step={step.step}
-          label={step.label}
-          title={step.title}
-          activeStep={activeStep && activeStep.step}
-          onClick={e => this.onStep(activeStep && activeStep.step)}
-        />
-      );
-    });
+    return wizardSteps.map((step, stepIndex) => (
+      <Wizard.Step
+        key={stepIndex}
+        stepIndex={stepIndex}
+        step={step.step}
+        label={step.label}
+        title={step.title}
+        activeStep={activeStep && activeStep.step}
+        onClick={() => this.onStep(activeStep && activeStep.step)}
+      />
+    ));
   }
 
   render() {
@@ -147,7 +142,7 @@ class AddSourceWizard extends React.Component {
         <Modal show={show} onHide={this.onCancel} dialogClassName="modal-dialog modal-lg wizard-pf quipucords-wizard">
           <Wizard>
             <Modal.Header>
-              <button className="close" onClick={this.onCancel} aria-hidden="true" aria-label="Close">
+              <button type="button" className="close" onClick={this.onCancel} aria-hidden="true" aria-label="Close">
                 <Icon type="pf" name="close" />
               </button>
               <Modal.Title>{edit ? 'Edit' : 'Add'} Source</Modal.Title>
@@ -156,13 +151,11 @@ class AddSourceWizard extends React.Component {
               <Wizard.Steps steps={this.renderWizardSteps()} />
               <Wizard.Row>
                 <Wizard.Main>
-                  {wizardSteps.map((step, stepIndex) => {
-                    return (
-                      <Wizard.Contents key={step.title} stepIndex={stepIndex} activeStepIndex={activeStepIndex}>
-                        {wizardSteps[stepIndex].page}
-                      </Wizard.Contents>
-                    );
-                  })}
+                  {wizardSteps.map((step, stepIndex) => (
+                    <Wizard.Contents key={step.title} stepIndex={stepIndex} activeStepIndex={activeStepIndex}>
+                      {wizardSteps[stepIndex].page}
+                    </Wizard.Contents>
+                  ))}
                 </Wizard.Main>
               </Wizard.Row>
             </Modal.Body>
@@ -220,16 +213,16 @@ AddSourceWizard.propTypes = {
   error: PropTypes.bool
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   addSource: (data, query) => dispatch(addSource(data, query)),
   updateSource: (id, data) => dispatch(updateSource(id, data))
 });
 
-const mapStateToProps = function(state) {
-  return { ...state.addSourceWizard.view };
-};
+const mapStateToProps = state => ({ ...state.addSourceWizard.view });
 
-export default connect(
+const ConnectedAddSourceWizard = connect(
   mapStateToProps,
   mapDispatchToProps
 )(AddSourceWizard);
+
+export { ConnectedAddSourceWizard as default, ConnectedAddSourceWizard, AddSourceWizard };

--- a/client/src/components/addSourceWizard/addSourceWizardField.js
+++ b/client/src/components/addSourceWizard/addSourceWizardField.js
@@ -1,9 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Form, Grid } from 'patternfly-react';
 import helpers from '../../common/helpers';
 
-const addSourceWizardField = ({ children, colLabel = 3, colField = 9, id, label, error, errorMessage, ...props }) => {
+const AddSourceWizardField = ({ children, colLabel = 3, colField = 9, id, label, error, errorMessage, ...props }) => {
   const setId = id || helpers.generateId();
 
   return (
@@ -19,7 +19,7 @@ const addSourceWizardField = ({ children, colLabel = 3, colField = 9, id, label,
   );
 };
 
-addSourceWizardField.propTypes = {
+AddSourceWizardField.propTypes = {
   children: PropTypes.node.isRequired,
   colLabel: PropTypes.number,
   colField: PropTypes.number,
@@ -29,6 +29,4 @@ addSourceWizardField.propTypes = {
   errorMessage: PropTypes.string
 };
 
-export { addSourceWizardField };
-
-export default addSourceWizardField;
+export { AddSourceWizardField as default, AddSourceWizardField };

--- a/client/src/components/addSourceWizard/addSourceWizardStepOne.js
+++ b/client/src/components/addSourceWizard/addSourceWizardStepOne.js
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Form, Radio } from 'patternfly-react';
+import _ from 'lodash';
 import Store from '../../redux/store';
-import helpers from '../../common/helpers';
 import { apiTypes } from '../../constants';
 import { sourcesTypes } from '../../redux/constants';
-import _ from 'lodash';
 
 class AddSourceWizardStepOne extends React.Component {
   constructor(props) {
@@ -18,20 +17,14 @@ class AddSourceWizardStepOne extends React.Component {
     };
 
     this.state = { ...this.initialState };
-
-    helpers.bindMethods(this, ['onChangeSourceType']);
   }
 
   componentDidMount() {
-    this.setState({ ...this.initializeState(this.props) }, () => {
+    const sourceType = _.get(this.props, ['source', apiTypes.API_SOURCE_TYPE], 'network');
+
+    this.setState({ sourceType }, () => {
       this.validateStep();
     });
-  }
-
-  initializeState(nextProps) {
-    return {
-      sourceType: _.get(nextProps, ['source', apiTypes.API_SOURCE_TYPE], 'network')
-    };
   }
 
   validateStep() {
@@ -46,14 +39,14 @@ class AddSourceWizardStepOne extends React.Component {
     }
   }
 
-  onChangeSourceType(event) {
+  onChangeSourceType = event => {
     this.setState(
       {
         sourceType: event.target.value
       },
       () => this.validateStep()
     );
-  }
+  };
 
   render() {
     const { sourceType, sourceTypeError } = this.state;
@@ -96,8 +89,8 @@ AddSourceWizardStepOne.propTypes = {
   source: PropTypes.object
 };
 
-const mapStateToProps = function(state) {
-  return { ...state.addSourceWizard.view };
-};
+const mapStateToProps = state => ({ ...state.addSourceWizard.view });
 
-export default connect(mapStateToProps)(AddSourceWizardStepOne);
+const ConnectedAddSourceWizardStepOne = connect(mapStateToProps)(AddSourceWizardStepOne);
+
+export { ConnectedAddSourceWizardStepOne as default, ConnectedAddSourceWizardStepOne, AddSourceWizardStepOne };

--- a/client/src/components/addSourceWizard/addSourceWizardStepThree.js
+++ b/client/src/components/addSourceWizard/addSourceWizardStepThree.js
@@ -44,8 +44,8 @@ AddSourceWizardStepThree.propTypes = {
   view: PropTypes.object
 };
 
-const mapStateToProps = function(state) {
-  return Object.assign({}, { view: state.addSourceWizard.view });
-};
+const mapStateToProps = state => ({ view: state.addSourceWizard.view });
 
-export default connect(mapStateToProps)(AddSourceWizardStepThree);
+const ConnectedAddSourceWizardStepThree = connect(mapStateToProps)(AddSourceWizardStepThree);
+
+export { ConnectedAddSourceWizardStepThree as default, ConnectedAddSourceWizardStepThree, AddSourceWizardStepThree };

--- a/client/src/components/addSourceWizard/addSourceWizardStepTwo.js
+++ b/client/src/components/addSourceWizard/addSourceWizardStepTwo.js
@@ -2,14 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { MenuItem, Button, Icon, Form, Grid, Checkbox } from 'patternfly-react';
+import _ from 'lodash';
 import Store from '../../redux/store';
 import helpers from '../../common/helpers';
 import DropdownSelect from '../dropdownSelect/dropdownSelect';
-import { addSourceWizardField as FieldGroup } from './addSourceWizardField';
+import { AddSourceWizardField as FieldGroup } from './addSourceWizardField';
 import { apiTypes } from '../../constants';
 import { sourcesTypes, credentialsTypes } from '../../redux/constants';
 import { getWizardCredentials } from '../../redux/actions/credentialsActions';
-import _ from 'lodash';
 
 class AddSourceWizardStepTwo extends React.Component {
   constructor(props) {
@@ -30,16 +30,6 @@ class AddSourceWizardStepTwo extends React.Component {
     };
 
     this.state = { ...this.initialState };
-
-    helpers.bindMethods(this, [
-      'onChangeSourceName',
-      'onChangeCredential',
-      'onClickCredential',
-      'onChangeHost',
-      'onChangeHosts',
-      'onChangePort',
-      'onChangeSslCertVerify'
-    ]);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -53,19 +43,19 @@ class AddSourceWizardStepTwo extends React.Component {
       }
 
       this.setState(Object.assign({ ...this.initialState }, { sslCertVerify }), () => {
-        this.invalidateStep();
+        AddSourceWizardStepTwo.invalidateStep();
       });
     }
   }
 
   componentDidMount() {
-    this.setState({ ...this.initializeState(this.props) }, () => {
+    this.setState({ ...AddSourceWizardStepTwo.initializeState(this.props) }, () => {
       this.props.getWizardCredentials();
       this.validateStep();
     });
   }
 
-  initializeState(nextProps) {
+  static initializeState(nextProps) {
     if (nextProps.source) {
       const credentials = _.get(nextProps.source, apiTypes.API_SOURCE_CREDENTIALS, []);
       let singlePort;
@@ -100,7 +90,7 @@ class AddSourceWizardStepTwo extends React.Component {
     return {};
   }
 
-  invalidateStep() {
+  static invalidateStep() {
     Store.dispatch({
       type: sourcesTypes.INVALID_SOURCE_WIZARD_STEPTWO
     });
@@ -129,7 +119,7 @@ class AddSourceWizardStepTwo extends React.Component {
       credentials.length &&
       !credentialsError
     ) {
-      let updatedSource = {};
+      const updatedSource = {};
 
       _.set(updatedSource, apiTypes.API_SOURCE_NAME, sourceName);
       _.set(updatedSource, apiTypes.API_SOURCE_HOSTS, hosts);
@@ -148,11 +138,11 @@ class AddSourceWizardStepTwo extends React.Component {
         source: Object.assign({ ...source }, updatedSource)
       });
     } else {
-      this.invalidateStep();
+      AddSourceWizardStepTwo.invalidateStep();
     }
   }
 
-  validateSourceName(value) {
+  static validateSourceName(value) {
     if (value === '') {
       return 'You must enter a source name';
     }
@@ -160,21 +150,21 @@ class AddSourceWizardStepTwo extends React.Component {
     return null;
   }
 
-  onChangeSourceName(event) {
+  onChangeSourceName = event => {
     this.setState(
       {
         sourceName: event.target.value,
-        sourceNameError: this.validateSourceName(event.target.value)
+        sourceNameError: AddSourceWizardStepTwo.validateSourceName(event.target.value)
       },
       () => this.validateStep()
     );
-  }
+  };
 
   credentialInfo(id) {
-    return _.find(this.props.allCredentials, { id: id }) || {};
+    return _.find(this.props.allCredentials, { id }) || {};
   }
 
-  validateCredentials(value) {
+  static validateCredentials(value) {
     if (!value.length) {
       return 'You must add a credential';
     }
@@ -182,18 +172,18 @@ class AddSourceWizardStepTwo extends React.Component {
     return null;
   }
 
-  onChangeCredential(event, value) {
+  onChangeCredential = (event, value) => {
     const { credentials } = this.state;
     const { source } = this.props;
 
-    let sourceType = _.get(source, apiTypes.API_SOURCE_TYPE);
+    const sourceType = _.get(source, apiTypes.API_SOURCE_TYPE);
     let submitCreds = [];
 
     if (sourceType === 'vcenter' || sourceType === 'satellite') {
       submitCreds = [value.id];
     } else {
       submitCreds = [...credentials];
-      let credentialIndex = submitCreds.indexOf(value.id);
+      const credentialIndex = submitCreds.indexOf(value.id);
 
       if (credentialIndex < 0) {
         submitCreds.push(value.id);
@@ -202,21 +192,22 @@ class AddSourceWizardStepTwo extends React.Component {
       }
     }
 
-    this.setState({ credentials: submitCreds, credentialsError: this.validateCredentials(submitCreds) }, () =>
-      this.validateStep()
+    this.setState(
+      { credentials: submitCreds, credentialsError: AddSourceWizardStepTwo.validateCredentials(submitCreds) },
+      () => this.validateStep()
     );
-  }
+  };
 
-  onClickCredential() {
+  onClickCredential = () => {
     const { source } = this.props;
 
     Store.dispatch({
       type: credentialsTypes.CREATE_CREDENTIAL_SHOW,
       credentialType: _.get(source, apiTypes.API_SOURCE_TYPE)
     });
-  }
+  };
 
-  validateHosts(value) {
+  static validateHosts(value) {
     let validation = null;
 
     if (value.length) {
@@ -234,13 +225,15 @@ class AddSourceWizardStepTwo extends React.Component {
           validation = 'You must enter a valid IP address or hostname';
           return false;
         }
+
+        return true;
       });
     }
 
     return validation;
   }
 
-  validateHost(value) {
+  static validateHost(value) {
     if (
       !new RegExp('^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$').test(value) &&
       !new RegExp('^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$', 'i').test(
@@ -253,7 +246,7 @@ class AddSourceWizardStepTwo extends React.Component {
     return null;
   }
 
-  validatePort(value) {
+  static validatePort(value) {
     if (value && value.length && !/^\d{1,4}$/.test(value)) {
       return 'Port must be valid';
     }
@@ -261,7 +254,7 @@ class AddSourceWizardStepTwo extends React.Component {
     return null;
   }
 
-  onChangePort(targetValue) {
+  onChangePort = targetValue => {
     const { source } = this.props;
     let value = targetValue;
     let defaultPort;
@@ -286,35 +279,32 @@ class AddSourceWizardStepTwo extends React.Component {
     this.setState(
       {
         port: value,
-        portError: this.validatePort(value)
+        portError: AddSourceWizardStepTwo.validatePort(value)
       },
       () => this.validateStep()
     );
-  }
+  };
 
-  onChangeSslCertVerify(event) {
+  onChangeSslCertVerify = event => {
     this.setState(
       {
         sslCertVerify: event.target.checked || false
       },
       () => this.validateStep()
     );
-  }
+  };
 
-  onChangeHost(event) {
-    let value = event.target.value;
+  onChangeHost = event => {
+    const { value } = event.target;
     let host = [];
     let port;
-    let hostPort;
-    let validateHost;
 
     if (value !== '') {
-      hostPort = value.split(':');
-      host = [hostPort[0]];
-      port = hostPort[1];
+      [host, port] = value.split(':');
+      host = [host];
     }
 
-    validateHost = this.validateHost(host);
+    const validateHost = AddSourceWizardStepTwo.validateHost(host);
     this.onChangePort(port || '');
 
     this.setState(
@@ -325,10 +315,10 @@ class AddSourceWizardStepTwo extends React.Component {
       },
       () => this.validateStep()
     );
-  }
+  };
 
-  onChangeHosts(event) {
-    const value = event.target.value;
+  onChangeHosts = event => {
+    const { value } = event.target;
     let hosts = [];
 
     if (value !== '') {
@@ -339,12 +329,12 @@ class AddSourceWizardStepTwo extends React.Component {
     this.setState(
       {
         multiHostDisplay: value,
-        hosts: hosts,
-        hostsError: this.validateHosts(hosts)
+        hosts,
+        hostsError: AddSourceWizardStepTwo.validateHosts(hosts)
       },
       () => this.validateStep()
     );
-  }
+  };
 
   renderHosts() {
     const { hostsError, port, portError, multiHostDisplay, singleHostPortDisplay } = this.state;
@@ -414,9 +404,7 @@ class AddSourceWizardStepTwo extends React.Component {
     const sourceType = _.get(source, apiTypes.API_SOURCE_TYPE);
     const hasSingleCredential = sourceType === 'vcenter' || sourceType === 'satellite';
 
-    const availableCredentials = allCredentials.filter(credential => {
-      return credential.cred_type === sourceType;
-    });
+    const availableCredentials = allCredentials.filter(credential => credential.cred_type === sourceType);
 
     let titleAddSelect;
     let title;
@@ -442,28 +430,26 @@ class AddSourceWizardStepTwo extends React.Component {
               multiselect={!hasSingleCredential}
             >
               {availableCredentials.length &&
-                availableCredentials.map((value, index) => {
-                  return (
-                    <MenuItem
-                      key={value.id}
-                      eventKey={index}
-                      className={{ 'quipucords-dropdownselect-menuitem-selected': credentials.indexOf(value.id) > -1 }}
-                      onSelect={e => this.onChangeCredential(e, value)}
-                    >
-                      {!hasSingleCredential && (
-                        <Grid.Row className="quipucords-dropdownselect-menuitem">
-                          <Grid.Col xs={10} className="quipucords-dropdownselect-menuitemname">
-                            {value.name}
-                          </Grid.Col>
-                          <Grid.Col xs={2} className="quipucords-dropdownselect-menuitemcheck">
-                            {credentials.indexOf(value.id) > -1 && <Icon type="fa" name="check" />}
-                          </Grid.Col>
-                        </Grid.Row>
-                      )}
-                      {hasSingleCredential && value.name}
-                    </MenuItem>
-                  );
-                })}
+                availableCredentials.map((value, index) => (
+                  <MenuItem
+                    key={value.id}
+                    eventKey={index}
+                    className={{ 'quipucords-dropdownselect-menuitem-selected': credentials.indexOf(value.id) > -1 }}
+                    onSelect={e => this.onChangeCredential(e, value)}
+                  >
+                    {!hasSingleCredential && (
+                      <Grid.Row className="quipucords-dropdownselect-menuitem">
+                        <Grid.Col xs={10} className="quipucords-dropdownselect-menuitemname">
+                          {value.name}
+                        </Grid.Col>
+                        <Grid.Col xs={2} className="quipucords-dropdownselect-menuitemcheck">
+                          {credentials.indexOf(value.id) > -1 && <Icon type="fa" name="check" />}
+                        </Grid.Col>
+                      </Grid.Row>
+                    )}
+                    {hasSingleCredential && value.name}
+                  </MenuItem>
+                ))}
             </DropdownSelect>
           </div>
           <Form.InputGroup.Button>
@@ -531,15 +517,15 @@ AddSourceWizardStepTwo.propTypes = {
   allCredentials: PropTypes.array
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   getWizardCredentials: () => dispatch(getWizardCredentials())
 });
 
-const mapStateToProps = function(state) {
-  return { ...state.addSourceWizard.view };
-};
+const mapStateToProps = state => ({ ...state.addSourceWizard.view });
 
-export default connect(
+const ConnectedAddSourceWizardStepTwo = connect(
   mapStateToProps,
   mapDispatchToProps
 )(AddSourceWizardStepTwo);
+
+export { ConnectedAddSourceWizardStepTwo as default, ConnectedAddSourceWizardStepTwo, AddSourceWizardStepTwo };

--- a/client/src/components/app.js
+++ b/client/src/components/app.js
@@ -59,17 +59,15 @@ class App extends React.Component {
 
     const activeItem = this.menu.find(item => _.startsWith(location.pathname, item.to));
 
-    return this.menu.map(item => {
-      return (
-        <VerticalNav.Item
-          key={item.to}
-          title={item.title}
-          iconClass={item.iconClass}
-          active={item === activeItem || (!activeItem && item.redirect)}
-          onClick={() => this.navigateTo(item.to)}
-        />
-      );
-    });
+    return this.menu.map(item => (
+      <VerticalNav.Item
+        key={item.to}
+        title={item.title}
+        iconClass={item.iconClass}
+        active={item === activeItem || (!activeItem && item.redirect)}
+        onClick={() => this.navigateTo(item.to)}
+      />
+    ));
   }
 
   renderMenuActions() {
@@ -184,20 +182,18 @@ App.propTypes = {
   }).isRequired
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   authorizeUser: () => dispatch(authorizeUser()),
   getUser: () => dispatch(getUser()),
   logoutUser: () => dispatch(logoutUser()),
   getStatus: () => dispatch(getStatus())
 });
 
-const mapStateToProps = function(state) {
-  return {
-    session: state.user.session,
-    user: state.user.user,
-    status: state.status.currentStatus
-  };
-};
+const mapStateToProps = state => ({
+  session: state.user.session,
+  user: state.user.user,
+  status: state.status.currentStatus
+});
 
 export default withRouter(
   connect(

--- a/client/src/components/confirmationModal/__tests__/__snapshots__/confirmationModal.test.js.snap
+++ b/client/src/components/confirmationModal/__tests__/__snapshots__/confirmationModal.test.js.snap
@@ -36,6 +36,7 @@ exports[`ConfirmationModal Component should shallow render a basic component 1`]
       aria-label="Close"
       className="close"
       onClick={[Function]}
+      type="button"
     >
       <Icon
         name="close"

--- a/client/src/components/confirmationModal/__tests__/confirmationModal.test.js
+++ b/client/src/components/confirmationModal/__tests__/confirmationModal.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import ConfirmationModal from '../confirmationModal';
 
-describe('ConfirmationModal Component', function() {
+describe('ConfirmationModal Component', () => {
   const generateEmptyStore = () => configureMockStore()({ confirmationModal: {} });
 
   it('should shallow render a basic component', () => {

--- a/client/src/components/confirmationModal/confirmationModal.js
+++ b/client/src/components/confirmationModal/confirmationModal.js
@@ -29,7 +29,7 @@ class ConfirmationModal extends React.Component {
     return (
       <Modal show={show} onHide={this.cancel}>
         <Modal.Header>
-          <button className="close" onClick={this.cancel} aria-hidden="true" aria-label="Close">
+          <button type="button" className="close" onClick={this.cancel} aria-hidden="true" aria-label="Close">
             <Icon type="pf" name="close" />
           </button>
           <Modal.Title>{title}</Modal.Title>
@@ -78,8 +78,8 @@ ConfirmationModal.defaultProps = {
   confirmButtonText: 'Confirm'
 };
 
-const mapStateToProps = function(state) {
-  return { ...state.confirmationModal };
-};
+const mapStateToProps = state => ({ ...state.confirmationModal });
 
-export default connect(mapStateToProps)(ConfirmationModal);
+const ConnectedConfirmationModal = connect(mapStateToProps)(ConfirmationModal);
+
+export { ConnectedConfirmationModal as default, ConnectedConfirmationModal, ConfirmationModal };

--- a/client/src/components/content/__tests__/content.test.js
+++ b/client/src/components/content/__tests__/content.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Content from '../content';
 
-describe('ConfirmationModal Component', function() {
+describe('ConfirmationModal Component', () => {
   it('should shallow render a basic component', () => {
     const wrapper = shallow(<Content />);
 

--- a/client/src/components/content/content.js
+++ b/client/src/components/content/content.js
@@ -3,7 +3,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import { routes } from '../../routes';
 
 class Content extends React.Component {
-  renderRoutes() {
+  static renderRoutes() {
     let redirectRoot = null;
 
     return {
@@ -19,7 +19,7 @@ class Content extends React.Component {
   }
 
   render() {
-    const { renderRoutes, redirectRoot } = this.renderRoutes();
+    const { renderRoutes, redirectRoot } = Content.renderRoutes();
 
     return (
       <div className="quipucords-content">
@@ -32,4 +32,4 @@ class Content extends React.Component {
   }
 }
 
-export default Content;
+export { Content as default, Content };

--- a/client/src/components/createCredentialDialog/__tests__/createCredentialDialog.test.js
+++ b/client/src/components/createCredentialDialog/__tests__/createCredentialDialog.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import CreateCredentialDialog from '../createCredentialDialog';
 
-describe('CreateCredentialDialog Component', function() {
+describe('CreateCredentialDialog Component', () => {
   const generateEmptyStore = () => configureMockStore()({ credentials: {}, viewOptions: {} });
 
   it('should shallow render a basic component', () => {

--- a/client/src/components/createCredentialDialog/createCredentialDialog.js
+++ b/client/src/components/createCredentialDialog/createCredentialDialog.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Store from '../../redux/store';
 import { Modal, Alert, Button, Icon, Form, Grid, MenuItem } from 'patternfly-react';
+import Store from '../../redux/store';
 import { helpers } from '../../common/helpers';
 import { credentialsTypes, toastNotificationTypes, viewTypes } from '../../redux/constants';
 import {
@@ -41,8 +41,6 @@ class CreateCredentialDialog extends React.Component {
     this.sshKeyFileValidator = new RegExp(/^\/.*$/);
 
     this.becomeMethods = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas'];
-
-    helpers.bindMethods(this, ['cancel', 'save']);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -62,7 +60,7 @@ class CreateCredentialDialog extends React.Component {
         )
       });
 
-      this.cancel();
+      this.onCancel();
       this.props.getCredentials(helpers.createViewQueryObject(this.props.viewOptions));
     }
   }
@@ -105,14 +103,14 @@ class CreateCredentialDialog extends React.Component {
     }
   }
 
-  cancel() {
+  onCancel = () => {
     Store.dispatch({
       type: credentialsTypes.UPDATE_CREDENTIAL_HIDE
     });
-  }
+  };
 
-  save() {
-    let credential = {
+  onSave = () => {
+    const credential = {
       username: this.state.username,
       name: this.state.credentialName
     };
@@ -147,7 +145,7 @@ class CreateCredentialDialog extends React.Component {
         this.props.getWizardCredentials();
       });
     }
-  }
+  };
 
   setAuthType(authType) {
     this.setState({ authorizationType: authType });
@@ -165,7 +163,7 @@ class CreateCredentialDialog extends React.Component {
     );
   }
 
-  validateCredentialName(credentialName) {
+  static validateCredentialName(credentialName) {
     if (!credentialName) {
       return 'You must enter a credential name';
     }
@@ -180,11 +178,11 @@ class CreateCredentialDialog extends React.Component {
   updateCredentialName(event) {
     this.setState({
       credentialName: event.target.value,
-      credentialNameError: this.validateCredentialName(event.target.value)
+      credentialNameError: CreateCredentialDialog.validateCredentialName(event.target.value)
     });
   }
 
-  validateUsername(username) {
+  static validateUsername(username) {
     if (!username || !username.length) {
       return 'You must enter a user name';
     }
@@ -195,11 +193,11 @@ class CreateCredentialDialog extends React.Component {
   updateUsername(event) {
     this.setState({
       username: event.target.value,
-      usernameError: this.validateUsername(event.target.value)
+      usernameError: CreateCredentialDialog.validateUsername(event.target.value)
     });
   }
 
-  validatePassword(password) {
+  static validatePassword(password) {
     if (!password || !password.length) {
       return 'You must enter a password';
     }
@@ -210,7 +208,7 @@ class CreateCredentialDialog extends React.Component {
   updatePassword(event) {
     this.setState({
       password: event.target.value,
-      passwordError: this.validatePassword(event.target.value)
+      passwordError: CreateCredentialDialog.validatePassword(event.target.value)
     });
   }
 
@@ -253,7 +251,7 @@ class CreateCredentialDialog extends React.Component {
     });
   }
 
-  renderFormLabel(label) {
+  static renderFormLabel(label) {
     return (
       <Grid.Col componentClass={Form.ControlLabel} sm={5}>
         {label}
@@ -276,7 +274,7 @@ class CreateCredentialDialog extends React.Component {
       case 'usernamePassword':
         return (
           <Form.FormGroup validationState={passwordError ? 'error' : null}>
-            {this.renderFormLabel('Password')}
+            {CreateCredentialDialog.renderFormLabel('Password')}
             <Grid.Col sm={7}>
               <Form.FormControl
                 type="password"
@@ -296,7 +294,7 @@ class CreateCredentialDialog extends React.Component {
         return (
           <React.Fragment>
             <Form.FormGroup validationState={sskKeyFileError ? 'error' : null}>
-              {this.renderFormLabel('SSH Key File')}
+              {CreateCredentialDialog.renderFormLabel('SSH Key File')}
               <Grid.Col sm={7}>
                 <Form.FormControl
                   type="text"
@@ -308,7 +306,7 @@ class CreateCredentialDialog extends React.Component {
               </Grid.Col>
             </Form.FormGroup>
             <Form.FormGroup>
-              {this.renderFormLabel('Passphrase')}
+              {CreateCredentialDialog.renderFormLabel('Passphrase')}
               <Grid.Col sm={7}>
                 <Form.FormControl
                   type="password"
@@ -335,7 +333,7 @@ class CreateCredentialDialog extends React.Component {
     return (
       <React.Fragment>
         <Form.FormGroup>
-          {this.renderFormLabel('Become Method')}
+          {CreateCredentialDialog.renderFormLabel('Become Method')}
           <Grid.Col sm={7}>
             <div className="quipucords-dropdownselect">
               <DropdownSelect
@@ -359,7 +357,7 @@ class CreateCredentialDialog extends React.Component {
           </Grid.Col>
         </Form.FormGroup>
         <Form.FormGroup validationState={becomeUserError ? 'error' : null}>
-          {this.renderFormLabel('Become User')}
+          {CreateCredentialDialog.renderFormLabel('Become User')}
           <Grid.Col sm={7}>
             <Form.FormControl
               type="text"
@@ -370,7 +368,7 @@ class CreateCredentialDialog extends React.Component {
           </Grid.Col>
         </Form.FormGroup>
         <Form.FormGroup>
-          {this.renderFormLabel('Become Password')}
+          {CreateCredentialDialog.renderFormLabel('Become Password')}
           <Grid.Col sm={7}>
             <Form.FormControl
               type="password"
@@ -384,18 +382,18 @@ class CreateCredentialDialog extends React.Component {
     );
   }
 
-  errorDismissed() {
+  onErrorDismissed = () => {
     Store.dispatch({
       type: credentialsTypes.RESET_CREDENTIAL_UPDATE_STATUS
     });
-  }
+  };
 
   renderErrorMessage() {
     const { error, errorMessage } = this.props;
 
     if (error) {
       return (
-        <Alert type="error" onDismiss={this.errorDismissed}>
+        <Alert type="error" onDismiss={this.onErrorDismissed}>
           <strong>Error</strong> {errorMessage}
         </Alert>
       );
@@ -417,9 +415,9 @@ class CreateCredentialDialog extends React.Component {
     } = this.state;
 
     return (
-      <Modal show={show} onHide={this.cancel}>
+      <Modal show={show} onHide={this.onCancel}>
         <Modal.Header>
-          <Button className="close" onClick={this.cancel} aria-hidden="true" aria-label="Close">
+          <Button className="close" onClick={this.onCancel} aria-hidden="true" aria-label="Close">
             <Icon type="pf" name="close" />
           </Button>
           <Modal.Title>{edit ? `Edit Credential - ${credentialName}` : 'Add Credential'}</Modal.Title>
@@ -429,7 +427,7 @@ class CreateCredentialDialog extends React.Component {
           {this.renderErrorMessage()}
           <Form horizontal>
             <Form.FormGroup>
-              {this.renderFormLabel('Source Type')}
+              {CreateCredentialDialog.renderFormLabel('Source Type')}
               <Grid.Col sm={7}>
                 <Form.FormControl
                   className="quipucords-form-control"
@@ -440,7 +438,7 @@ class CreateCredentialDialog extends React.Component {
               </Grid.Col>
             </Form.FormGroup>
             <Form.FormGroup validationState={credentialNameError ? 'error' : null}>
-              {this.renderFormLabel('Credential Name')}
+              {CreateCredentialDialog.renderFormLabel('Credential Name')}
               <Grid.Col sm={7}>
                 <Form.FormControl
                   type="text"
@@ -455,7 +453,7 @@ class CreateCredentialDialog extends React.Component {
             </Form.FormGroup>
             {!sshKeyDisabled && (
               <Form.FormGroup>
-                {this.renderFormLabel('Authentication Type')}
+                {CreateCredentialDialog.renderFormLabel('Authentication Type')}
                 <Grid.Col sm={7}>
                   <div className="quipucords-dropdownselect">
                     <DropdownSelect
@@ -488,7 +486,7 @@ class CreateCredentialDialog extends React.Component {
               </Form.FormGroup>
             )}
             <Form.FormGroup validationState={usernameError ? 'error' : null}>
-              {this.renderFormLabel('Username')}
+              {CreateCredentialDialog.renderFormLabel('Username')}
               <Grid.Col sm={7}>
                 <Form.FormControl
                   type="text"
@@ -504,10 +502,10 @@ class CreateCredentialDialog extends React.Component {
           </Form>
         </Grid>
         <Modal.Footer>
-          <Button bsStyle="default" className="btn-cancel" autoFocus={edit} onClick={this.cancel}>
+          <Button bsStyle="default" className="btn-cancel" autoFocus={edit} onClick={this.onCancel}>
             Cancel
           </Button>
-          <Button bsStyle="primary" onClick={this.save} disabled={!this.validateForm()}>
+          <Button bsStyle="primary" onClick={this.onSave} disabled={!this.validateForm()}>
             Save
           </Button>
         </Modal.Footer>
@@ -531,20 +529,21 @@ CreateCredentialDialog.propTypes = {
   viewOptions: PropTypes.object
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   getCredentials: queryObj => dispatch(getCredentials(queryObj)),
   getWizardCredentials: () => dispatch(getWizardCredentials()),
   addCredential: data => dispatch(addCredential(data)),
   updateCredential: (id, data) => dispatch(updateCredential(id, data))
 });
 
-const mapStateToProps = function(state) {
-  return Object.assign({}, state.credentials.update, {
+const mapStateToProps = state =>
+  Object.assign({}, state.credentials.update, {
     viewOptions: state.viewOptions[viewTypes.CREDENTIALS_VIEW]
   });
-};
 
-export default connect(
+const ConnectedCreateCredentialDialog = connect(
   mapStateToProps,
   mapDispatchToProps
 )(CreateCredentialDialog);
+
+export { ConnectedCreateCredentialDialog as default, ConnectedCreateCredentialDialog, CreateCredentialDialog };

--- a/client/src/components/credentials/__tests__/credentialsEmptyState.test.js
+++ b/client/src/components/credentials/__tests__/credentialsEmptyState.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import CredentialsEmptyState from '../credentialsEmptyState';
 
-describe('CredentialsEmptyState Component', function() {
+describe('CredentialsEmptyState Component', () => {
   it('should render a basic component', () => {
     const props = {};
 

--- a/client/src/components/credentials/__tests__/credentialsListItem.test.js
+++ b/client/src/components/credentials/__tests__/credentialsListItem.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import CredentialListItem from '../credentialListItem';
 import { mount } from 'enzyme';
-import { viewTypes } from '../../../redux/constants/';
+import CredentialListItem from '../credentialListItem';
+import { viewTypes } from '../../../redux/constants';
 
-describe('CredentialListItem Component', function() {
+describe('CredentialListItem Component', () => {
   const generateEmptyStore = () =>
     configureMockStore()({ credentials: {}, viewOptions: { [viewTypes.CREDENTIALS_VIEW]: {} } });
 

--- a/client/src/components/credentials/credentialListItem.js
+++ b/client/src/components/credentials/credentialListItem.js
@@ -1,9 +1,9 @@
-import _ from 'lodash';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import cx from 'classnames';
-import PropTypes from 'prop-types';
 import { ListView, Button, Grid, Icon, Checkbox } from 'patternfly-react';
+import _ from 'lodash';
 import { helpers } from '../../common/helpers';
 import SimpleTooltip from '../simpleTooltIp/simpleTooltip';
 import Store from '../../redux/store';
@@ -19,22 +19,13 @@ class CredentialListItem extends React.Component {
   expandType() {
     const { item, expandedCredentials } = this.props;
 
-    return _.get(
-      _.find(expandedCredentials, nextExpanded => {
-        return nextExpanded.id === item.id;
-      }),
-      'expandType'
-    );
+    return _.get(_.find(expandedCredentials, nextExpanded => nextExpanded.id === item.id), 'expandType');
   }
 
   isSelected() {
     const { item, selectedCredentials } = this.props;
 
-    return (
-      _.find(selectedCredentials, nextSelected => {
-        return nextSelected.id === item.id;
-      }) !== undefined
-    );
+    return _.find(selectedCredentials, nextSelected => nextSelected.id === item.id) !== undefined;
   }
 
   itemSelectChange() {
@@ -43,7 +34,7 @@ class CredentialListItem extends React.Component {
     Store.dispatch({
       type: this.isSelected() ? viewTypes.DESELECT_ITEM : viewTypes.SELECT_ITEM,
       viewType: viewTypes.CREDENTIALS_VIEW,
-      item: item
+      item
     });
   }
 
@@ -54,14 +45,14 @@ class CredentialListItem extends React.Component {
       Store.dispatch({
         type: viewTypes.EXPAND_ITEM,
         viewType: viewTypes.CREDENTIALS_VIEW,
-        item: item
+        item
       });
     } else {
       Store.dispatch({
         type: viewTypes.EXPAND_ITEM,
         viewType: viewTypes.CREDENTIALS_VIEW,
-        item: item,
-        expandType: expandType
+        item,
+        expandType
       });
     }
   }
@@ -71,7 +62,7 @@ class CredentialListItem extends React.Component {
     Store.dispatch({
       type: viewTypes.EXPAND_ITEM,
       viewType: viewTypes.CREDENTIALS_VIEW,
-      item: item
+      item
     });
   }
 
@@ -107,7 +98,7 @@ class CredentialListItem extends React.Component {
   renderStatusItems() {
     const { item } = this.props;
 
-    let sourceCount = item.sources ? item.sources.length : 0;
+    const sourceCount = item.sources ? item.sources.length : 0;
 
     return [
       <ListView.InfoItem
@@ -133,27 +124,22 @@ class CredentialListItem extends React.Component {
 
     switch (this.expandType(item, expandedCredentials)) {
       case 'sources':
-        item.sources &&
-          item.sources.sort((item1, item2) => {
-            return item1.name.localeCompare(item2.name);
-          });
+        (item.sources || []).sort((item1, item2) => item1.name.localeCompare(item2.name));
         return (
           <Grid fluid>
             {item.sources &&
-              item.sources.map((source, index) => {
-                return (
-                  <Grid.Row key={index}>
-                    <Grid.Col xs={12} sm={4}>
-                      <span>
-                        <SimpleTooltip id="sourceTypeTip" tooltip={helpers.sourceTypeString(source.source_type)}>
-                          <Icon type={typeIcon.type} name={typeIcon.name} />
-                        </SimpleTooltip>
-                        &nbsp; {source.name}
-                      </span>
-                    </Grid.Col>
-                  </Grid.Row>
-                );
-              })}
+              item.sources.map((source, index) => (
+                <Grid.Row key={index}>
+                  <Grid.Col xs={12} sm={4}>
+                    <span>
+                      <SimpleTooltip id="sourceTypeTip" tooltip={helpers.sourceTypeString(source.source_type)}>
+                        <Icon type={typeIcon.type} name={typeIcon.name} />
+                      </SimpleTooltip>
+                      &nbsp; {source.name}
+                    </span>
+                  </Grid.Col>
+                </Grid.Row>
+              ))}
           </Grid>
         );
       default:
@@ -214,11 +200,11 @@ CredentialListItem.propTypes = {
   expandedCredentials: PropTypes.array
 };
 
-const mapStateToProps = function(state) {
-  return Object.assign({
-    selectedCredentials: state.viewOptions[viewTypes.CREDENTIALS_VIEW].selectedItems,
-    expandedCredentials: state.viewOptions[viewTypes.CREDENTIALS_VIEW].expandedItems
-  });
-};
+const mapStateToProps = state => ({
+  selectedCredentials: state.viewOptions[viewTypes.CREDENTIALS_VIEW].selectedItems,
+  expandedCredentials: state.viewOptions[viewTypes.CREDENTIALS_VIEW].expandedItems
+});
 
-export default connect(mapStateToProps)(CredentialListItem);
+const ConnectedCredentialListItem = connect(mapStateToProps)(CredentialListItem);
+
+export { ConnectedCredentialListItem as default, ConnectedCredentialListItem, CredentialListItem };

--- a/client/src/components/credentials/credentials.js
+++ b/client/src/components/credentials/credentials.js
@@ -1,10 +1,8 @@
-import _ from 'lodash';
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
 import { Alert, Button, DropdownButton, EmptyState, Form, Grid, ListView, MenuItem, Modal } from 'patternfly-react';
-
+import _ from 'lodash';
 import { getCredentials, deleteCredential } from '../../redux/actions/credentialsActions';
 import {
   confirmationModalTypes,
@@ -16,10 +14,8 @@ import {
 } from '../../redux/constants';
 import Store from '../../redux/store';
 import helpers from '../../common/helpers';
-
 import ViewToolbar from '../viewToolbar/viewToolbar';
 import ViewPaginationRow from '../viewPaginationRow/viewPaginationRow';
-
 import CredentialsEmptyState from './credentialsEmptyState';
 import CredentialListItem from './credentialListItem';
 import { CredentialFilterFields, CredentialSortFields } from './crendentialConstants';
@@ -27,15 +23,6 @@ import { CredentialFilterFields, CredentialSortFields } from './crendentialConst
 class Credentials extends React.Component {
   constructor() {
     super();
-
-    helpers.bindMethods(this, [
-      'addCredential',
-      'deleteCredentials',
-      'editCredential',
-      'deleteCredential',
-      'addSource',
-      'refresh'
-    ]);
 
     this.credentialsToDelete = [];
     this.deletingCredential = null;
@@ -46,7 +33,7 @@ class Credentials extends React.Component {
   }
 
   componentDidMount() {
-    this.refresh();
+    this.onRefresh();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -67,7 +54,7 @@ class Credentials extends React.Component {
 
     // Check for changes resulting in a fetch
     if (helpers.viewPropsChanged(nextProps.viewOptions, this.props.viewOptions)) {
-      this.refresh(nextProps);
+      this.onRefresh(nextProps);
     }
 
     if (_.get(nextProps, 'update.delete')) {
@@ -81,7 +68,7 @@ class Credentials extends React.Component {
             </span>
           )
         });
-        this.refresh(nextProps);
+        this.onRefresh(nextProps);
 
         Store.dispatch({
           type: viewTypes.DESELECT_ITEM,
@@ -110,12 +97,12 @@ class Credentials extends React.Component {
     }
   }
 
-  addCredential(credentialType) {
+  onAddCredential = credentialType => {
     Store.dispatch({
       type: credentialsTypes.CREATE_CREDENTIAL_SHOW,
       credentialType
     });
-  }
+  };
 
   deleteNextCredential() {
     if (this.credentialsToDelete.length > 0) {
@@ -136,22 +123,22 @@ class Credentials extends React.Component {
     this.deleteNextCredential();
   }
 
-  deleteCredentials() {
+  onDeleteCredentials = () => {
     const { viewOptions } = this.props;
 
     if (viewOptions.selectedItems.length === 1) {
-      this.deleteCredential(viewOptions.selectedItems[0]);
+      this.onDeleteCredential(viewOptions.selectedItems[0]);
       return;
     }
 
-    let heading = <span>Are you sure you want to delete the following credentials?</span>;
+    const heading = <span>Are you sure you want to delete the following credentials?</span>;
 
     let credentialsList = '';
     viewOptions.selectedItems.forEach((item, index) => {
-      return (credentialsList += (index > 0 ? '\n' : '') + item.name);
+      credentialsList += (index > 0 ? '\n' : '') + item.name;
     });
 
-    let body = (
+    const body = (
       <Grid.Col sm={12}>
         <Form.FormControl
           className="quipucords-form-control"
@@ -164,60 +151,60 @@ class Credentials extends React.Component {
       </Grid.Col>
     );
 
-    let onConfirm = () => this.doDeleteCredentials(viewOptions.selectedItems);
+    const onConfirm = () => this.doDeleteCredentials(viewOptions.selectedItems);
 
     Store.dispatch({
       type: confirmationModalTypes.CONFIRMATION_MODAL_SHOW,
       title: 'Delete Credentials',
-      heading: heading,
-      body: body,
+      heading,
+      body,
       confirmButtonText: 'Delete',
-      onConfirm: onConfirm
+      onConfirm
     });
-  }
+  };
 
-  editCredential(item) {
+  onEditCredential = item => {
     Store.dispatch({
       type: credentialsTypes.EDIT_CREDENTIAL_SHOW,
       credential: item
     });
-  }
+  };
 
-  deleteCredential(item) {
-    let heading = (
+  onDeleteCredential = item => {
+    const heading = (
       <span>
         Are you sure you want to delete the credential <strong>{item.name}</strong>?
       </span>
     );
 
-    let onConfirm = () => this.doDeleteCredentials([item]);
+    const onConfirm = () => this.doDeleteCredentials([item]);
 
     Store.dispatch({
       type: confirmationModalTypes.CONFIRMATION_MODAL_SHOW,
       title: 'Delete Credential',
-      heading: heading,
+      heading,
       confirmButtonText: 'Delete',
-      onConfirm: onConfirm
+      onConfirm
     });
-  }
+  };
 
-  addSource() {
+  onAddSource = () => {
     Store.dispatch({
       type: sourcesTypes.CREATE_SOURCE_SHOW
     });
-  }
+  };
 
-  refresh(props) {
+  onRefresh = props => {
     const options = _.get(props, 'viewOptions') || this.props.viewOptions;
     this.props.getCredentials(helpers.createViewQueryObject(options));
-  }
+  };
 
-  clearFilters() {
+  onClearFilters = () => {
     Store.dispatch({
       type: viewToolbarTypes.CLEAR_FILTERS,
       viewType: viewTypes.CREDENTIALS_VIEW
     });
-  }
+  };
 
   renderCredentialActions() {
     const { viewOptions } = this.props;
@@ -225,19 +212,19 @@ class Credentials extends React.Component {
     return (
       <div className="form-group">
         <DropdownButton bsStyle="primary" title="Add" pullRight id="createCredentialButton">
-          <MenuItem eventKey="1" onClick={() => this.addCredential('network')}>
+          <MenuItem eventKey="1" onClick={() => this.onAddCredential('network')}>
             Network Credential
           </MenuItem>
-          <MenuItem eventKey="2" onClick={() => this.addCredential('satellite')}>
+          <MenuItem eventKey="2" onClick={() => this.onAddCredential('satellite')}>
             Satellite Credential
           </MenuItem>
-          <MenuItem eventKey="2" onClick={() => this.addCredential('vcenter')}>
+          <MenuItem eventKey="2" onClick={() => this.onAddCredential('vcenter')}>
             VCenter Credential
           </MenuItem>
         </DropdownButton>
         <Button
           disabled={!viewOptions.selectedItems || viewOptions.selectedItems.length === 0}
-          onClick={this.deleteCredentials}
+          onClick={this.onDeleteCredentials}
         >
           Delete
         </Button>
@@ -267,7 +254,12 @@ class Credentials extends React.Component {
       return (
         <ListView className="quipicords-list-view">
           {items.map((item, index) => (
-            <CredentialListItem item={item} key={index} onEdit={this.editCredential} onDelete={this.deleteCredential} />
+            <CredentialListItem
+              item={item}
+              key={index}
+              onEdit={this.onEditCredential}
+              onDelete={this.onDeleteCredential}
+            />
           ))}
         </ListView>
       );
@@ -278,7 +270,7 @@ class Credentials extends React.Component {
         <EmptyState.Title>No Results Match the Filter Criteria</EmptyState.Title>
         <EmptyState.Info>The active filters are hiding all items.</EmptyState.Info>
         <EmptyState.Action>
-          <Button bsStyle="link" onClick={this.clearFilters}>
+          <Button bsStyle="link" onClick={this.onClearFilters}>
             Clear Filters
           </Button>
         </EmptyState.Action>
@@ -309,7 +301,7 @@ class Credentials extends React.Component {
               viewType={viewTypes.CREDENTIALS_VIEW}
               filterFields={CredentialFilterFields}
               sortFields={CredentialSortFields}
-              onRefresh={this.refresh}
+              onRefresh={this.onRefresh}
               lastRefresh={lastRefresh}
               actions={this.renderCredentialActions()}
               itemsType="Credential"
@@ -328,7 +320,7 @@ class Credentials extends React.Component {
     return (
       <React.Fragment>
         {this.renderPendingMessage()}
-        <CredentialsEmptyState onAddCredential={this.addCredential} onAddSource={this.addSource} />,
+        <CredentialsEmptyState onAddCredential={this.onAddCredential} onAddSource={this.onAddSource} />,
       </React.Fragment>
     );
   }
@@ -346,19 +338,20 @@ Credentials.propTypes = {
   update: PropTypes.object
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   getCredentials: queryObj => dispatch(getCredentials(queryObj)),
   deleteCredential: id => dispatch(deleteCredential(id))
 });
 
-const mapStateToProps = function(state) {
-  return Object.assign({}, state.credentials.view, {
+const mapStateToProps = state =>
+  Object.assign({}, state.credentials.view, {
     viewOptions: state.viewOptions[viewTypes.CREDENTIALS_VIEW],
     update: state.credentials.update
   });
-};
 
-export default connect(
+const ConnectedCredentials = connect(
   mapStateToProps,
   mapDispatchToProps
 )(Credentials);
+
+export { ConnectedCredentials as default, ConnectedCredentials, Credentials };

--- a/client/src/components/credentials/credentialsEmptyState.js
+++ b/client/src/components/credentials/credentialsEmptyState.js
@@ -3,51 +3,43 @@ import PropTypes from 'prop-types';
 import { Button, DropdownButton, EmptyState, Grid, MenuItem, Row } from 'patternfly-react';
 import helpers from '../../common/helpers';
 
-const CredentialsEmptyState = ({ onAddCredential, onAddSource }) => {
-  return (
-    <Grid fluid>
-      <Row>
-        <EmptyState className="full-page-blank-slate">
-          <EmptyState.Icon />
-          <EmptyState.Title>Welcome to {helpers.RH_BRAND && 'Red Hat'} Entitlements Reporting</EmptyState.Title>
-          <EmptyState.Info>
-            Credentials contain authentication information needed to scan a source. A credential includes <br />a
-            username and a password or SSH key. Entitlements Reporting uses SSH to connect to servers <br /> on the
-            network and uses credentials to access those servers.
-          </EmptyState.Info>
-          <EmptyState.Action>
-            <DropdownButton
-              bsStyle="primary"
-              bsSize="large"
-              title="Add Credential"
-              pullRight
-              id="createCredentialButton"
-            >
-              <MenuItem eventKey="1" onClick={() => onAddCredential('network')}>
-                Network Credential
-              </MenuItem>
-              <MenuItem eventKey="2" onClick={() => onAddCredential('satellite')}>
-                Satellite Credential
-              </MenuItem>
-              <MenuItem eventKey="2" onClick={() => onAddCredential('vcenter')}>
-                VCenter Credential
-              </MenuItem>
-            </DropdownButton>
-          </EmptyState.Action>
-          <EmptyState.Action secondary>
-            <Button bsStyle="default" onClick={onAddSource}>
-              Add Source
-            </Button>
-          </EmptyState.Action>
-        </EmptyState>
-      </Row>
-    </Grid>
-  );
-};
+const CredentialsEmptyState = ({ onAddCredential, onAddSource }) => (
+  <Grid fluid>
+    <Row>
+      <EmptyState className="full-page-blank-slate">
+        <EmptyState.Icon />
+        <EmptyState.Title>Welcome to {helpers.RH_BRAND && 'Red Hat'} Entitlements Reporting</EmptyState.Title>
+        <EmptyState.Info>
+          Credentials contain authentication information needed to scan a source. A credential includes <br />a username
+          and a password or SSH key. Entitlements Reporting uses SSH to connect to servers <br /> on the network and
+          uses credentials to access those servers.
+        </EmptyState.Info>
+        <EmptyState.Action>
+          <DropdownButton bsStyle="primary" bsSize="large" title="Add Credential" pullRight id="createCredentialButton">
+            <MenuItem eventKey="1" onClick={() => onAddCredential('network')}>
+              Network Credential
+            </MenuItem>
+            <MenuItem eventKey="2" onClick={() => onAddCredential('satellite')}>
+              Satellite Credential
+            </MenuItem>
+            <MenuItem eventKey="2" onClick={() => onAddCredential('vcenter')}>
+              VCenter Credential
+            </MenuItem>
+          </DropdownButton>
+        </EmptyState.Action>
+        <EmptyState.Action secondary>
+          <Button bsStyle="default" onClick={onAddSource}>
+            Add Source
+          </Button>
+        </EmptyState.Action>
+      </EmptyState>
+    </Row>
+  </Grid>
+);
 
 CredentialsEmptyState.propTypes = {
   onAddCredential: PropTypes.func,
   onAddSource: PropTypes.func
 };
 
-export default CredentialsEmptyState;
+export { CredentialsEmptyState as default, CredentialsEmptyState };

--- a/client/src/components/dropdownSelect/__tests__/dropdownSelect.test.js
+++ b/client/src/components/dropdownSelect/__tests__/dropdownSelect.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import DropdownSelect from '../dropdownSelect';
 import { MenuItem } from 'patternfly-react';
+import DropdownSelect from '../dropdownSelect';
 
-describe('DropdownSelect Component', function() {
+describe('DropdownSelect Component', () => {
   it('should render', () => {
     const props = {
       id: 'testing',

--- a/client/src/components/dropdownSelect/dropdownSelect.js
+++ b/client/src/components/dropdownSelect/dropdownSelect.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from 'patternfly-react';
-import helpers from '../../common/helpers';
 import _ from 'lodash';
+import helpers from '../../common/helpers';
 
 class DropdownSelect extends React.Component {
   constructor(props) {
@@ -10,26 +10,26 @@ class DropdownSelect extends React.Component {
     this.state = { dropdownIsOpen: false };
   }
 
+  passOnClick = (event, callback) => {
+    if (callback) {
+      callback.apply(this, event);
+    }
+
+    this.toggleDropDown();
+  };
+
+  toggleDropDown = (a, b, c) => {
+    const { dropdownIsOpen } = this.state;
+
+    this.setState({
+      dropdownIsOpen: (c && c.source === 'select') || !dropdownIsOpen
+    });
+  };
+
   render() {
     const { dropdownIsOpen } = this.state;
     const { id, title, multiselect, children } = this.props;
     const filteredProps = _.omit(this.props, ['multiselect']);
-
-    const toggleDropDown = (a, b, c) => {
-      this.setState({
-        dropdownIsOpen: (c && c.source === 'select') || !dropdownIsOpen
-      });
-    };
-
-    const passOnClick = callback => {
-      return function() {
-        if (callback) {
-          callback.apply(this, arguments);
-        }
-
-        toggleDropDown.apply(this, arguments);
-      };
-    };
 
     if (!multiselect) {
       return (
@@ -45,14 +45,14 @@ class DropdownSelect extends React.Component {
     }
 
     return (
-      <Dropdown id={id || helpers.generateId()} open={dropdownIsOpen} onToggle={toggleDropDown} {...filteredProps}>
+      <Dropdown id={id || helpers.generateId()} open={dropdownIsOpen} onToggle={this.toggleDropDown} {...filteredProps}>
         <Dropdown.Toggle>
           <span>{title}</span>
         </Dropdown.Toggle>
         <Dropdown.Menu>
           {children &&
             React.Children.map(children, menuItem =>
-              React.cloneElement(menuItem, { onClick: passOnClick(menuItem.props.onClick) })
+              React.cloneElement(menuItem, { onClick: e => this.passOnClick(e, menuItem.props.onClick) })
             )}
         </Dropdown.Menu>
       </Dropdown>
@@ -67,4 +67,4 @@ DropdownSelect.propTypes = {
   multiselect: PropTypes.bool
 };
 
-export default DropdownSelect;
+export { DropdownSelect as default, DropdownSelect };

--- a/client/src/components/listStatusItem/__tests__/listStatusItem.test.js
+++ b/client/src/components/listStatusItem/__tests__/listStatusItem.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import ListStatusItem from '../listStatusItem';
 
-describe('ListStatusItem Component', function() {
+describe('ListStatusItem Component', () => {
   it('should render', () => {
     const props = {
       key: 'credential',

--- a/client/src/components/listStatusItem/listStatusItem.js
+++ b/client/src/components/listStatusItem/listStatusItem.js
@@ -73,4 +73,4 @@ ListStatusItem.propTypes = {
   iconInfo: PropTypes.object
 };
 
-export default ListStatusItem;
+export { ListStatusItem as default, ListStatusItem };

--- a/client/src/components/mastheadOptions/__tests__/mastheadOptions.test.js
+++ b/client/src/components/mastheadOptions/__tests__/mastheadOptions.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import MastheadOptions from '../mastheadOptions';
 
-describe('MastheadOptions Component', function() {
+describe('MastheadOptions Component', () => {
   it('should render', () => {
     const props = {
       user: { currentUser: { username: 'Admin' } }

--- a/client/src/components/mastheadOptions/mastheadOptions.js
+++ b/client/src/components/mastheadOptions/mastheadOptions.js
@@ -1,32 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { Dropdown, Icon, MenuItem } from 'patternfly-react';
 
-const MastheadOptions = ({ user, logoutUser, showAboutModal }) => {
-  return (
-    <nav className="collapse navbar-collapse">
-      <ul className="navbar-iconic nav navbar-nav navbar-right">
-        <Dropdown componentClass="li" id="help">
-          <Dropdown.Toggle useAnchor className="nav-item-iconic">
-            <Icon type="pf" name="help" />
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            <MenuItem onClick={showAboutModal}>About</MenuItem>
-          </Dropdown.Menu>
-        </Dropdown>
-        <Dropdown componentClass="li" id="user">
-          <Dropdown.Toggle useAnchor className="nav-item-iconic">
-            <Icon type="pf" name="user" /> {user.currentUser && user.currentUser.username}
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            <MenuItem onClick={logoutUser}>Log out</MenuItem>
-          </Dropdown.Menu>
-        </Dropdown>
-      </ul>
-    </nav>
-  );
-};
+const MastheadOptions = ({ user, logoutUser, showAboutModal }) => (
+  <nav className="collapse navbar-collapse">
+    <ul className="navbar-iconic nav navbar-nav navbar-right">
+      <Dropdown componentClass="li" id="help">
+        <Dropdown.Toggle useAnchor className="nav-item-iconic">
+          <Icon type="pf" name="help" />
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <MenuItem onClick={showAboutModal}>About</MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
+      <Dropdown componentClass="li" id="user">
+        <Dropdown.Toggle useAnchor className="nav-item-iconic">
+          <Icon type="pf" name="user" /> {user.currentUser && user.currentUser.username}
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <MenuItem onClick={logoutUser}>Log out</MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
+    </ul>
+  </nav>
+);
 
 MastheadOptions.propTypes = {
   user: PropTypes.object,
@@ -34,4 +31,4 @@ MastheadOptions.propTypes = {
   showAboutModal: PropTypes.func
 };
 
-export default MastheadOptions;
+export { MastheadOptions as default, MastheadOptions };

--- a/client/src/components/mergeReportsDialog/__tests__/__snapshots__/mergeReportsDialog.test.js.snap
+++ b/client/src/components/mergeReportsDialog/__tests__/__snapshots__/mergeReportsDialog.test.js.snap
@@ -36,6 +36,7 @@ exports[`ToastNotificationsList Component should shallow render a basic componen
       aria-label="Close"
       className="close"
       onClick={[Function]}
+      type="button"
     >
       <Icon
         name="close"

--- a/client/src/components/mergeReportsDialog/__tests__/mergeReportsDialog.test.js
+++ b/client/src/components/mergeReportsDialog/__tests__/mergeReportsDialog.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import MergeReportsDialog from '../mergeReportsDialog';
 
-describe('ToastNotificationsList Component', function() {
+describe('ToastNotificationsList Component', () => {
   const generateEmptyStore = () => configureMockStore()({ scans: {} });
 
   it('should shallow render a basic component', () => {

--- a/client/src/components/mergeReportsDialog/mergeReportsDialog.js
+++ b/client/src/components/mergeReportsDialog/mergeReportsDialog.js
@@ -13,30 +13,20 @@ import {
 } from '../../redux/actions/reportsActions';
 
 class MergeReportsDialog extends React.Component {
-  constructor() {
-    super();
-
-    helpers.bindMethods(this, ['mergeScanResults', 'onClose']);
-  }
-
-  onClose() {
+  onClose = () => {
     Store.dispatch({
       type: scansTypes.MERGE_SCAN_DIALOG_HIDE
     });
-  }
+  };
 
   getValidScans() {
     const { scans } = this.props;
-    return _.filter(scans, scan => {
-      return _.get(scan, 'most_recent.status') === 'completed';
-    });
+    return _.filter(scans, scan => _.get(scan, 'most_recent.status') === 'completed');
   }
 
   getInvalidScans() {
     const { scans } = this.props;
-    return _.filter(scans, scan => {
-      return _.get(scan, 'most_recent.status') !== 'completed';
-    });
+    return _.filter(scans, scan => _.get(scan, 'most_recent.status') !== 'completed');
   }
 
   getValidReportId() {
@@ -62,7 +52,7 @@ class MergeReportsDialog extends React.Component {
     this.onClose();
   }
 
-  mergeScanResults() {
+  onMergeScanResults = () => {
     const { mergeScans, details, getMergedScanReportDetailsCsv, getMergedScanReportSummaryCsv } = this.props;
     const data = { reports: this.getValidReportId() };
 
@@ -70,19 +60,19 @@ class MergeReportsDialog extends React.Component {
       response => {
         if (details) {
           getMergedScanReportDetailsCsv(_.get(response, 'value.data.id')).then(
-            success => this.notifyDownloadStatus(false),
+            () => this.notifyDownloadStatus(false),
             error => this.notifyDownloadStatus(true, error)
           );
         } else {
           getMergedScanReportSummaryCsv(_.get(response, 'value.data.id')).then(
-            success => this.notifyDownloadStatus(false),
+            () => this.notifyDownloadStatus(false),
             error => this.notifyDownloadStatus(true, error)
           );
         }
       },
       error => this.notifyDownloadStatus(true, error)
     );
-  }
+  };
 
   renderValidScans() {
     const validScans = this.getValidScans();
@@ -92,9 +82,9 @@ class MergeReportsDialog extends React.Component {
         <div>
           <span>Scans to be included in the merged report:</span>
           <ul>
-            {validScans.map(scan => {
-              return <li key={scan.id}>{scan.name}</li>;
-            })}
+            {validScans.map(scan => (
+              <li key={scan.id}>{scan.name}</li>
+            ))}
           </ul>
         </div>
       );
@@ -111,9 +101,9 @@ class MergeReportsDialog extends React.Component {
         <div>
           <span>Failed scans that cannot be included in the merged report:</span>
           <ul>
-            {invalidScans.map(scan => {
-              return <li key={scan.id}>{scan.name}</li>;
-            })}
+            {invalidScans.map(scan => (
+              <li key={scan.id}>{scan.name}</li>
+            ))}
           </ul>
         </div>
       );
@@ -138,7 +128,7 @@ class MergeReportsDialog extends React.Component {
         <Button bsStyle="default" className="btn-cancel" onClick={this.onClose}>
           Cancel
         </Button>
-        <Button bsStyle="primary" type="submit" disabled={validCount < 2} onClick={this.mergeScanResults}>
+        <Button bsStyle="primary" type="submit" disabled={validCount < 2} onClick={this.onMergeScanResults}>
           Merge
         </Button>
       </React.Fragment>
@@ -180,7 +170,7 @@ class MergeReportsDialog extends React.Component {
     return (
       <Modal show={show} onHide={this.onClose}>
         <Modal.Header>
-          <button className="close" onClick={this.onClose} aria-hidden="true" aria-label="Close">
+          <button type="button" className="close" onClick={this.onClose} aria-hidden="true" aria-label="Close">
             <Icon type="pf" name="close" />
           </button>
           <Modal.Title>{`${details ? 'Detailed' : 'Summary'} Merge Report`}</Modal.Title>
@@ -213,19 +203,19 @@ MergeReportsDialog.propTypes = {
   details: PropTypes.bool.isRequired
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   mergeScans: data => dispatch(mergeScanReports(data)),
   getMergedScanReportDetailsCsv: id => dispatch(getMergedScanReportDetailsCsv(id)),
   getMergedScanReportSummaryCsv: id => dispatch(getMergedScanReportSummaryCsv(id))
 });
 
-const mapStateToProps = function(state) {
-  return {
-    ...state.scans.merge_dialog
-  };
-};
+const mapStateToProps = state => ({
+  ...state.scans.merge_dialog
+});
 
-export default connect(
+const ConnectedMergeReportsDialog = connect(
   mapStateToProps,
   mapDispatchToProps
 )(MergeReportsDialog);
+
+export { ConnectedMergeReportsDialog as default, ConnectedMergeReportsDialog, MergeReportsDialog };

--- a/client/src/components/refreshTimeButton/__tests__/refreshTimeButton.test.js
+++ b/client/src/components/refreshTimeButton/__tests__/refreshTimeButton.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import RefreshTimeButton from '../refreshTimeButton';
 
-describe('RefreshTimeButton Component', function() {
+describe('RefreshTimeButton Component', () => {
   it('should render', () => {
     const props = {
       onRefresh: jest.fn()

--- a/client/src/components/refreshTimeButton/refreshTimeButton.js
+++ b/client/src/components/refreshTimeButton/refreshTimeButton.js
@@ -70,4 +70,4 @@ RefreshTimeButton.propTypes = {
   onRefresh: PropTypes.func.isRequired
 };
 
-export default RefreshTimeButton;
+export { RefreshTimeButton as default, RefreshTimeButton };

--- a/client/src/components/scanHostList/__tests__/scanHostList.test.js
+++ b/client/src/components/scanHostList/__tests__/scanHostList.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import ScanHostList from '../scanHostList';
 
-describe('ScanHostList Component', function() {
+describe('ScanHostList Component', () => {
   const generateEmptyStore = () => configureMockStore()({});
 
   it('should shallow render a basic component with an empty state status', () => {

--- a/client/src/components/scanHostList/scanHostList.js
+++ b/client/src/components/scanHostList/scanHostList.js
@@ -1,11 +1,10 @@
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import InfiniteScroll from 'react-infinite-scroller';
-
-import helpers from '../../common/helpers';
 import { connect } from 'react-redux';
 import { EmptyState, Grid } from 'patternfly-react';
+import _ from 'lodash';
+import helpers from '../../common/helpers';
 import { getConnectionScanResults, getInspectionScanResults } from '../../redux/actions/scansActions';
 
 class ScanHostList extends React.Component {
@@ -47,7 +46,7 @@ class ScanHostList extends React.Component {
     const { useConnectionResults, useInspectionResults } = this.props;
 
     const newResults = _.get(results, 'value.data.results', []);
-    let allResults = [...scanResults, ...newResults];
+    const allResults = [...scanResults, ...newResults];
 
     if (useConnectionResults && useInspectionResults) {
       allResults.sort((item1, item2) => {
@@ -73,7 +72,7 @@ class ScanHostList extends React.Component {
       page: page === undefined ? this.state.page : page,
       page_size: 100,
       ordering: 'name',
-      status: status
+      status
     };
 
     if (sourceId) {
@@ -111,7 +110,7 @@ class ScanHostList extends React.Component {
       page: page === undefined ? this.state.page : page,
       page_size: 100,
       ordering: 'name',
-      status: status
+      status
     };
 
     if (sourceId) {
@@ -144,7 +143,7 @@ class ScanHostList extends React.Component {
   }
 
   refresh(useProps, page = 1) {
-    let { useConnectionResults, useInspectionResults, status } = useProps;
+    const { useConnectionResults, useInspectionResults, status } = useProps;
 
     this.setState({
       scanResultsPending: true,
@@ -272,16 +271,16 @@ ScanHostList.defaultProps = {
   useInspectionResults: false
 };
 
-const mapStateToProps = function(state) {
-  return {};
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   getConnectionScanResults: (id, query) => dispatch(getConnectionScanResults(id, query)),
   getInspectionScanResults: (id, query) => dispatch(getInspectionScanResults(id, query))
 });
 
-export default connect(
+const mapStateToProps = () => ({});
+
+const ConnectedScanHostList = connect(
   mapStateToProps,
   mapDispatchToProps
 )(ScanHostList);
+
+export { ConnectedScanHostList as default, ConnectedScanHostList, ScanHostList };

--- a/client/src/components/scans/__tests__/scanJobsList.test.js
+++ b/client/src/components/scans/__tests__/scanJobsList.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import ScanJobsList from '../scanJobsList';
 
-describe('ScanJobsList Component', function() {
+describe('ScanJobsList Component', () => {
   const generateEmptyStore = () => configureMockStore()({});
 
   it('should shallow render a basic component with an empty state status', () => {

--- a/client/src/components/scans/__tests__/scanListItem.test.js
+++ b/client/src/components/scans/__tests__/scanListItem.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import ScanListItem from '../scanListItem';
 import { mount } from 'enzyme';
-import { viewTypes } from '../../../redux/constants/';
+import ScanListItem from '../scanListItem';
+import { viewTypes } from '../../../redux/constants';
 
-describe('SourceListItem Component', function() {
+describe('SourceListItem Component', () => {
   const generateEmptyStore = () => configureMockStore()({ sources: {}, viewOptions: { [viewTypes.SCANS_VIEW]: {} } });
 
   it('should render a basic component with a success status', () => {

--- a/client/src/components/scans/__tests__/scanSourceList.test.js
+++ b/client/src/components/scans/__tests__/scanSourceList.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import ScanSourceList from '../scanSourceList';
 
-describe('ScanSourceList Component', function() {
+describe('ScanSourceList Component', () => {
   const generateEmptyStore = () => configureMockStore()({});
 
   it('should shallow render a basic component with status', () => {

--- a/client/src/components/scans/scanJobsList.js
+++ b/client/src/components/scans/scanJobsList.js
@@ -190,15 +190,15 @@ ScanJobsList.propTypes = {
   getScanJobs: PropTypes.func
 };
 
-const mapStateToProps = function(state) {
-  return {};
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   getScanJobs: (id, query) => dispatch(getScanJobs(id, query))
 });
 
-export default connect(
+const mapStateToProps = () => ({});
+
+const ConnectedScanJobsList = connect(
   mapStateToProps,
   mapDispatchToProps
 )(ScanJobsList);
+
+export { ConnectedScanJobsList as default, ConnectedScanJobsList, ScanJobsList };

--- a/client/src/components/scans/scanListItem.js
+++ b/client/src/components/scans/scanListItem.js
@@ -18,8 +18,6 @@ class ScanListItem extends React.Component {
   constructor() {
     super();
 
-    helpers.bindMethods(this, ['toggleExpand', 'closeExpand', 'itemSelectChange']);
-
     this.state = {
       scanResultsPending: false,
       scanResultsError: null,
@@ -40,12 +38,7 @@ class ScanListItem extends React.Component {
   expandType() {
     const { item, expandedScans } = this.props;
 
-    return _.get(
-      _.find(expandedScans, nextExpanded => {
-        return nextExpanded.id === item.id;
-      }),
-      'expandType'
-    );
+    return _.get(_.find(expandedScans, nextExpanded => nextExpanded.id === item.id), 'expandType');
   }
 
   closeExpandIfNoData(expandType) {
@@ -60,55 +53,51 @@ class ScanListItem extends React.Component {
       (expandType === 'systemsFailed' && failedHosts === 0) ||
       (expandType === 'jobs' && prevCount === 0)
     ) {
-      this.closeExpand();
+      this.onCloseExpand();
     }
   }
 
-  toggleExpand(expandType) {
+  onToggleExpand = expandType => {
     const { item } = this.props;
 
     if (expandType === this.expandType()) {
       Store.dispatch({
         type: viewTypes.EXPAND_ITEM,
         viewType: viewTypes.SCANS_VIEW,
-        item: item
+        item
       });
     } else {
       Store.dispatch({
         type: viewTypes.EXPAND_ITEM,
         viewType: viewTypes.SCANS_VIEW,
-        item: item,
-        expandType: expandType
+        item,
+        expandType
       });
     }
-  }
+  };
 
-  closeExpand() {
+  onCloseExpand = () => {
     const { item } = this.props;
     Store.dispatch({
       type: viewTypes.EXPAND_ITEM,
       viewType: viewTypes.SCANS_VIEW,
-      item: item
+      item
     });
+  };
+
+  static isSelected(item, selectedSources) {
+    return _.find(selectedSources, nextSelected => nextSelected.id === item.id) !== undefined;
   }
 
-  isSelected(item, selectedSources) {
-    return (
-      _.find(selectedSources, nextSelected => {
-        return nextSelected.id === item.id;
-      }) !== undefined
-    );
-  }
-
-  itemSelectChange() {
+  onItemSelectChange = () => {
     const { item, selectedScans } = this.props;
 
     Store.dispatch({
-      type: this.isSelected(item, selectedScans) ? viewTypes.DESELECT_ITEM : viewTypes.SELECT_ITEM,
+      type: ScanListItem.isSelected(item, selectedScans) ? viewTypes.DESELECT_ITEM : viewTypes.SELECT_ITEM,
       viewType: viewTypes.SCANS_VIEW,
-      item: item
+      item
     });
-  }
+  };
 
   renderDescription() {
     const { item } = this.props;
@@ -161,7 +150,7 @@ class ScanListItem extends React.Component {
         tipPlural="Successful Systems"
         expanded={expandType === 'systemsScanned'}
         expandType="systemsScanned"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
         iconInfo={helpers.scanStatusIcon('success')}
       />,
       <ListStatusItem
@@ -173,7 +162,7 @@ class ScanListItem extends React.Component {
         tipPlural="Failed Systems"
         expanded={expandType === 'systemsFailed'}
         expandType="systemsFailed"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
         iconInfo={helpers.scanStatusIcon('failed')}
       />,
       <ListStatusItem
@@ -185,7 +174,7 @@ class ScanListItem extends React.Component {
         tipPlural="Sources"
         expanded={expandType === 'sources'}
         expandType="sources"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
       />,
       <ListStatusItem
         key="scans"
@@ -196,7 +185,7 @@ class ScanListItem extends React.Component {
         tipPlural="Previous"
         expanded={expandType === 'jobs'}
         expandType="jobs"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
       />
     ];
   }
@@ -279,7 +268,7 @@ class ScanListItem extends React.Component {
     }
   }
 
-  renderHostRow(host) {
+  static renderHostRow(host) {
     return (
       <React.Fragment>
         <Grid.Col xs={6} sm={4} md={3}>
@@ -305,7 +294,7 @@ class ScanListItem extends React.Component {
             scanId={item.most_recent.id}
             lastRefresh={lastRefresh}
             status="success"
-            renderHostRow={this.renderHostRow}
+            renderHostRow={ScanListItem.renderHostRow}
             useInspectionResults
           />
         );
@@ -315,7 +304,7 @@ class ScanListItem extends React.Component {
             scanId={item.most_recent.id}
             lastRefresh={lastRefresh}
             status="failed"
-            renderHostRow={this.renderHostRow}
+            renderHostRow={ScanListItem.renderHostRow}
             useConnectionResults
             useInspectionResults
           />
@@ -338,7 +327,7 @@ class ScanListItem extends React.Component {
 
   render() {
     const { item, selectedScans } = this.props;
-    const selected = this.isSelected(item, selectedScans);
+    const selected = ScanListItem.isSelected(item, selectedScans);
 
     const classes = cx({
       'quipucords-scan-list-item': true,
@@ -350,14 +339,14 @@ class ScanListItem extends React.Component {
       <ListView.Item
         key={item.id}
         className={classes}
-        checkboxInput={<Checkbox checked={selected} bsClass="" onChange={this.itemSelectChange} />}
+        checkboxInput={<Checkbox checked={selected} bsClass="" onChange={this.onItemSelectChange} />}
         actions={this.renderActions()}
         leftContent={<div className="list-item-name">{item.name}</div>}
         description={this.renderDescription()}
         additionalInfo={this.renderStatusItems()}
         compoundExpand
         compoundExpanded={this.expandType() !== undefined}
-        onCloseCompoundExpand={this.closeExpand}
+        onCloseCompoundExpand={this.onCloseExpand}
       >
         {this.renderExpansionContents()}
       </ListView.Item>
@@ -378,11 +367,11 @@ ScanListItem.propTypes = {
   expandedScans: PropTypes.array
 };
 
-const mapStateToProps = function(state) {
-  return Object.assign({
-    expandedScans: state.viewOptions[viewTypes.SCANS_VIEW].expandedItems,
-    selectedScans: state.viewOptions[viewTypes.SCANS_VIEW].selectedItems
-  });
-};
+const mapStateToProps = state => ({
+  expandedScans: state.viewOptions[viewTypes.SCANS_VIEW].expandedItems,
+  selectedScans: state.viewOptions[viewTypes.SCANS_VIEW].selectedItems
+});
 
-export default connect(mapStateToProps)(ScanListItem);
+const ConnectedScanListItem = connect(mapStateToProps)(ScanListItem);
+
+export { ConnectedScanListItem as default, ConnectedScanListItem, ScanListItem };

--- a/client/src/components/scans/scanSourceList.js
+++ b/client/src/components/scans/scanSourceList.js
@@ -1,8 +1,8 @@
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Grid, Icon } from 'patternfly-react';
+import _ from 'lodash';
 import { helpers } from '../../common/helpers';
 import { getScanJob } from '../../redux/actions/scansActions';
 
@@ -44,7 +44,7 @@ class ScanSourceList extends React.Component {
   }
 
   sortSources(scan) {
-    let sources = [..._.get(scan, 'sources', [])];
+    const sources = [..._.get(scan, 'sources', [])];
 
     sources.sort((item1, item2) => {
       let cmp = item1.source_type.localeCompare(item2.source_type);
@@ -54,7 +54,7 @@ class ScanSourceList extends React.Component {
       return cmp;
     });
 
-    this.setState({ sources: sources });
+    this.setState({ sources });
   }
 
   getSourceStatus(source) {
@@ -75,7 +75,7 @@ class ScanSourceList extends React.Component {
     return `Inspection Scan: ${_.get(inspectTask, 'status_message', 'checking status...')}`;
   }
 
-  renderSourceIcon(source) {
+  static renderSourceIcon(source) {
     const iconInfo = helpers.sourceTypeIcon(source.source_type);
 
     return <Icon type={iconInfo.type} name={iconInfo.name} />;
@@ -89,7 +89,7 @@ class ScanSourceList extends React.Component {
         {sources.map((item, index) => (
           <Grid.Row key={index}>
             <Grid.Col xs={4} md={3}>
-              {this.renderSourceIcon(item)}
+              {ScanSourceList.renderSourceIcon(item)}
               &nbsp; {item.name}
             </Grid.Col>
             <Grid.Col xs={8} md={9}>
@@ -108,15 +108,15 @@ ScanSourceList.propTypes = {
   getScanJob: PropTypes.func
 };
 
-const mapStateToProps = function(state) {
-  return {};
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  getScanJob: (id, query) => dispatch(getScanJob(id))
+const mapDispatchToProps = dispatch => ({
+  getScanJob: id => dispatch(getScanJob(id))
 });
 
-export default connect(
+const mapStateToProps = () => ({});
+
+const ConnectedScanSourceList = connect(
   mapStateToProps,
   mapDispatchToProps
 )(ScanSourceList);
+
+export { ConnectedScanSourceList as default, ConnectedScanSourceList, ScanSourceList };

--- a/client/src/components/scans/scansEmptyState.js
+++ b/client/src/components/scans/scansEmptyState.js
@@ -31,4 +31,4 @@ ScansEmptyState.propTypes = {
   sourcesExist: PropTypes.bool
 };
 
-export default ScansEmptyState;
+export { ScansEmptyState as default, ScansEmptyState };

--- a/client/src/components/simpleTooltIp/__tests__/simpleTooltip.test.js
+++ b/client/src/components/simpleTooltIp/__tests__/simpleTooltip.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import SimpleTooltip from '../simpleTooltip';
 
-describe('SimpleTooltip Component', function() {
+describe('SimpleTooltip Component', () => {
   it('should render', () => {
     const props = {
       id: 'test'

--- a/client/src/components/simpleTooltIp/simpleTooltip.js
+++ b/client/src/components/simpleTooltIp/simpleTooltip.js
@@ -2,18 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { OverlayTrigger, Tooltip } from 'patternfly-react';
 
-const SimpleTooltip = ({ children, tooltip, placement, trigger, delayShow, ...props }) => {
-  return (
-    <OverlayTrigger
-      overlay={<Tooltip {...props}>{tooltip}</Tooltip>}
-      placement={placement}
-      trigger={trigger}
-      delayShow={delayShow}
-    >
-      <span>{children}</span>
-    </OverlayTrigger>
-  );
-};
+const SimpleTooltip = ({ children, tooltip, placement, trigger, delayShow, ...props }) => (
+  <OverlayTrigger
+    overlay={<Tooltip {...props}>{tooltip}</Tooltip>}
+    placement={placement}
+    trigger={trigger}
+    delayShow={delayShow}
+  >
+    <span>{children}</span>
+  </OverlayTrigger>
+);
 
 SimpleTooltip.propTypes = {
   children: PropTypes.node,
@@ -29,4 +27,4 @@ SimpleTooltip.defaultProps = {
   delayShow: 500
 };
 
-export default SimpleTooltip;
+export { SimpleTooltip as default, SimpleTooltip };

--- a/client/src/components/sources/__tests__/__snapshots__/createScanDialog.test.js.snap
+++ b/client/src/components/sources/__tests__/__snapshots__/createScanDialog.test.js.snap
@@ -27,6 +27,7 @@ exports[`CreateScanDialog Component should render a basic component 1`] = `
             aria-hidden="true"
             aria-label="Close"
             class="close"
+            type="button"
           >
             <span
               aria-hidden="true"

--- a/client/src/components/sources/__tests__/createScanDialog.test.js
+++ b/client/src/components/sources/__tests__/createScanDialog.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import CreateScanDialog from '../createScanDialog';
 import { mount } from 'enzyme';
+import CreateScanDialog from '../createScanDialog';
 
-describe('CreateScanDialog Component', function() {
+describe('CreateScanDialog Component', () => {
   const generateEmptyStore = () => configureMockStore()({ scans: {} });
 
   it('should render a basic component', () => {

--- a/client/src/components/sources/__tests__/sourceCredentialsList.test.js
+++ b/client/src/components/sources/__tests__/sourceCredentialsList.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import SourceCredentialsList from '../sourceCredentialsList';
 
-describe('SourceCredentialsList Component', function() {
+describe('SourceCredentialsList Component', () => {
   it('should render a sorted list', () => {
     const props = {
       source: {

--- a/client/src/components/sources/__tests__/sourcesEmptyState.test.js
+++ b/client/src/components/sources/__tests__/sourcesEmptyState.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import SourcesEmptyState from '../sourcesEmptyState';
 
-describe('SourcesEmptyState Component', function() {
+describe('SourcesEmptyState Component', () => {
   it('should render a basic component', () => {
     const props = {};
     const component = mount(<SourcesEmptyState {...props} />);

--- a/client/src/components/sources/__tests__/sourcesListItem.test.js
+++ b/client/src/components/sources/__tests__/sourcesListItem.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import SourceListItem from '../sourceListItem';
 import { mount } from 'enzyme';
-import { viewTypes } from '../../../redux/constants/';
+import SourceListItem from '../sourceListItem';
+import { viewTypes } from '../../../redux/constants';
 
-describe('SourceListItem Component', function() {
+describe('SourceListItem Component', () => {
   const generateEmptyStore = () => configureMockStore()({ sources: {}, viewOptions: { [viewTypes.SOURCES_VIEW]: {} } });
 
   it('should render a basic component', () => {

--- a/client/src/components/sources/createScanDialog.js
+++ b/client/src/components/sources/createScanDialog.js
@@ -11,8 +11,6 @@ class CreateScanDialog extends React.Component {
   constructor() {
     super();
 
-    helpers.bindMethods(this, ['updateScanName', 'createScan', 'startChange']);
-
     this.state = {
       scanName: '',
       validScanName: false
@@ -87,11 +85,11 @@ class CreateScanDialog extends React.Component {
     }
   }
 
-  createScan() {
+  onCreateScan = () => {
     const { sources, addScan } = this.props;
     const { scanName } = this.state;
 
-    let data = {
+    const data = {
       name: scanName,
       sources: sources.map(item => item.id)
     };
@@ -100,22 +98,18 @@ class CreateScanDialog extends React.Component {
       response => this.notifyAddStatus(false, response.value),
       error => this.notifyAddStatus(true, error)
     );
-  }
+  };
 
-  startChange(value) {
-    this.setState({ start: value });
-  }
-
-  validateScanName(scanName) {
+  static validateScanName(scanName) {
     return scanName && scanName.length > 0;
   }
 
-  updateScanName(event) {
+  onUpdateScanName = event => {
     this.setState({
       scanName: event.target.value,
-      validScanName: this.validateScanName(event.target.value)
+      validScanName: CreateScanDialog.validateScanName(event.target.value)
     });
-  }
+  };
 
   onScanNameKeyPress(keyEvent) {
     const { scanName, validScanName } = this.state;
@@ -123,22 +117,22 @@ class CreateScanDialog extends React.Component {
     if (keyEvent.key === 'Enter' && scanName && validScanName) {
       keyEvent.stopPropagation();
       keyEvent.preventDefault();
-      this.createScan();
+      this.onCreateScan();
     }
   }
 
-  errorDismissed() {
+  onErrorDismissed = () => {
     Store.dispatch({
       type: scansTypes.RESET_SCAN_ADD_STATUS
     });
-  }
+  };
 
   renderErrorMessage() {
     const { action } = this.props;
 
     if (action && action.error) {
       return (
-        <Alert type="error" onDismiss={this.errorDismissed}>
+        <Alert type="error" onDismiss={this.onErrorDismissed}>
           <strong>Error</strong> {action.errorMessage}
         </Alert>
       );
@@ -158,7 +152,7 @@ class CreateScanDialog extends React.Component {
     return (
       <Modal show={show} onHide={onClose}>
         <Modal.Header>
-          <button className="close" onClick={onClose} aria-hidden="true" aria-label="Close">
+          <button type="button" className="close" onClick={onClose} aria-hidden="true" aria-label="Close">
             <Icon type="pf" name="close" />
           </button>
           <Modal.Title>Scan</Modal.Title>
@@ -166,7 +160,7 @@ class CreateScanDialog extends React.Component {
         <Modal.Body />
         <Grid fluid>
           {this.renderErrorMessage()}
-          <Form horizontal onSubmit={this.createScan}>
+          <Form horizontal onSubmit={this.onCreateScan}>
             <Form.FormGroup controlId="scanName">
               <Grid.Col componentClass={Form.ControlLabel} sm={3}>
                 <label htmlFor="scanName" className="control-label">
@@ -180,7 +174,7 @@ class CreateScanDialog extends React.Component {
                   autoFocus
                   value={scanName}
                   placeholder="Enter a name for the scan"
-                  onChange={e => this.updateScanName(e)}
+                  onChange={e => this.onUpdateScanName(e)}
                   onKeyPress={e => this.onScanNameKeyPress(e)}
                 />
               </Grid.Col>
@@ -206,7 +200,7 @@ class CreateScanDialog extends React.Component {
           <Button bsStyle="default" className="btn-cancel" onClick={onClose}>
             Cancel
           </Button>
-          <Button bsStyle="primary" type="submit" onClick={this.createScan} disabled={!validScanName}>
+          <Button bsStyle="primary" type="submit" onClick={this.onCreateScan} disabled={!validScanName}>
             Scan
           </Button>
         </Modal.Footer>
@@ -224,16 +218,16 @@ CreateScanDialog.propTypes = {
   action: PropTypes.object
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   addScan: data => dispatch(addScan(data)),
   startScan: data => dispatch(startScan(data))
 });
 
-const mapStateToProps = function(state) {
-  return Object.assign({}, { action: state.scans.action });
-};
+const mapStateToProps = state => ({ action: state.scans.action });
 
-export default connect(
+const ConnectedCreateScanDialog = connect(
   mapStateToProps,
   mapDispatchToProps
 )(CreateScanDialog);
+
+export { ConnectedCreateScanDialog as default, ConnectedCreateScanDialog, CreateScanDialog };

--- a/client/src/components/sources/sourceCredentialsList.js
+++ b/client/src/components/sources/sourceCredentialsList.js
@@ -4,11 +4,9 @@ import { Grid, Icon } from 'patternfly-react';
 import _ from 'lodash';
 
 const SourceCredentialsList = ({ source }) => {
-  let credentials = [..._.get(source, 'credentials', [])];
+  const credentials = [..._.get(source, 'credentials', [])];
 
-  credentials.sort((item1, item2) => {
-    return item1.name.localeCompare(item2.name);
-  });
+  credentials.sort((item1, item2) => item1.name.localeCompare(item2.name));
 
   return (
     <Grid fluid>
@@ -30,4 +28,4 @@ SourceCredentialsList.propTypes = {
   source: PropTypes.object
 };
 
-export default SourceCredentialsList;
+export { SourceCredentialsList as default, SourceCredentialsList };

--- a/client/src/components/sources/sourceListItem.js
+++ b/client/src/components/sources/sourceListItem.js
@@ -14,12 +14,6 @@ import SimpleTooltip from '../simpleTooltIp/simpleTooltip';
 import ListStatusItem from '../listStatusItem/listStatusItem';
 
 class SourceListItem extends React.Component {
-  constructor() {
-    super();
-
-    helpers.bindMethods(this, ['itemSelectChange', 'toggleExpand', 'closeExpand']);
-  }
-
   componentWillReceiveProps(nextProps) {
     // Check for changes resulting in a fetch
     if (!_.isEqual(nextProps.lastRefresh, this.props.lastRefresh)) {
@@ -30,72 +24,63 @@ class SourceListItem extends React.Component {
   expandType() {
     const { item, expandedSources } = this.props;
 
-    return _.get(
-      _.find(expandedSources, nextExpanded => {
-        return nextExpanded.id === item.id;
-      }),
-      'expandType'
-    );
+    return _.get(_.find(expandedSources, nextExpanded => nextExpanded.id === item.id), 'expandType');
   }
 
-  isSelected(item, selectedSources) {
-    return (
-      _.find(selectedSources, nextSelected => {
-        return nextSelected.id === item.id;
-      }) !== undefined
-    );
+  static isSelected(item, selectedSources) {
+    return _.find(selectedSources, nextSelected => nextSelected.id === item.id) !== undefined;
   }
 
-  itemSelectChange() {
+  onItemSelectChange = () => {
     const { item, selectedSources } = this.props;
 
     Store.dispatch({
-      type: this.isSelected(item, selectedSources) ? viewTypes.DESELECT_ITEM : viewTypes.SELECT_ITEM,
+      type: SourceListItem.isSelected(item, selectedSources) ? viewTypes.DESELECT_ITEM : viewTypes.SELECT_ITEM,
       viewType: viewTypes.SOURCES_VIEW,
-      item: item
+      item
     });
-  }
+  };
 
   closeExpandIfNoData(expandType) {
     const { item } = this.props;
 
     if (expandType === 'okHosts' || expandType === 'failedHosts') {
-      let okHostCount = _.get(item, 'connection.source_systems_scanned', 0);
-      let failedHostCount = _.get(item, 'connection.source_systems_failed', 0);
+      const okHostCount = _.get(item, 'connection.source_systems_scanned', 0);
+      const failedHostCount = _.get(item, 'connection.source_systems_failed', 0);
 
       if ((expandType === 'okHosts' && okHostCount === 0) || (expandType === 'failedHosts' && failedHostCount === 0)) {
-        this.closeExpand();
+        this.onCloseExpand();
       }
     }
   }
 
-  toggleExpand(expandType) {
+  onToggleExpand = expandType => {
     const { item } = this.props;
 
     if (expandType === this.expandType()) {
       Store.dispatch({
         type: viewTypes.EXPAND_ITEM,
         viewType: viewTypes.SOURCES_VIEW,
-        item: item
+        item
       });
     } else {
       Store.dispatch({
         type: viewTypes.EXPAND_ITEM,
         viewType: viewTypes.SOURCES_VIEW,
-        item: item,
-        expandType: expandType
+        item,
+        expandType
       });
     }
-  }
+  };
 
-  closeExpand() {
+  onCloseExpand = () => {
     const { item } = this.props;
     Store.dispatch({
       type: viewTypes.EXPAND_ITEM,
       viewType: viewTypes.SOURCES_VIEW,
-      item: item
+      item
     });
-  }
+  };
 
   renderSourceType() {
     const { item } = this.props;
@@ -137,7 +122,7 @@ class SourceListItem extends React.Component {
     const credentialCount = _.size(_.get(item, 'credentials', []));
     let okHostCount = _.get(item, 'connection.source_systems_scanned', 0);
     let failedHostCount = _.get(item, 'connection.source_systems_failed', 0);
-    let unreachableHostCount = _.get(item, 'connection.source_systems_unreachable', 0);
+    const unreachableHostCount = _.get(item, 'connection.source_systems_unreachable', 0);
 
     if (helpers.DEV_MODE) {
       okHostCount = helpers.devModeNormalizeCount(okHostCount);
@@ -154,7 +139,7 @@ class SourceListItem extends React.Component {
         tipPlural="Credentials"
         expanded={expandType === 'credentials'}
         expandType="credentials"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
         iconInfo={{ type: 'fa', name: 'id-card' }}
       />,
       <ListStatusItem
@@ -166,7 +151,7 @@ class SourceListItem extends React.Component {
         tipPlural="Successful Authentications"
         expanded={expandType === 'okHosts'}
         expandType="okHosts"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
         iconInfo={helpers.scanStatusIcon('success')}
       />,
       <ListStatusItem
@@ -178,7 +163,7 @@ class SourceListItem extends React.Component {
         tipPlural="Failed Authentications"
         expanded={expandType === 'failedHosts'}
         expandType="failedHosts"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
         iconInfo={helpers.scanStatusIcon('failed')}
       />,
       <ListStatusItem
@@ -190,13 +175,13 @@ class SourceListItem extends React.Component {
         tipPlural="Unreachable Systems"
         expanded={expandType === 'unreachableHosts'}
         expandType="unreachableHosts"
-        toggleExpand={this.toggleExpand}
+        toggleExpand={this.onToggleExpand}
         iconInfo={helpers.scanStatusIcon('unreachable')}
       />
     ];
   }
 
-  renderHostRow(host) {
+  static renderHostRow(host) {
     const iconInfo = helpers.scanStatusIcon(host.status);
     const classes = cx(...iconInfo.classNames);
 
@@ -231,7 +216,7 @@ class SourceListItem extends React.Component {
             sourceId={item.id}
             lastRefresh={lastRefresh}
             status="success"
-            renderHostRow={this.renderHostRow}
+            renderHostRow={SourceListItem.renderHostRow}
             useConnectionResults
           />
         );
@@ -242,7 +227,7 @@ class SourceListItem extends React.Component {
             sourceId={item.id}
             lastRefresh={lastRefresh}
             status="failed"
-            renderHostRow={this.renderHostRow}
+            renderHostRow={SourceListItem.renderHostRow}
             useConnectionResults
           />
         );
@@ -253,7 +238,7 @@ class SourceListItem extends React.Component {
             sourceId={item.id}
             lastRefresh={lastRefresh}
             status="unreachable"
-            renderHostRow={this.renderHostRow}
+            renderHostRow={SourceListItem.renderHostRow}
             useConnectionResults
           />
         );
@@ -273,9 +258,9 @@ class SourceListItem extends React.Component {
           item.hosts.length > 1 && (
             <ul className="quipucords-popover-list">
               hello
-              {item.hosts.map((host, index) => {
-                return <li key={index}>{host}</li>;
-              })}
+              {item.hosts.map((host, index) => (
+                <li key={index}>{host}</li>
+              ))}
             </ul>
           )}
         {item.hosts && item.hosts.length === 1 && <div>{item.hosts[0]}</div>}
@@ -365,7 +350,7 @@ class SourceListItem extends React.Component {
 
   render() {
     const { item, selectedSources } = this.props;
-    const selected = this.isSelected(item, selectedSources);
+    const selected = SourceListItem.isSelected(item, selectedSources);
 
     const classes = cx({
       'list-view-pf-top-align': true,
@@ -377,14 +362,14 @@ class SourceListItem extends React.Component {
         key={item.id}
         stacked
         className={classes}
-        checkboxInput={<Checkbox checked={selected} bsClass="" onChange={this.itemSelectChange} />}
+        checkboxInput={<Checkbox checked={selected} bsClass="" onChange={this.onItemSelectChange} />}
         actions={this.renderActions()}
         leftContent={this.renderSourceType()}
         description={this.renderDescription()}
         additionalInfo={this.renderStatusItems()}
         compoundExpand
         compoundExpanded={this.expandType() !== undefined}
-        onCloseCompoundExpand={this.closeExpand}
+        onCloseCompoundExpand={this.onCloseExpand}
       >
         {this.renderExpansionContents()}
       </ListView.Item>
@@ -402,11 +387,12 @@ SourceListItem.propTypes = {
   expandedSources: PropTypes.array
 };
 
-const mapStateToProps = function(state) {
-  return Object.assign({
+const mapStateToProps = state =>
+  Object.assign({
     selectedSources: state.viewOptions[viewTypes.SOURCES_VIEW].selectedItems,
     expandedSources: state.viewOptions[viewTypes.SOURCES_VIEW].expandedItems
   });
-};
 
-export default connect(mapStateToProps)(SourceListItem);
+const ConnectedSourceListItem = connect(mapStateToProps)(SourceListItem);
+
+export { ConnectedSourceListItem as default, ConnectedSourceListItem, SourceListItem };

--- a/client/src/components/sources/sourcesEmptyState.js
+++ b/client/src/components/sources/sourcesEmptyState.js
@@ -3,31 +3,29 @@ import PropTypes from 'prop-types';
 import { Button, EmptyState, Grid, Row } from 'patternfly-react';
 import helpers from '../../common/helpers';
 
-const SourcesEmptyState = ({ onAddSource }) => {
-  return (
-    <Grid fluid>
-      <Row>
-        <EmptyState className="full-page-blank-slate">
-          <EmptyState.Icon />
-          <EmptyState.Title>Welcome to {helpers.RH_BRAND && 'Red Hat'} Entitlements Reporting</EmptyState.Title>
-          <EmptyState.Info>
-            Begin by adding one or more sources. A source contains a collection of network information, <br />
-            including systems management solution information, IP addresses, or host names, in addition to <br />
-            SSH ports and credentials.
-          </EmptyState.Info>
-          <EmptyState.Action>
-            <Button bsStyle="primary" bsSize="large" onClick={onAddSource}>
-              Add Source
-            </Button>
-          </EmptyState.Action>
-        </EmptyState>
-      </Row>
-    </Grid>
-  );
-};
+const SourcesEmptyState = ({ onAddSource }) => (
+  <Grid fluid>
+    <Row>
+      <EmptyState className="full-page-blank-slate">
+        <EmptyState.Icon />
+        <EmptyState.Title>Welcome to {helpers.RH_BRAND && 'Red Hat'} Entitlements Reporting</EmptyState.Title>
+        <EmptyState.Info>
+          Begin by adding one or more sources. A source contains a collection of network information, <br />
+          including systems management solution information, IP addresses, or host names, in addition to <br />
+          SSH ports and credentials.
+        </EmptyState.Info>
+        <EmptyState.Action>
+          <Button bsStyle="primary" bsSize="large" onClick={onAddSource}>
+            Add Source
+          </Button>
+        </EmptyState.Action>
+      </EmptyState>
+    </Row>
+  </Grid>
+);
 
 SourcesEmptyState.propTypes = {
   onAddSource: PropTypes.func
 };
 
-export default SourcesEmptyState;
+export { SourcesEmptyState as default, SourcesEmptyState };

--- a/client/src/components/toastNotificationsList/__tests__/toastNotificationsList.test.js
+++ b/client/src/components/toastNotificationsList/__tests__/toastNotificationsList.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { shallow } from 'enzyme';
 import ToastNotificationsList from '../toastNotificationsList';
 
-describe('ToastNotificationsList Component', function() {
+describe('ToastNotificationsList Component', () => {
   const generateEmptyStore = () => configureMockStore()({ toastNotifications: {} });
 
   it('should shallow render a basic component', () => {

--- a/client/src/components/toastNotificationsList/toastNotificationsList.js
+++ b/client/src/components/toastNotificationsList/toastNotificationsList.js
@@ -2,31 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ToastNotificationList, TimedToastNotification } from 'patternfly-react';
 import { connect } from 'react-redux';
-import helpers from '../../common/helpers';
 import Store from '../../redux/store';
 import { toastNotificationTypes } from '../../redux/constants';
 
 class ToastNotificationsList extends React.Component {
-  constructor() {
-    super();
-
-    helpers.bindMethods(this, ['onHover', 'onLeave', 'onDismiss']);
-  }
-
-  onHover() {
+  onHover = () => {
     Store.dispatch({ type: toastNotificationTypes.TOAST_PAUSE });
-  }
+  };
 
-  onLeave() {
+  onLeave = () => {
     Store.dispatch({ type: toastNotificationTypes.TOAST_RESUME });
-  }
+  };
 
-  onDismiss(toast) {
+  onDismiss = toast => {
     Store.dispatch({
       type: toastNotificationTypes.TOAST_REMOVE,
-      toast: toast
+      toast
     });
-  }
+  };
 
   render() {
     const { toasts, paused } = this.props;
@@ -42,7 +35,7 @@ class ToastNotificationsList extends React.Component {
                   toastIndex={index}
                   type={toast.alertType}
                   paused={paused}
-                  onDismiss={e => this.onDismiss(toast)}
+                  onDismiss={() => this.onDismiss(toast)}
                   onMouseEnter={this.onHover}
                   onMouseLeave={this.onLeave}
                 >
@@ -66,8 +59,8 @@ ToastNotificationsList.propTypes = {
   paused: PropTypes.bool
 };
 
-const mapStateToProps = function(state) {
-  return { ...state.toastNotifications };
-};
+const mapStateToProps = state => ({ ...state.toastNotifications });
 
-export default connect(mapStateToProps)(ToastNotificationsList);
+const ConnectedToastNotificationsList = connect(mapStateToProps)(ToastNotificationsList);
+
+export { ConnectedToastNotificationsList as default, ConnectedToastNotificationsList, ToastNotificationsList };

--- a/client/src/components/viewPaginationRow/__tests__/viewPaginationRow.test.js
+++ b/client/src/components/viewPaginationRow/__tests__/viewPaginationRow.test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import ViewPaginationRow from '../viewPaginationRow';
 import { viewTypes } from '../../../redux/constants';
 
-describe('ViewPaginationRow Component', function() {
+describe('ViewPaginationRow Component', () => {
   it('should render', () => {
     const props = {
       viewType: viewTypes.SCANS_VIEW,

--- a/client/src/components/viewPaginationRow/viewPaginationRow.js
+++ b/client/src/components/viewPaginationRow/viewPaginationRow.js
@@ -1,11 +1,8 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
-
 import helpers from '../../common/helpers';
 import Store from '../../redux/store';
-
 import { viewPaginationTypes } from '../../redux/constants';
 
 class ViewPaginationRow extends React.Component {
@@ -26,7 +23,7 @@ class ViewPaginationRow extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_FIRST_PAGE,
-      viewType: viewType
+      viewType
     });
   }
 
@@ -34,7 +31,7 @@ class ViewPaginationRow extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_LAST_PAGE,
-      viewType: viewType
+      viewType
     });
   }
 
@@ -42,7 +39,7 @@ class ViewPaginationRow extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_PREVIOUS_PAGE,
-      viewType: viewType
+      viewType
     });
   }
 
@@ -50,7 +47,7 @@ class ViewPaginationRow extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_NEXT_PAGE,
-      viewType: viewType
+      viewType
     });
   }
 
@@ -58,7 +55,7 @@ class ViewPaginationRow extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_PAGE_NUMBER,
-      viewType: viewType,
+      viewType,
       pageNumber: parseInt(e.target.value, 10)
     });
   }
@@ -67,7 +64,7 @@ class ViewPaginationRow extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.SET_PER_PAGE,
-      viewType: viewType,
+      viewType,
       pageSize: eventKey
     });
   }
@@ -79,11 +76,11 @@ class ViewPaginationRow extends React.Component {
     const rowPagination = {
       page: currentPage,
       perPage: pageSize,
-      perPageOptions: perPageOptions
+      perPageOptions
     };
 
-    let itemsStart = (currentPage - 1) * pageSize + 1;
-    let itemsEnd = Math.min(currentPage * pageSize, totalCount);
+    const itemsStart = (currentPage - 1) * pageSize + 1;
+    const itemsEnd = Math.min(currentPage * pageSize, totalCount);
 
     return (
       <PaginationRow
@@ -115,4 +112,4 @@ ViewPaginationRow.propTypes = {
   totalPages: PropTypes.number
 };
 
-export default ViewPaginationRow;
+export { ViewPaginationRow as default, ViewPaginationRow };

--- a/client/src/components/viewToolbar/__tests__/viewToolbar.test.js
+++ b/client/src/components/viewToolbar/__tests__/viewToolbar.test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import ViewToolbar from '../viewToolbar';
 import { viewTypes } from '../../../redux/constants';
 
-describe('ViewPaginationRow Component', function() {
+describe('ViewPaginationRow Component', () => {
   it('should render', () => {
     const props = {
       viewType: viewTypes.SCANS_VIEW,

--- a/client/src/components/viewToolbar/viewToolbar.js
+++ b/client/src/components/viewToolbar/viewToolbar.js
@@ -2,10 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Filter, Sort, Toolbar } from 'patternfly-react';
 import _ from 'lodash';
-
 import helpers from '../../common/helpers';
 import Store from '../../redux/store';
-
 import { viewToolbarTypes } from '../../redux/constants';
 import SimpleTooltip from '../simpleTooltIp/simpleTooltip';
 import RefreshTimeButton from '../refreshTimeButton/refreshTimeButton';
@@ -56,10 +54,10 @@ class ViewToolbar extends React.Component {
       filterText += value;
     }
 
-    const filter = { field: field, value: value, label: filterText };
+    const filter = { field, value, label: filterText };
     Store.dispatch({
       type: viewToolbarTypes.ADD_FILTER,
-      viewType: viewType,
+      viewType,
       filter
     });
   }
@@ -68,7 +66,7 @@ class ViewToolbar extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.SET_FILTER_TYPE,
-      viewType: viewType,
+      viewType,
       filterType
     });
   }
@@ -79,7 +77,7 @@ class ViewToolbar extends React.Component {
 
     Store.dispatch({
       type: viewToolbarTypes.SET_FILTER_VALUE,
-      viewType: viewType,
+      viewType,
       filterValue
     });
 
@@ -94,7 +92,7 @@ class ViewToolbar extends React.Component {
 
     Store.dispatch({
       type: viewToolbarTypes.SET_FILTER_VALUE,
-      viewType: viewType,
+      viewType,
       filterValue
     });
   }
@@ -113,7 +111,7 @@ class ViewToolbar extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.REMOVE_FILTER,
-      viewType: viewType,
+      viewType,
       filter
     });
   }
@@ -122,7 +120,7 @@ class ViewToolbar extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.CLEAR_FILTERS,
-      viewType: viewType
+      viewType
     });
   }
 
@@ -130,7 +128,7 @@ class ViewToolbar extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.SET_SORT_TYPE,
-      viewType: viewType,
+      viewType,
       sortType
     });
   }
@@ -139,7 +137,7 @@ class ViewToolbar extends React.Component {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.TOGGLE_SORT_ASCENDING,
-      viewType: viewType
+      viewType
     });
   }
 
@@ -246,13 +244,11 @@ class ViewToolbar extends React.Component {
       return [
         <Filter.ActiveLabel key="label">Active Filters:</Filter.ActiveLabel>,
         <Filter.List key="list">
-          {activeFilters.map((item, index) => {
-            return (
-              <Filter.Item key={index} onRemove={this.removeFilter} filterData={item}>
-                {item.label}
-              </Filter.Item>
-            );
-          })}
+          {activeFilters.map((item, index) => (
+            <Filter.Item key={index} onRemove={this.removeFilter} filterData={item}>
+              {item.label}
+            </Filter.Item>
+          ))}
         </Filter.List>,
         <Button bsStyle="link" key="clear" onClick={this.clearFilters}>
           Clear All Filters
@@ -300,9 +296,8 @@ ViewToolbar.propTypes = {
 };
 
 ViewToolbar.defaultProps = {
-  filteredCount: -1,
   itemsType: '',
   itemsTypePlural: ''
 };
 
-export default ViewToolbar;
+export { ViewToolbar as default, ViewToolbar };

--- a/client/src/redux/actions/__tests__/credentialsActions.test.js
+++ b/client/src/redux/actions/__tests__/credentialsActions.test.js
@@ -1,7 +1,6 @@
-import expect from 'expect';
 import { reducers } from '../../reducers';
 
-describe('CredentialsActions', function() {
+describe('CredentialsActions', () => {
   it('Get the initial state', () => {
     expect(reducers.credentials.initialState).toBeDefined();
   });

--- a/client/src/redux/actions/__tests__/factsActions.test.js
+++ b/client/src/redux/actions/__tests__/factsActions.test.js
@@ -1,7 +1,6 @@
-import expect from 'expect';
 import { reducers } from '../../reducers';
 
-describe('FactsActions', function() {
+describe('FactsActions', () => {
   it('Get the initial state', () => {
     expect(reducers.facts.initialState).toBeDefined();
   });

--- a/client/src/redux/actions/__tests__/reportsActions.test.js
+++ b/client/src/redux/actions/__tests__/reportsActions.test.js
@@ -1,7 +1,6 @@
-import expect from 'expect';
 import { reducers } from '../../reducers';
 
-describe('ReportsActions', function() {
+describe('ReportsActions', () => {
   it('Get the initial state', () => {
     expect(reducers.reports.initialState).toBeDefined();
   });

--- a/client/src/redux/actions/__tests__/scansActions.test.js
+++ b/client/src/redux/actions/__tests__/scansActions.test.js
@@ -1,11 +1,10 @@
-import expect from 'expect';
 import moxios from 'moxios';
 import promiseMiddleware from 'redux-promise-middleware';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
-import { actions } from '../';
+import { actions } from '..';
 import { reducers } from '../../reducers';
 
-describe('ScansActions', function() {
+describe('ScansActions', () => {
   const middleware = [promiseMiddleware()];
   const generateStore = () => createStore(combineReducers({ scans: reducers.scans }), applyMiddleware(...middleware));
 
@@ -53,7 +52,7 @@ describe('ScansActions', function() {
 
     const dispatcher = actions.scans.getScans();
     dispatcher(store.dispatch).then(() => {
-      const view = store.getState().scans.view;
+      const { view } = store.getState().scans;
 
       expect(view.scans).toEqual(getScansMock.results);
       expect(view.fulfilled).toBeTruthy();

--- a/client/src/redux/actions/__tests__/sourcesActions.test.js
+++ b/client/src/redux/actions/__tests__/sourcesActions.test.js
@@ -1,7 +1,6 @@
-import expect from 'expect';
 import { reducers } from '../../reducers';
 
-describe('SourcesActions', function() {
+describe('SourcesActions', () => {
   it('Get the initial state', () => {
     expect(reducers.sources.initialState).toBeDefined();
   });

--- a/client/src/redux/actions/__tests__/statusActions.test.js
+++ b/client/src/redux/actions/__tests__/statusActions.test.js
@@ -1,7 +1,6 @@
-import expect from 'expect';
 import { reducers } from '../../reducers';
 
-describe('StatusActions', function() {
+describe('StatusActions', () => {
   it('Get the initial state', () => {
     expect(reducers.status.initialState).toBeDefined();
   });

--- a/client/src/redux/actions/__tests__/userActions.test.js
+++ b/client/src/redux/actions/__tests__/userActions.test.js
@@ -1,7 +1,6 @@
-import expect from 'expect';
 import { reducers } from '../../reducers';
 
-describe('UserActions', function() {
+describe('UserActions', () => {
   it('Get the initial state', () => {
     expect(reducers.user.initialState).toBeDefined();
   });

--- a/client/src/redux/actions/credentialsActions.js
+++ b/client/src/redux/actions/credentialsActions.js
@@ -1,54 +1,47 @@
 import { credentialsTypes } from '../constants';
 import credentialsService from '../../services/credentialsService';
 
-const addCredential = data => dispatch => {
-  return dispatch({
+const addCredential = data => dispatch =>
+  dispatch({
     type: credentialsTypes.ADD_CREDENTIAL,
     payload: credentialsService.addCredential(data)
   });
-};
 
-const getCredential = id => dispatch => {
-  return dispatch({
+const getCredential = id => dispatch =>
+  dispatch({
     type: credentialsTypes.GET_CREDENTIAL,
     payload: credentialsService.getCredential(id)
   });
-};
 
-const getCredentials = (query = {}) => dispatch => {
-  return dispatch({
+const getCredentials = (query = {}) => dispatch =>
+  dispatch({
     type: credentialsTypes.GET_CREDENTIALS,
     payload: credentialsService.getCredentials('', query)
   });
-};
 
-const getWizardCredentials = (query = {}) => dispatch => {
-  return dispatch({
+const getWizardCredentials = (query = {}) => dispatch =>
+  dispatch({
     type: credentialsTypes.GET_WIZARD_CREDENTIALS,
     payload: credentialsService.getCredentials('', query)
   });
-};
 
-const updateCredential = (id, data) => dispatch => {
-  return dispatch({
+const updateCredential = (id, data) => dispatch =>
+  dispatch({
     type: credentialsTypes.UPDATE_CREDENTIAL,
     payload: credentialsService.updateCredential(id, data)
   });
-};
 
-const deleteCredential = id => dispatch => {
-  return dispatch({
+const deleteCredential = id => dispatch =>
+  dispatch({
     type: credentialsTypes.DELETE_CREDENTIAL,
     payload: credentialsService.deleteCredential(id)
   });
-};
 
-const deleteCredentials = (ids = []) => dispatch => {
-  return dispatch({
+const deleteCredentials = (ids = []) => dispatch =>
+  dispatch({
     type: credentialsTypes.DELETE_CREDENTIALS,
     payload: credentialsService.deleteCredentials(ids)
   });
-};
 
 export {
   addCredential,

--- a/client/src/redux/actions/factsActions.js
+++ b/client/src/redux/actions/factsActions.js
@@ -1,11 +1,10 @@
 import { factsTypes } from '../constants';
 import factsService from '../../services/factsService';
 
-const addFacts = data => dispatch => {
-  return dispatch({
+const addFacts = data => dispatch =>
+  dispatch({
     type: factsTypes.ADD_FACTS,
     payload: factsService.addFacts(data)
   });
-};
 
-export { addFacts };
+export { addFacts as default, addFacts };

--- a/client/src/redux/actions/reportsActions.js
+++ b/client/src/redux/actions/reportsActions.js
@@ -1,54 +1,47 @@
 import { reportsTypes } from '../constants';
 import reportsService from '../../services/reportsService';
 
-const getReportSummary = (id, query) => dispatch => {
-  return dispatch({
+const getReportSummary = (id, query) => dispatch =>
+  dispatch({
     type: reportsTypes.GET_REPORT,
     payload: reportsService.getReportSummary(id, query)
   });
-};
 
-const getReportSummaryCsv = (id, query) => dispatch => {
-  return dispatch({
+const getReportSummaryCsv = (id, query) => dispatch =>
+  dispatch({
     type: reportsTypes.GET_REPORT,
     payload: reportsService.getReportSummaryCsv(id, query)
   });
-};
 
-const getReportDetails = id => dispatch => {
-  return dispatch({
+const getReportDetails = id => dispatch =>
+  dispatch({
     type: reportsTypes.GET_REPORT,
     payload: reportsService.getReportDetails(id)
   });
-};
 
-const getReportDetailsCsv = id => dispatch => {
-  return dispatch({
+const getReportDetailsCsv = id => dispatch =>
+  dispatch({
     type: reportsTypes.GET_REPORT,
     payload: reportsService.getReportDetailsCsv(id)
   });
-};
 
-const getMergedScanReportSummaryCsv = id => dispatch => {
-  return dispatch({
+const getMergedScanReportSummaryCsv = id => dispatch =>
+  dispatch({
     type: reportsTypes.GET_REPORT,
     payload: reportsService.getMergedScanReportSummaryCsv(id)
   });
-};
 
-const getMergedScanReportDetailsCsv = id => dispatch => {
-  return dispatch({
+const getMergedScanReportDetailsCsv = id => dispatch =>
+  dispatch({
     type: reportsTypes.GET_REPORT,
     payload: reportsService.getMergedScanReportDetailsCsv(id)
   });
-};
 
-const mergeScanReports = data => dispatch => {
-  return dispatch({
+const mergeScanReports = data => dispatch =>
+  dispatch({
     type: reportsTypes.GET_MERGE_REPORT,
     payload: reportsService.mergeScanReports(data)
   });
-};
 
 export {
   getReportSummary,

--- a/client/src/redux/actions/scansActions.js
+++ b/client/src/redux/actions/scansActions.js
@@ -1,103 +1,89 @@
 import { scansTypes } from '../constants';
 import scansService from '../../services/scansService';
 
-const addScan = data => dispatch => {
-  return dispatch({
+const addScan = data => dispatch =>
+  dispatch({
     type: scansTypes.ADD_SCAN,
     payload: scansService.addScan(data)
   });
-};
 
-const getScan = id => dispatch => {
-  return dispatch({
+const getScan = id => dispatch =>
+  dispatch({
     type: scansTypes.GET_SCAN,
     payload: scansService.getScan(id)
   });
-};
 
-const getScans = (query = {}) => dispatch => {
-  return dispatch({
+const getScans = (query = {}) => dispatch =>
+  dispatch({
     type: scansTypes.GET_SCANS,
     payload: scansService.getScans('', query)
   });
-};
 
-const updateScan = (id, data) => dispatch => {
-  return dispatch({
+const updateScan = (id, data) => dispatch =>
+  dispatch({
     type: scansTypes.UPDATE_SCAN,
     payload: scansService.updateScan(id, data)
   });
-};
 
-const updatePartialScan = (id, data) => dispatch => {
-  return dispatch({
+const updatePartialScan = (id, data) => dispatch =>
+  dispatch({
     type: scansTypes.UPDATE_SCAN,
     payload: scansService.updatePartialScan(id, data)
   });
-};
 
-const deleteScan = id => dispatch => {
-  return dispatch({
+const deleteScan = id => dispatch =>
+  dispatch({
     type: scansTypes.DELETE_SCAN,
     payload: scansService.deleteScan(id)
   });
-};
 
-const startScan = id => dispatch => {
-  return dispatch({
+const startScan = id => dispatch =>
+  dispatch({
     type: scansTypes.START_SCAN,
     payload: scansService.startScan(id)
   });
-};
 
-const getScanJobs = (id, query = {}) => dispatch => {
-  return dispatch({
+const getScanJobs = (id, query = {}) => dispatch =>
+  dispatch({
     type: scansTypes.GET_SCAN_JOBS,
     payload: scansService.getScanJobs(id, query)
   });
-};
 
-const getScanJob = id => dispatch => {
-  return dispatch({
+const getScanJob = id => dispatch =>
+  dispatch({
     type: scansTypes.GET_SCAN_JOB,
     payload: scansService.getScanJob(id)
   });
-};
 
-const getConnectionScanResults = (id, query = {}) => dispatch => {
-  return dispatch({
+const getConnectionScanResults = (id, query = {}) => dispatch =>
+  dispatch({
     type: scansTypes.GET_SCAN_CONNECTION_RESULTS,
     payload: scansService.getConnectionScanResults(id, query)
   });
-};
 
-const getInspectionScanResults = (id, query = {}) => dispatch => {
-  return dispatch({
+const getInspectionScanResults = (id, query = {}) => dispatch =>
+  dispatch({
     type: scansTypes.GET_SCAN_INSPECTION_RESULTS,
     payload: scansService.getInspectionScanResults(id, query)
   });
-};
 
-const pauseScan = id => dispatch => {
-  return dispatch({
+const pauseScan = id => dispatch =>
+  dispatch({
     type: scansTypes.PAUSE_SCAN,
     payload: scansService.pauseScan(id)
   });
-};
 
-const cancelScan = id => dispatch => {
-  return dispatch({
+const cancelScan = id => dispatch =>
+  dispatch({
     type: scansTypes.CANCEL_SCAN,
     payload: scansService.cancelScan(id)
   });
-};
 
-const restartScan = id => dispatch => {
-  return dispatch({
+const restartScan = id => dispatch =>
+  dispatch({
     type: scansTypes.RESTART_SCAN,
     payload: scansService.restartScan(id)
   });
-};
 
 export {
   addScan,

--- a/client/src/redux/actions/sourcesActions.js
+++ b/client/src/redux/actions/sourcesActions.js
@@ -1,53 +1,46 @@
 import { sourcesTypes } from '../constants';
 import sourcesService from '../../services/sourcesService';
 
-const addSource = (data, query = {}) => dispatch => {
-  return dispatch({
+const addSource = (data, query = {}) => dispatch =>
+  dispatch({
     type: sourcesTypes.ADD_SOURCE,
     payload: sourcesService.addSource(data, query)
   });
-};
 
-const deleteSource = id => dispatch => {
-  return dispatch({
+const deleteSource = id => dispatch =>
+  dispatch({
     type: sourcesTypes.DELETE_SOURCE,
     payload: sourcesService.deleteSource(id)
   });
-};
 
-const deleteSources = (ids = []) => dispatch => {
-  return dispatch({
+const deleteSources = (ids = []) => dispatch =>
+  dispatch({
     type: sourcesTypes.DELETE_SOURCES,
     payload: sourcesService.deleteSources(ids)
   });
-};
 
-const getScansSources = (query = {}) => dispatch => {
-  return dispatch({
+const getScansSources = (query = {}) => dispatch =>
+  dispatch({
     type: sourcesTypes.GET_SCANS_SOURCES,
     payload: sourcesService.getSources('', query)
   });
-};
 
-const getSource = id => dispatch => {
-  return dispatch({
+const getSource = id => dispatch =>
+  dispatch({
     type: sourcesTypes.GET_SOURCE,
     payload: sourcesService.getSource(id)
   });
-};
 
-const getSources = (query = {}) => dispatch => {
-  return dispatch({
+const getSources = (query = {}) => dispatch =>
+  dispatch({
     type: sourcesTypes.GET_SOURCES,
     payload: sourcesService.getSources('', query)
   });
-};
 
-const updateSource = (id, data) => dispatch => {
-  return dispatch({
+const updateSource = (id, data) => dispatch =>
+  dispatch({
     type: sourcesTypes.UPDATE_SOURCE,
     payload: sourcesService.updateSource(id, data)
   });
-};
 
 export { addSource, deleteSource, deleteSources, getScansSources, getSource, getSources, updateSource };

--- a/client/src/redux/actions/statusActions.js
+++ b/client/src/redux/actions/statusActions.js
@@ -1,11 +1,10 @@
 import { statusTypes } from '../constants';
 import statusService from '../../services/statusService';
 
-const getStatus = () => dispatch => {
-  return dispatch({
+const getStatus = () => dispatch =>
+  dispatch({
     type: statusTypes.STATUS_INFO,
     payload: statusService.getStatus()
   });
-};
 
-export { getStatus };
+export { getStatus as default, getStatus };

--- a/client/src/redux/actions/userActions.js
+++ b/client/src/redux/actions/userActions.js
@@ -1,25 +1,22 @@
 import { userTypes } from '../constants';
 import userService from '../../services/userService';
 
-const getUser = () => dispatch => {
-  return dispatch({
+const getUser = () => dispatch =>
+  dispatch({
     type: userTypes.USER_INFO,
     payload: userService.whoami()
   });
-};
 
-const authorizeUser = () => dispatch => {
-  return dispatch({
+const authorizeUser = () => dispatch =>
+  dispatch({
     type: userTypes.USER_AUTH,
     payload: userService.whoami()
   });
-};
 
-const logoutUser = () => dispatch => {
-  return dispatch({
+const logoutUser = () => dispatch =>
+  dispatch({
     type: userTypes.USER_LOGOUT,
     payload: userService.logoutUser()
   });
-};
 
 export { getUser, authorizeUser, logoutUser };

--- a/client/src/redux/constants/__tests__/index.test.js
+++ b/client/src/redux/constants/__tests__/index.test.js
@@ -12,7 +12,7 @@ import * as viewTypes from '../viewConstants';
 import * as viewPaginationTypes from '../viewPaginationConstants';
 import * as viewToolbarTypes from '../viewToolbarConstants';
 
-describe('reduxTypes', function() {
+describe('reduxTypes', () => {
   it('should export the same number of name-spaced types as imported', () => {
     expect(Object.keys(reduxTypes)).toHaveLength(12);
   });

--- a/client/src/redux/constants/factsConstants.js
+++ b/client/src/redux/constants/factsConstants.js
@@ -1,3 +1,3 @@
 const ADD_FACTS = 'ADD_FACTS';
 
-export { ADD_FACTS };
+export { ADD_FACTS as default, ADD_FACTS };

--- a/client/src/redux/constants/statusConstants.js
+++ b/client/src/redux/constants/statusConstants.js
@@ -1,3 +1,3 @@
 const STATUS_INFO = 'STATUS_INFO';
 
-export { STATUS_INFO };
+export { STATUS_INFO as default, STATUS_INFO };

--- a/client/src/redux/reducers/__tests__/addSourceWizardReducer.test.js
+++ b/client/src/redux/reducers/__tests__/addSourceWizardReducer.test.js
@@ -17,7 +17,7 @@ const initialState = {
   }
 };
 
-describe('AddSourceWizardReducer', function() {
+describe('AddSourceWizardReducer', () => {
   it('should return the initial state', () => {
     expect(addSourceWizardReducer(undefined, {})).toEqual(initialState);
   });
@@ -65,7 +65,7 @@ describe('AddSourceWizardReducer', function() {
   });
 
   it('should handle ADD_SOURCE_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(sourcesTypes.ADD_SOURCE),
       error: true,
       payload: {
@@ -78,14 +78,14 @@ describe('AddSourceWizardReducer', function() {
       }
     };
 
-    let resultState = addSourceWizardReducer(undefined, dispatched);
+    const resultState = addSourceWizardReducer(undefined, dispatched);
 
     expect(resultState.view.error).toBeTruthy();
     expect(resultState.view.errorMessage).toEqual('ADD ERROR');
   });
 
   it('should handle UPDATE_SOURCE_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(sourcesTypes.UPDATE_SOURCE),
       error: true,
       payload: {
@@ -98,14 +98,14 @@ describe('AddSourceWizardReducer', function() {
       }
     };
 
-    let resultState = addSourceWizardReducer(undefined, dispatched);
+    const resultState = addSourceWizardReducer(undefined, dispatched);
 
     expect(resultState.view.error).toBeTruthy();
     expect(resultState.view.errorMessage).toEqual('UPDATE ERROR');
   });
 
   it('should handle UPDATE_SOURCE_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(sourcesTypes.UPDATE_SOURCE),
       payload: {
         data: {
@@ -140,13 +140,13 @@ describe('AddSourceWizardReducer', function() {
       }
     };
 
-    let resultState = addSourceWizardReducer(undefined, dispatched);
+    const resultState = addSourceWizardReducer(undefined, dispatched);
 
     expect(Object.keys(resultState.view.source).length).toBeGreaterThan(0);
   });
 
   it('should handle ADD_SOURCE_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(sourcesTypes.ADD_SOURCE),
       payload: {
         data: {
@@ -181,7 +181,7 @@ describe('AddSourceWizardReducer', function() {
       }
     };
 
-    let resultState = addSourceWizardReducer(undefined, dispatched);
+    const resultState = addSourceWizardReducer(undefined, dispatched);
 
     expect(Object.keys(resultState.view.source).length).toBeGreaterThan(0);
   });

--- a/client/src/redux/reducers/__tests__/confirmationModalReducer.test.js
+++ b/client/src/redux/reducers/__tests__/confirmationModalReducer.test.js
@@ -1,7 +1,7 @@
 import { confirmationModalTypes } from '../../constants/index';
 import confirmationModalReducer from '../confirmationModalReducer';
 
-describe('ConfirmationModalReducer', function() {
+describe('ConfirmationModalReducer', () => {
   it('should return the initial state', () => {
     const initialState = {
       show: false,

--- a/client/src/redux/reducers/__tests__/credentialsReducer.test.js
+++ b/client/src/redux/reducers/__tests__/credentialsReducer.test.js
@@ -25,7 +25,7 @@ const initialState = {
   }
 };
 
-describe('CredentialsReducer', function() {
+describe('CredentialsReducer', () => {
   it('should return the initial state', () => {
     expect(credentialsReducer(undefined, {})).toEqual(initialState);
   });
@@ -77,7 +77,7 @@ describe('CredentialsReducer', function() {
   });
 
   it('should handle ADD_CREDENTIAL_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(credentialsTypes.ADD_CREDENTIAL),
       error: true,
       payload: {
@@ -90,7 +90,7 @@ describe('CredentialsReducer', function() {
       }
     };
 
-    let resultState = credentialsReducer(undefined, dispatched);
+    const resultState = credentialsReducer(undefined, dispatched);
 
     expect(resultState.update.error).toBeTruthy();
     expect(resultState.update.errorMessage).toEqual('ADD ERROR');
@@ -101,7 +101,7 @@ describe('CredentialsReducer', function() {
   });
 
   it('should handle DELETE_CREDENTIAL_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(credentialsTypes.DELETE_CREDENTIAL),
       error: true,
       payload: {
@@ -114,7 +114,7 @@ describe('CredentialsReducer', function() {
       }
     };
 
-    let resultState = credentialsReducer(undefined, dispatched);
+    const resultState = credentialsReducer(undefined, dispatched);
 
     expect(resultState.update.error).toBeTruthy();
     expect(resultState.update.errorMessage).toEqual('DELETE ERROR');
@@ -125,7 +125,7 @@ describe('CredentialsReducer', function() {
   });
 
   it('should handle UPDATE_CREDENTIAL_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(credentialsTypes.UPDATE_CREDENTIAL),
       error: true,
       payload: {
@@ -138,7 +138,7 @@ describe('CredentialsReducer', function() {
       }
     };
 
-    let resultState = credentialsReducer(undefined, dispatched);
+    const resultState = credentialsReducer(undefined, dispatched);
 
     expect(resultState.update.error).toBeTruthy();
     expect(resultState.update.errorMessage).toEqual('UPDATE ERROR');
@@ -149,7 +149,7 @@ describe('CredentialsReducer', function() {
   });
 
   it('should handle GET_CREDENTIALS_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(credentialsTypes.GET_CREDENTIALS),
       error: true,
       payload: {
@@ -162,7 +162,7 @@ describe('CredentialsReducer', function() {
       }
     };
 
-    let resultState = credentialsReducer(undefined, dispatched);
+    const resultState = credentialsReducer(undefined, dispatched);
 
     expect(resultState.view.error).toBeTruthy();
     expect(resultState.view.errorMessage).toEqual('GET ERROR');
@@ -171,11 +171,11 @@ describe('CredentialsReducer', function() {
   });
 
   it('should handle GET_CREDENTIALS_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(credentialsTypes.GET_CREDENTIALS)
     };
 
-    let resultState = credentialsReducer(undefined, dispatched);
+    const resultState = credentialsReducer(undefined, dispatched);
 
     expect(resultState.view.pending).toBeTruthy();
 
@@ -183,7 +183,7 @@ describe('CredentialsReducer', function() {
   });
 
   it('should handle GET_CREDENTIALS_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(credentialsTypes.GET_CREDENTIALS),
       payload: {
         data: {
@@ -209,7 +209,7 @@ describe('CredentialsReducer', function() {
       }
     };
 
-    let resultState = credentialsReducer(undefined, dispatched);
+    const resultState = credentialsReducer(undefined, dispatched);
 
     expect(resultState.view.fulfilled).toBeTruthy();
     expect(resultState.view.credentials).toHaveLength(4);

--- a/client/src/redux/reducers/__tests__/factsReducer.test.js
+++ b/client/src/redux/reducers/__tests__/factsReducer.test.js
@@ -14,13 +14,13 @@ const initialState = {
   }
 };
 
-describe('factsReducer', function() {
+describe('factsReducer', () => {
   it('should return the initial state', () => {
     expect(factsReducer(undefined, {})).toEqual(initialState);
   });
 
   it('should handle ADD_FACTS_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(factsTypes.ADD_FACTS),
       error: true,
       payload: {
@@ -33,7 +33,7 @@ describe('factsReducer', function() {
       }
     };
 
-    let resultState = factsReducer(undefined, dispatched);
+    const resultState = factsReducer(undefined, dispatched);
     expect(resultState.update.error).toBeTruthy();
     expect(resultState.update.errorMessage).toEqual('GET ERROR');
 
@@ -41,18 +41,18 @@ describe('factsReducer', function() {
   });
 
   it('should handle ADD_FACTS_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(factsTypes.ADD_FACTS)
     };
 
-    let resultState = factsReducer(undefined, dispatched);
+    const resultState = factsReducer(undefined, dispatched);
 
     expect(resultState.update.pending).toBeTruthy();
     expect(resultState.persist).toEqual(initialState.persist);
   });
 
   it('should handle ADD_FACTS_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(factsTypes.ADD_FACTS),
       payload: {
         data: [
@@ -76,7 +76,7 @@ describe('factsReducer', function() {
       }
     };
 
-    let resultState = factsReducer(undefined, dispatched);
+    const resultState = factsReducer(undefined, dispatched);
 
     expect(resultState.update.fulfilled).toBeTruthy();
     expect(resultState.update.facts).toHaveLength(4);

--- a/client/src/redux/reducers/__tests__/reportsReducer.test.js
+++ b/client/src/redux/reducers/__tests__/reportsReducer.test.js
@@ -19,13 +19,13 @@ const initialState = {
   }
 };
 
-describe('ReportsReducer', function() {
+describe('ReportsReducer', () => {
   it('should return the initial state', () => {
     expect(reportsReducer(undefined, {})).toEqual(initialState);
   });
 
   it('should handle GET_REPORT_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(reportsTypes.GET_REPORT),
       error: true,
       payload: {
@@ -38,7 +38,7 @@ describe('ReportsReducer', function() {
       }
     };
 
-    let resultState = reportsReducer(undefined, dispatched);
+    const resultState = reportsReducer(undefined, dispatched);
     expect(resultState.report.error).toBeTruthy();
     expect(resultState.report.errorMessage).toEqual('GET ERROR');
     expect(resultState.report.pending).toBeFalsy();
@@ -49,11 +49,11 @@ describe('ReportsReducer', function() {
   });
 
   it('should handle GET_REPORT_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(reportsTypes.GET_REPORT)
     };
 
-    let resultState = reportsReducer(undefined, dispatched);
+    const resultState = reportsReducer(undefined, dispatched);
 
     expect(resultState.report.error).toBeFalsy();
     expect(resultState.report.errorMessage).toEqual('');
@@ -63,7 +63,7 @@ describe('ReportsReducer', function() {
   });
 
   it('should handle GET_REPORT_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(reportsTypes.GET_REPORT),
       payload: {
         data: [
@@ -87,7 +87,7 @@ describe('ReportsReducer', function() {
       }
     };
 
-    let resultState = reportsReducer(undefined, dispatched);
+    const resultState = reportsReducer(undefined, dispatched);
 
     expect(resultState.report.error).toBeFalsy();
     expect(resultState.report.errorMessage).toEqual('');

--- a/client/src/redux/reducers/__tests__/scansReducer.test.js
+++ b/client/src/redux/reducers/__tests__/scansReducer.test.js
@@ -71,13 +71,13 @@ const initialState = {
   }
 };
 
-describe('scansReducer', function() {
+describe('scansReducer', () => {
   it('should return the initial state', () => {
     expect(scansReducer(undefined, {})).toEqual(initialState);
   });
 
   it('should handle GET_SCANS_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.GET_SCANS),
       error: true,
       payload: {
@@ -90,7 +90,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.view.error).toBeTruthy();
     expect(resultState.view.errorMessage).toEqual('GET ERROR');
@@ -104,11 +104,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCANS_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.GET_SCANS)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.view.pending).toBeTruthy();
 
@@ -121,7 +121,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCANS_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.GET_SCANS),
       payload: {
         data: {
@@ -147,7 +147,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.view.fulfilled).toBeTruthy();
     expect(resultState.view.scans).toHaveLength(4);
@@ -161,7 +161,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.GET_SCAN),
       error: true,
       payload: {
@@ -174,7 +174,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.detail.error).toBeTruthy();
     expect(resultState.detail.errorMessage).toEqual('GET ERROR');
@@ -188,11 +188,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.GET_SCAN)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.detail.pending).toBeTruthy();
 
@@ -205,7 +205,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.GET_SCAN),
       payload: {
         data: {
@@ -217,7 +217,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.detail.fulfilled).toBeTruthy();
     expect(resultState.detail.scan.id).toEqual(1);
@@ -231,7 +231,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_JOBS_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.GET_SCAN_JOBS),
       error: true,
       payload: {
@@ -244,7 +244,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.jobs.error).toBeTruthy();
     expect(resultState.jobs.errorMessage).toEqual('GET JOBS ERROR');
@@ -258,11 +258,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_JOBS_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.GET_SCAN_JOBS)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.jobs.pending).toBeTruthy();
 
@@ -275,7 +275,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_JOBS_FULFILLED', () => {
-    let mockResults = [
+    const mockResults = [
       {
         scan_type: 'inspect',
         options: {
@@ -316,7 +316,7 @@ describe('scansReducer', function() {
       }
     ];
 
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.GET_SCAN_JOBS),
       payload: {
         data: {
@@ -325,7 +325,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.jobs.fulfilled).toBeTruthy();
     expect(resultState.jobs.jobs).toEqual(mockResults);
@@ -339,7 +339,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_CONNECTION_RESULTS_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.GET_SCAN_CONNECTION_RESULTS),
       error: true,
       payload: {
@@ -352,7 +352,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.connectionResults.error).toBeTruthy();
     expect(resultState.connectionResults.errorMessage).toEqual('GET CONNECTION RESULTS ERROR');
@@ -366,11 +366,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_CONNECTION_RESULTS_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.GET_SCAN_CONNECTION_RESULTS)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.connectionResults.pending).toBeTruthy();
 
@@ -383,7 +383,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_CONNECTION_RESULTS_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.GET_SCAN_CONNECTION_RESULTS),
       payload: {
         data: {
@@ -429,7 +429,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.connectionResults.fulfilled).toBeTruthy();
     expect(resultState.connectionResults.results).toHaveLength(4);
@@ -443,7 +443,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_INSPECTION_RESULTS_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.GET_SCAN_INSPECTION_RESULTS),
       error: true,
       payload: {
@@ -456,7 +456,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.inspectionResults.error).toBeTruthy();
     expect(resultState.inspectionResults.errorMessage).toEqual('GET INSPECTION RESULTS ERROR');
@@ -470,11 +470,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_INSPECTION_RESULTS_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.GET_SCAN_INSPECTION_RESULTS)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.inspectionResults.pending).toBeTruthy();
 
@@ -487,7 +487,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle GET_SCAN_INSPECTION_RESULTS_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.GET_SCAN_INSPECTION_RESULTS),
       payload: {
         data: {
@@ -533,7 +533,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.inspectionResults.fulfilled).toBeTruthy();
     expect(resultState.inspectionResults.results).toHaveLength(4);
@@ -547,7 +547,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle ADD_SCAN_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.ADD_SCAN),
       error: true,
       payload: {
@@ -560,7 +560,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.error).toBeTruthy();
     expect(resultState.action.errorMessage).toEqual('ADD ERROR');
@@ -579,11 +579,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle ADD_SCAN_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.ADD_SCAN)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.pending).toBeTruthy();
     expect(resultState.action.add).toBeTruthy();
@@ -601,12 +601,12 @@ describe('scansReducer', function() {
   });
 
   it('should handle ADD_SCAN_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.ADD_SCAN),
       payload: {}
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.fulfilled).toBeTruthy();
     expect(resultState.action.add).toBeTruthy();
@@ -624,7 +624,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle START_SCAN_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.START_SCAN),
       error: true,
       payload: {
@@ -637,7 +637,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.error).toBeTruthy();
     expect(resultState.action.errorMessage).toEqual('START ERROR');
@@ -656,11 +656,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle START_SCAN_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.START_SCAN)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.pending).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -678,12 +678,12 @@ describe('scansReducer', function() {
   });
 
   it('should handle START_SCAN_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.START_SCAN),
       payload: {}
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.fulfilled).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -701,7 +701,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle CANCEL_SCAN_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.CANCEL_SCAN),
       error: true,
       payload: {
@@ -714,7 +714,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.error).toBeTruthy();
     expect(resultState.action.errorMessage).toEqual('CANCEL ERROR');
@@ -733,11 +733,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle CANCEL_SCAN_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.CANCEL_SCAN)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.pending).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -755,12 +755,12 @@ describe('scansReducer', function() {
   });
 
   it('should handle CANCEL_SCAN_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.CANCEL_SCAN),
       payload: {}
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.fulfilled).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -778,7 +778,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle PAUSE_SCAN_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.PAUSE_SCAN),
       error: true,
       payload: {
@@ -791,7 +791,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.error).toBeTruthy();
     expect(resultState.action.errorMessage).toEqual('PAUSE ERROR');
@@ -810,11 +810,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle PAUSE_SCAN_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.PAUSE_SCAN)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.pending).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -831,12 +831,12 @@ describe('scansReducer', function() {
   });
 
   it('should handle PAUSE_SCAN_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.PAUSE_SCAN),
       payload: {}
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.fulfilled).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -854,7 +854,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle RESTART_SCAN_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.RESTART_SCAN),
       error: true,
       payload: {
@@ -867,7 +867,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.error).toBeTruthy();
     expect(resultState.action.errorMessage).toEqual('RESTART ERROR');
@@ -886,11 +886,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle RESTART_SCAN_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.RESTART_SCAN)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.pending).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -908,12 +908,12 @@ describe('scansReducer', function() {
   });
 
   it('should handle RESTART_SCAN_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.RESTART_SCAN),
       payload: {}
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.action.fulfilled).toBeTruthy();
     expect(resultState.action.add).toBeFalsy();
@@ -931,7 +931,7 @@ describe('scansReducer', function() {
   });
 
   it('should handle DELETE_SCAN_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(scansTypes.DELETE_SCAN),
       error: true,
       payload: {
@@ -944,7 +944,7 @@ describe('scansReducer', function() {
       }
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.update.delete).toBeTruthy();
     expect(resultState.update.error).toBeTruthy();
@@ -961,11 +961,11 @@ describe('scansReducer', function() {
   });
 
   it('should handle DELETE_SCAN_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(scansTypes.DELETE_SCAN)
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.update.delete).toBeTruthy();
     expect(resultState.update.error).toBeFalsy();
@@ -982,12 +982,12 @@ describe('scansReducer', function() {
   });
 
   it('should handle DELETE_SCAN_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(scansTypes.DELETE_SCAN),
       payload: {}
     };
 
-    let resultState = scansReducer(undefined, dispatched);
+    const resultState = scansReducer(undefined, dispatched);
 
     expect(resultState.update.delete).toBeTruthy();
     expect(resultState.update.error).toBeFalsy();

--- a/client/src/redux/reducers/__tests__/sourcesReducer.test.js
+++ b/client/src/redux/reducers/__tests__/sourcesReducer.test.js
@@ -21,13 +21,13 @@ const initialState = {
   }
 };
 
-describe('SourcesReducer', function() {
+describe('SourcesReducer', () => {
   it('should return the initial state', () => {
     expect(sourcesReducer(undefined, {})).toEqual(initialState);
   });
 
   it('should handle DELETE_SOURCE_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(sourcesTypes.DELETE_SOURCE),
       error: true,
       payload: {
@@ -40,7 +40,7 @@ describe('SourcesReducer', function() {
       }
     };
 
-    let resultState = sourcesReducer(undefined, dispatched);
+    const resultState = sourcesReducer(undefined, dispatched);
 
     expect(resultState.update.error).toBeTruthy();
     expect(resultState.update.errorMessage).toEqual('DELETE ERROR');
@@ -50,7 +50,7 @@ describe('SourcesReducer', function() {
   });
 
   it('should handle GET_SOURCES_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(sourcesTypes.GET_SOURCES),
       error: true,
       payload: {
@@ -63,7 +63,7 @@ describe('SourcesReducer', function() {
       }
     };
 
-    let resultState = sourcesReducer(undefined, dispatched);
+    const resultState = sourcesReducer(undefined, dispatched);
 
     expect(resultState.view.error).toBeTruthy();
     expect(resultState.view.errorMessage).toEqual('GET ERROR');
@@ -72,11 +72,11 @@ describe('SourcesReducer', function() {
   });
 
   it('should handle GET_SOURCES_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(sourcesTypes.GET_SOURCES)
     };
 
-    let resultState = sourcesReducer(undefined, dispatched);
+    const resultState = sourcesReducer(undefined, dispatched);
 
     expect(resultState.view.pending).toBeTruthy();
 
@@ -84,7 +84,7 @@ describe('SourcesReducer', function() {
   });
 
   it('should handle GET_SOURCES_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(sourcesTypes.GET_SOURCES),
       payload: {
         data: {
@@ -110,7 +110,7 @@ describe('SourcesReducer', function() {
       }
     };
 
-    let resultState = sourcesReducer(undefined, dispatched);
+    const resultState = sourcesReducer(undefined, dispatched);
 
     expect(resultState.view.fulfilled).toBeTruthy();
     expect(resultState.view.sources).toHaveLength(4);

--- a/client/src/redux/reducers/__tests__/toastNotificationsReducer.test.js
+++ b/client/src/redux/reducers/__tests__/toastNotificationsReducer.test.js
@@ -1,6 +1,6 @@
 import toastNotificationsReducer from '../toastNotificationsReducer';
 
-describe('toastNotificationsReducer', function() {
+describe('toastNotificationsReducer', () => {
   it('should return the initial state', () => {
     const initialState = {
       toasts: [],

--- a/client/src/redux/reducers/__tests__/userReducer.test.js
+++ b/client/src/redux/reducers/__tests__/userReducer.test.js
@@ -21,13 +21,13 @@ const initialState = {
   }
 };
 
-describe('userReducer', function() {
+describe('userReducer', () => {
   it('should return the initial state', () => {
     expect(userReducer(undefined, {})).toEqual(initialState);
   });
 
   it('should handle USER_INFO_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(userTypes.USER_INFO),
       error: true,
       payload: {
@@ -40,7 +40,7 @@ describe('userReducer', function() {
       }
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
     expect(resultState.user.error).toBeTruthy();
     expect(resultState.user.errorMessage).toEqual('USER INFO ERROR');
 
@@ -48,18 +48,18 @@ describe('userReducer', function() {
   });
 
   it('should handle USER_INFO_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(userTypes.USER_INFO)
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
 
     expect(resultState.user.pending).toBeTruthy();
     expect(resultState.session).toEqual(initialState.session);
   });
 
   it('should handle USER_INFO_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(userTypes.USER_INFO),
       payload: {
         data: {
@@ -69,7 +69,7 @@ describe('userReducer', function() {
       }
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
 
     expect(resultState.user.fulfilled).toBeTruthy();
     expect(resultState.user.currentUser.userName).toEqual('admin');
@@ -78,7 +78,7 @@ describe('userReducer', function() {
   });
 
   it('should handle USER_AUTH_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(userTypes.USER_AUTH),
       error: true,
       payload: {
@@ -91,7 +91,7 @@ describe('userReducer', function() {
       }
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
     expect(resultState.session.error).toBeTruthy();
     expect(resultState.session.errorMessage).toEqual('USER AUTH ERROR');
 
@@ -99,25 +99,25 @@ describe('userReducer', function() {
   });
 
   it('should handle USER_AUTH_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(userTypes.USER_AUTH)
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
 
     expect(resultState.session.pending).toBeTruthy();
     expect(resultState.user).toEqual(initialState.user);
   });
 
   it('should handle USER_AUTH_FULFILLED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.FULFILLED_ACTION(userTypes.USER_AUTH),
       payload: {
         authToken: 'spoof'
       }
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
 
     expect(resultState.session.fulfilled).toBeTruthy();
     expect(resultState.session.loggedIn).toBeTruthy();
@@ -129,7 +129,7 @@ describe('userReducer', function() {
   });
 
   it('should handle USER_LOGOUT_REJECTED', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.REJECTED_ACTION(userTypes.USER_LOGOUT),
       error: true,
       payload: {
@@ -142,7 +142,7 @@ describe('userReducer', function() {
       }
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
     expect(resultState.session.error).toBeTruthy();
     expect(resultState.session.errorMessage).toEqual('USER LOGOUT ERROR');
 
@@ -150,11 +150,11 @@ describe('userReducer', function() {
   });
 
   it('should handle USER_LOGOUT_PENDING', () => {
-    let dispatched = {
+    const dispatched = {
       type: helpers.PENDING_ACTION(userTypes.USER_LOGOUT)
     };
 
-    let resultState = userReducer(undefined, dispatched);
+    const resultState = userReducer(undefined, dispatched);
 
     expect(resultState.session.pending).toBeTruthy();
     expect(resultState.user).toEqual(initialState.user);

--- a/client/src/redux/reducers/__tests__/viewOptionsReducer.test.js
+++ b/client/src/redux/reducers/__tests__/viewOptionsReducer.test.js
@@ -1,6 +1,6 @@
 import viewOptionsReducer from '../viewOptionsReducer';
 
-describe('viewOptionsReducer', function() {
+describe('viewOptionsReducer', () => {
   it('should return the initial state', () => {
     const initialState = {
       SOURCES_VIEW: {

--- a/client/src/redux/reducers/addSourceWizardReducer.js
+++ b/client/src/redux/reducers/addSourceWizardReducer.js
@@ -1,6 +1,6 @@
+import _ from 'lodash';
 import { credentialsTypes, sourcesTypes } from '../constants';
 import helpers from '../../common/helpers';
-import _ from 'lodash';
 
 const initialState = {
   view: {
@@ -17,7 +17,7 @@ const initialState = {
   }
 };
 
-function addSourceWizardReducer(state = initialState, action) {
+const addSourceWizardReducer = (state = initialState, action) => {
   switch (action.type) {
     // Show/Hide
     case sourcesTypes.CREATE_SOURCE_SHOW:
@@ -156,10 +156,8 @@ function addSourceWizardReducer(state = initialState, action) {
     default:
       return state;
   }
-}
+};
 
 addSourceWizardReducer.initialState = initialState;
 
-export { initialState, addSourceWizardReducer };
-
-export default addSourceWizardReducer;
+export { addSourceWizardReducer as default, initialState, addSourceWizardReducer };

--- a/client/src/redux/reducers/confirmationModalReducer.js
+++ b/client/src/redux/reducers/confirmationModalReducer.js
@@ -10,7 +10,7 @@ const initialState = {
   cancelButtonText: 'Cancel'
 };
 
-const confirmationModalReducer = function(state = initialState, action) {
+const confirmationModalReducer = (state = initialState, action) => {
   switch (action.type) {
     case confirmationModalTypes.CONFIRMATION_MODAL_SHOW:
       return Object.assign({}, state, {
@@ -37,6 +37,4 @@ const confirmationModalReducer = function(state = initialState, action) {
 
 confirmationModalReducer.initialState = initialState;
 
-export { initialState, confirmationModalReducer };
-
-export default confirmationModalReducer;
+export { confirmationModalReducer as default, initialState, confirmationModalReducer };

--- a/client/src/redux/reducers/credentialsReducer.js
+++ b/client/src/redux/reducers/credentialsReducer.js
@@ -25,7 +25,7 @@ const initialState = {
   }
 };
 
-const credentialsReducer = function(state = initialState, action) {
+const credentialsReducer = (state = initialState, action) => {
   switch (action.type) {
     // Show/Hide
     case credentialsTypes.CREATE_CREDENTIAL_SHOW:
@@ -273,6 +273,4 @@ const credentialsReducer = function(state = initialState, action) {
 
 credentialsReducer.initialState = initialState;
 
-export { initialState, credentialsReducer };
-
-export default credentialsReducer;
+export { credentialsReducer as default, initialState, credentialsReducer };

--- a/client/src/redux/reducers/factsReducer.js
+++ b/client/src/redux/reducers/factsReducer.js
@@ -13,7 +13,7 @@ const initialState = {
   }
 };
 
-const factsReducer = function(state = initialState, action) {
+const factsReducer = (state = initialState, action) => {
   switch (action.type) {
     // Error/Rejected
     case helpers.REJECTED_ACTION(factsTypes.ADD_FACTS):
@@ -63,6 +63,4 @@ const factsReducer = function(state = initialState, action) {
 
 factsReducer.initialState = initialState;
 
-export { initialState, factsReducer };
-
-export default factsReducer;
+export { factsReducer as default, initialState, factsReducer };

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -28,6 +28,4 @@ const reducers = {
 
 const reduxReducers = combineReducers(reducers);
 
-export { reduxReducers, reducers };
-
-export default reduxReducers;
+export { reduxReducers as default, reduxReducers, reducers };

--- a/client/src/redux/reducers/reportsReducer.js
+++ b/client/src/redux/reducers/reportsReducer.js
@@ -18,7 +18,7 @@ const initialState = {
   }
 };
 
-const reportsReducer = function(state = initialState, action) {
+const reportsReducer = (state = initialState, action) => {
   switch (action.type) {
     // Error/Rejected
     case helpers.REJECTED_ACTION(reportsTypes.GET_REPORT):
@@ -105,6 +105,4 @@ const reportsReducer = function(state = initialState, action) {
 
 reportsReducer.initialState = initialState;
 
-export { initialState, reportsReducer };
-
-export default reportsReducer;
+export { reportsReducer as default, initialState, reportsReducer };

--- a/client/src/redux/reducers/scansReducer.js
+++ b/client/src/redux/reducers/scansReducer.js
@@ -1,6 +1,6 @@
+import _ from 'lodash';
 import helpers from '../../common/helpers';
 import { scansTypes, sourcesTypes } from '../constants';
-import _ from 'lodash';
 
 const initialState = {
   view: {
@@ -71,7 +71,7 @@ const initialState = {
   }
 };
 
-const scansReducer = function(state = initialState, action) {
+const scansReducer = (state = initialState, action) => {
   switch (action.type) {
     // Error/Rejected
     case helpers.REJECTED_ACTION(scansTypes.GET_SCANS):
@@ -619,6 +619,4 @@ const scansReducer = function(state = initialState, action) {
 
 scansReducer.initialState = initialState;
 
-export { initialState, scansReducer };
-
-export default scansReducer;
+export { scansReducer as default, initialState, scansReducer };

--- a/client/src/redux/reducers/sourcesReducer.js
+++ b/client/src/redux/reducers/sourcesReducer.js
@@ -21,7 +21,7 @@ const initialState = {
   }
 };
 
-const sourcesReducer = function(state = initialState, action) {
+const sourcesReducer = (state = initialState, action) => {
   switch (action.type) {
     // Error/Rejected
     case helpers.REJECTED_ACTION(sourcesTypes.DELETE_SOURCE):
@@ -101,7 +101,7 @@ const sourcesReducer = function(state = initialState, action) {
       return helpers.setStateProp(
         'view',
         {
-          sources: sources,
+          sources,
           fulfilled: true
         },
         {
@@ -117,6 +117,4 @@ const sourcesReducer = function(state = initialState, action) {
 
 sourcesReducer.initialState = initialState;
 
-export { initialState, sourcesReducer };
-
-export default sourcesReducer;
+export { sourcesReducer as default, initialState, sourcesReducer };

--- a/client/src/redux/reducers/statusReducer.js
+++ b/client/src/redux/reducers/statusReducer.js
@@ -9,7 +9,7 @@ const initialState = {
   currentStatus: {}
 };
 
-const statusReducer = function(state = initialState, action) {
+const statusReducer = (state = initialState, action) => {
   switch (action.type) {
     // Error/Rejected
     case helpers.REJECTED_ACTION(statusTypes.STATUS_INFO):
@@ -38,6 +38,4 @@ const statusReducer = function(state = initialState, action) {
 
 statusReducer.initialState = initialState;
 
-export { initialState, statusReducer };
-
-export default statusReducer;
+export { statusReducer as default, initialState, statusReducer };

--- a/client/src/redux/reducers/toastNotificationsReducer.js
+++ b/client/src/redux/reducers/toastNotificationsReducer.js
@@ -5,27 +5,26 @@ const initialState = {
   paused: false
 };
 
-const toastNotificationsReducer = function(state = initialState, action) {
+const toastNotificationsReducer = (state = initialState, action) => {
   switch (action.type) {
     case toastNotificationTypes.TOAST_ADD:
-      let newToast = {
+      const newToast = {
         header: action.header,
         message: action.message,
         alertType: action.alertType,
         persistent: action.persistent
       };
+
       return Object.assign({}, state, {
         toasts: [...state.toasts, newToast],
         displayedToasts: state.displayedToasts + 1
       });
 
     case toastNotificationTypes.TOAST_REMOVE:
-      let index = state.toasts.indexOf(action.toast);
+      const index = state.toasts.indexOf(action.toast);
       action.toast.removed = true;
 
-      let displayedToast = state.toasts.find(toast => {
-        return !toast.removed;
-      });
+      const displayedToast = state.toasts.find(toast => !toast.removed);
 
       if (!displayedToast) {
         return Object.assign({}, state, { toasts: [] });
@@ -48,6 +47,4 @@ const toastNotificationsReducer = function(state = initialState, action) {
 
 toastNotificationsReducer.initialState = initialState;
 
-export { initialState, toastNotificationsReducer };
-
-export default toastNotificationsReducer;
+export { toastNotificationsReducer as default, initialState, toastNotificationsReducer };

--- a/client/src/redux/reducers/userReducer.js
+++ b/client/src/redux/reducers/userReducer.js
@@ -20,7 +20,7 @@ const initialState = {
   }
 };
 
-const userReducer = function(state = initialState, action) {
+const userReducer = (state = initialState, action) => {
   switch (action.type) {
     // Error/Rejected
     case helpers.REJECTED_ACTION(userTypes.USER_INFO):
@@ -159,6 +159,4 @@ const userReducer = function(state = initialState, action) {
 
 userReducer.initialState = initialState;
 
-export { initialState, userReducer };
-
-export default userReducer;
+export { userReducer as default, initialState, userReducer };

--- a/client/src/redux/reducers/viewOptionsReducer.js
+++ b/client/src/redux/reducers/viewOptionsReducer.js
@@ -30,10 +30,10 @@ initialState[viewTypes.SOURCES_VIEW] = Object.assign(INITAL_VIEW_STATE);
 initialState[viewTypes.SCANS_VIEW] = Object.assign(INITAL_VIEW_STATE);
 initialState[viewTypes.CREDENTIALS_VIEW] = Object.assign(INITAL_VIEW_STATE);
 
-const viewOptionsReducer = function(state = initialState, action) {
-  let updateState = {};
+const viewOptionsReducer = (state = initialState, action) => {
+  const updateState = {};
 
-  let updatePageCounts = (viewType, itemsCount) => {
+  const updatePageCounts = (viewType, itemsCount) => {
     let totalCount = itemsCount;
 
     // TODO: Remove this when we get decent data back in development mode
@@ -41,26 +41,20 @@ const viewOptionsReducer = function(state = initialState, action) {
       totalCount = Math.abs(itemsCount) % 1000;
     }
 
-    let totalPages = Math.ceil(totalCount / state[viewType].pageSize);
+    const totalPages = Math.ceil(totalCount / state[viewType].pageSize);
 
     updateState[viewType] = Object.assign({}, state[viewType], {
-      totalCount: totalCount,
-      totalPages: totalPages,
+      totalCount,
+      totalPages,
       currentPage: Math.min(state[viewType].currentPage, totalPages || 1)
     });
   };
 
-  const selectedIndex = function(state, item) {
-    return _.findIndex(state.selectedItems, nextSelected => {
-      return nextSelected.id === _.get(item, 'id');
-    });
-  };
+  const selectedIndex = (state, item) =>
+    _.findIndex(state.selectedItems, nextSelected => nextSelected.id === _.get(item, 'id'));
 
-  const expandedIndex = function(state, item) {
-    return _.findIndex(state.expandedItems, nextExpanded => {
-      return nextExpanded.id === _.get(item, 'id');
-    });
-  };
+  const expandedIndex = (state, item) =>
+    _.findIndex(state.expandedItems, nextExpanded => nextExpanded.id === _.get(item, 'id'));
 
   switch (action.type) {
     case viewToolbarTypes.SET_FILTER_TYPE:
@@ -81,7 +75,7 @@ const viewOptionsReducer = function(state = initialState, action) {
       return Object.assign({}, state, updateState);
 
     case viewToolbarTypes.ADD_FILTER:
-      let currentFilter = state[action.viewType].activeFilters.find(filter => action.filter.field === filter.field);
+      const currentFilter = state[action.viewType].activeFilters.find(filter => action.filter.field === filter.field);
 
       if (!currentFilter) {
         updateState[action.viewType] = Object.assign({}, state[action.viewType], {
@@ -93,7 +87,7 @@ const viewOptionsReducer = function(state = initialState, action) {
         return state;
       } else {
         // replace the existing filter
-        let index = state[action.viewType].activeFilters.indexOf(currentFilter);
+        const index = state[action.viewType].activeFilters.indexOf(currentFilter);
         updateState[action.viewType] = Object.assign({}, state[action.viewType], {
           activeFilters: [
             ...state[action.viewType].activeFilters.slice(0, index),
@@ -107,7 +101,7 @@ const viewOptionsReducer = function(state = initialState, action) {
       return Object.assign({}, state, updateState);
 
     case viewToolbarTypes.REMOVE_FILTER:
-      let index = state[action.viewType].activeFilters.indexOf(action.filter);
+      const index = state[action.viewType].activeFilters.indexOf(action.filter);
       if (index >= 0) {
         updateState[action.viewType] = Object.assign({}, state[action.viewType], {
           activeFilters: [
@@ -274,6 +268,4 @@ const viewOptionsReducer = function(state = initialState, action) {
 
 viewOptionsReducer.initialState = initialState;
 
-export { initialState, viewOptionsReducer };
-
-export default viewOptionsReducer;
+export { viewOptionsReducer as default, initialState, viewOptionsReducer };

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -4,12 +4,10 @@ import { createLogger } from 'redux-logger';
 import promiseMiddleware from 'redux-promise-middleware';
 import reduxReducers from './reducers';
 
-const hydrateStore = () => {
-  // Create any initial state items based on stored data (cookies etc.)
-  return {};
-};
+// Create any initial state items based on stored data (cookies etc.)
+const hydrateStore = () => {};
 
-let middleware = [thunkMiddleware, promiseMiddleware()];
+const middleware = [thunkMiddleware, promiseMiddleware()];
 
 if (process.env.NODE_ENV !== 'production' && process.env.REACT_APP_DEBUG_MIDDLEWARE === 'true') {
   middleware.push(createLogger());

--- a/client/src/services/credentialsService.js
+++ b/client/src/services/credentialsService.js
@@ -8,7 +8,7 @@ class CredentialsService {
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
-      data: data
+      data
     });
   }
 
@@ -45,7 +45,7 @@ class CredentialsService {
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
-      data: data
+      data
     });
   }
 }

--- a/client/src/services/factsService.js
+++ b/client/src/services/factsService.js
@@ -8,7 +8,7 @@ class FactsService {
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
-      data: data
+      data
     });
   }
 }

--- a/client/src/services/reportsService.js
+++ b/client/src/services/reportsService.js
@@ -14,9 +14,9 @@ class ReportsService {
 
         if (window.navigator && window.navigator.msSaveBlob) {
           window.navigator.msSaveBlob(blob, fileName);
-          resolve({ fileName: fileName, data: data });
+          resolve({ fileName, data });
         } else {
-          let anchorTag = window.document.createElement('a');
+          const anchorTag = window.document.createElement('a');
 
           anchorTag.href = window.URL.createObjectURL(blob);
           anchorTag.style.display = 'none';
@@ -29,7 +29,7 @@ class ReportsService {
           setTimeout(() => {
             window.document.body.removeChild(anchorTag);
             window.URL.revokeObjectURL(blob);
-            resolve({ fileName: fileName, data: data });
+            resolve({ fileName, data });
           }, 250);
         }
       } catch (error) {
@@ -39,7 +39,7 @@ class ReportsService {
   }
 
   static getReportDetails(id, query = {}) {
-    let apiPath = process.env.REACT_APP_REPORTS_SERVICE_DETAILS.replace('{0}', id);
+    const apiPath = process.env.REACT_APP_REPORTS_SERVICE_DETAILS.replace('{0}', id);
 
     return axios({
       url: apiPath,
@@ -49,13 +49,13 @@ class ReportsService {
   }
 
   static getReportDetailsCsv(id) {
-    return this.getReportDetails(id, { format: 'csv' }).then(success => {
-      return this.downloadCSV(success.data, `report_${id}_details_${this.getTimeStampFromResults(success)}.csv`);
-    });
+    return this.getReportDetails(id, { format: 'csv' }).then(success =>
+      this.downloadCSV(success.data, `report_${id}_details_${this.getTimeStampFromResults(success)}.csv`)
+    );
   }
 
   static getReportSummary(id, query = {}) {
-    let apiPath = process.env.REACT_APP_REPORTS_SERVICE_DEPLOYMENTS.replace('{0}', id);
+    const apiPath = process.env.REACT_APP_REPORTS_SERVICE_DEPLOYMENTS.replace('{0}', id);
 
     return axios({
       url: apiPath,
@@ -65,28 +65,28 @@ class ReportsService {
   }
 
   static getReportSummaryCsv(id, query = {}) {
-    return this.getReportSummary(id, Object.assign(query, { format: 'csv' })).then(success => {
-      return this.downloadCSV(success.data, `report_${id}_summary_${this.getTimeStampFromResults(success)}.csv`);
-    });
+    return this.getReportSummary(id, Object.assign(query, { format: 'csv' })).then(success =>
+      this.downloadCSV(success.data, `report_${id}_summary_${this.getTimeStampFromResults(success)}.csv`)
+    );
   }
 
   static getMergedScanReportDetailsCsv(id) {
-    return this.getReportDetails(id, { format: 'csv' }).then(success => {
-      return this.downloadCSV(success.data, `merged_report_details_${this.getTimeStampFromResults(success)}.csv`);
-    });
+    return this.getReportDetails(id, { format: 'csv' }).then(success =>
+      this.downloadCSV(success.data, `merged_report_details_${this.getTimeStampFromResults(success)}.csv`)
+    );
   }
 
   static getMergedScanReportSummaryCsv(id) {
-    return this.getReportSummary(id, { format: 'csv' }).then(success => {
-      return this.downloadCSV(success.data, `merged_report_summary_${this.getTimeStampFromResults(success)}.csv`);
-    });
+    return this.getReportSummary(id, { format: 'csv' }).then(success =>
+      this.downloadCSV(success.data, `merged_report_summary_${this.getTimeStampFromResults(success)}.csv`)
+    );
   }
 
   static mergeScanReports(data = {}) {
     return axios({
       method: 'put',
       url: process.env.REACT_APP_REPORTS_SERVICE_MERGE,
-      data: data,
+      data,
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT

--- a/client/src/services/scansService.js
+++ b/client/src/services/scansService.js
@@ -8,7 +8,7 @@ class ScansService {
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
-      data: data
+      data
     });
   }
 
@@ -31,7 +31,7 @@ class ScansService {
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
-      data: data
+      data
     });
   }
 
@@ -41,7 +41,8 @@ class ScansService {
       url: `${process.env.REACT_APP_SCANS_SERVICE}${id}`,
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
-      timeout: process.env.REACT_APP_AJAX_TIMEOUT
+      timeout: process.env.REACT_APP_AJAX_TIMEOUT,
+      data
     });
   }
 

--- a/client/src/services/sourcesService.js
+++ b/client/src/services/sourcesService.js
@@ -8,7 +8,7 @@ class SourcesService {
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
-      data: data,
+      data,
       params: query
     });
   }
@@ -46,7 +46,7 @@ class SourcesService {
       xsrfCookieName: process.env.REACT_APP_AUTH_TOKEN,
       xsrfHeaderName: process.env.REACT_APP_AUTH_HEADER,
       timeout: process.env.REACT_APP_AJAX_TIMEOUT,
-      data: data
+      data
     });
   }
 }

--- a/client/src/services/userService.js
+++ b/client/src/services/userService.js
@@ -11,7 +11,7 @@ class UserService {
 
     const token = cookies.get(process.env.REACT_APP_AUTH_TOKEN);
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       if (token) {
         return resolve({
           authToken: token


### PR DESCRIPTION
**Leaving this PR broken into multiple commits temporarily for review... will rebase accordingly**

### What's included

fix(ui linter): ui activate linter
* arrow-body-style
* class-methods-use-this
* consistent-return
* func-names
* import/no-extraneous-dependencies
* import/no-useless-path-segments
* import/order
* import/prefer-default-export
* no-return-assign
* no-unused-expressions
* no-unused-vars
* object-shorthand
* prefer-arrow-callback
* prefer-destructuring
* prefer-const
* prefer-rest-params
* react/button-has-type
* react/default-props-match-prop-types

### Notes
* This is an incremental client linter update avoiding UI behavior changes
* minor convert from helpers bindMethods on select lint’d files
* prep for expanding unit testing by exporting both Redux connected and "un-connected" components

### Updates issue
updates #1520 