### PR TITLE
UI: Activate select linter rules

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -63,17 +63,6 @@
       "required": {
         "some": [ "nesting", "id" ]
       }
-    }],
-    "jsx-a11y/label-has-associated-control": 0,
-    "no-param-reassign": 0,
-    "no-shadow": 0,
-    "react/destructuring-assignment": 0,
-    "react/jsx-curly-brace-presence": 0,
-    "react/jsx-wrap-multilines": 0,
-    "react/no-access-state-in-setstate": 0,
-    "react/no-array-index-key": 0,
-    "react/no-unused-state": 0,
-    "react/require-default-props": 0,
-    "react/sort-comp": 0
+    }]
   }
 }

--- a/client/src/common/helpers.js
+++ b/client/src/common/helpers.js
@@ -1,12 +1,5 @@
 import _ from 'lodash';
 
-// ToDo: update and remove all bindMethods calls in favor of public class fields syntax
-const bindMethods = (context, methods) => {
-  methods.forEach(method => {
-    context[method] = context[method].bind(context);
-  });
-};
-
 const devModeNormalizeCount = (count, modulus = 100) => Math.abs(count) % modulus;
 
 const generateId = prefix => `${prefix || 'generatedid'}-${Math.ceil(1e5 * Math.random())}`;
@@ -219,7 +212,6 @@ const PENDING_ACTION = base => `${base}_PENDING`;
 const REJECTED_ACTION = base => `${base}_REJECTED`;
 
 export const helpers = {
-  bindMethods,
   devModeNormalizeCount,
   generateId,
   noop,

--- a/client/src/components/about/about.js
+++ b/client/src/components/about/about.js
@@ -50,4 +50,11 @@ About.propTypes = {
   onClose: PropTypes.func
 };
 
+About.defaultProps = {
+  user: {},
+  status: {},
+  shown: false,
+  onClose: helpers.noop
+};
+
 export { About as default, About };

--- a/client/src/components/addSourceWizard/addSourceWizard.js
+++ b/client/src/components/addSourceWizard/addSourceWizard.js
@@ -5,7 +5,8 @@ import { connect } from 'react-redux';
 import Store from '../../redux/store';
 import { confirmationModalTypes, sourcesTypes } from '../../redux/constants';
 import { addSourceWizardSteps, editSourceWizardSteps } from './addSourceWizardConstants';
-import { addSource, updateSource } from '../../redux/actions/sourcesActions';
+import { reduxActions } from '../../redux/actions';
+import helpers from '../../common/helpers';
 
 class AddSourceWizard extends React.Component {
   constructor(props) {
@@ -21,7 +22,9 @@ class AddSourceWizard extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.props.show && nextProps.show) {
+    const { show } = this.props;
+
+    if (!show && nextProps.show) {
       this.resetInitialState(nextProps);
     }
 
@@ -29,14 +32,6 @@ class AddSourceWizard extends React.Component {
       stepOneValid: nextProps.stepOneValid || false,
       stepTwoValid: nextProps.stepTwoValid || false
     });
-  }
-
-  resetInitialState(nextProps) {
-    if (nextProps && nextProps.edit && nextProps.source) {
-      this.setState(Object.assign({ ...this.initialState }, { source: nextProps.source }));
-    } else {
-      this.setState(Object.assign({ ...this.initialState }));
-    }
   }
 
   onCancel = () => {
@@ -113,6 +108,14 @@ class AddSourceWizard extends React.Component {
     }
   };
 
+  resetInitialState(nextProps) {
+    if (nextProps && nextProps.edit && nextProps.source) {
+      this.setState(Object.assign({ ...this.initialState }, { source: nextProps.source }));
+    } else {
+      this.setState(Object.assign({ ...this.initialState }));
+    }
+  }
+
   renderWizardSteps() {
     const { activeStepIndex } = this.state;
     const { edit } = this.props;
@@ -121,7 +124,7 @@ class AddSourceWizard extends React.Component {
 
     return wizardSteps.map((step, stepIndex) => (
       <Wizard.Step
-        key={stepIndex}
+        key={step.title}
         stepIndex={stepIndex}
         step={step.step}
         label={step.label}
@@ -213,9 +216,20 @@ AddSourceWizard.propTypes = {
   error: PropTypes.bool
 };
 
+AddSourceWizard.defaultProps = {
+  addSource: helpers.noop,
+  updateSource: helpers.noop,
+  edit: false,
+  source: {},
+  stepOneValid: false,
+  stepTwoValid: false,
+  fulfilled: false,
+  error: false
+};
+
 const mapDispatchToProps = dispatch => ({
-  addSource: (data, query) => dispatch(addSource(data, query)),
-  updateSource: (id, data) => dispatch(updateSource(id, data))
+  addSource: (data, query) => dispatch(reduxActions.sources.addSource(data, query)),
+  updateSource: (id, data) => dispatch(reduxActions.sources.updateSource(id, data))
 });
 
 const mapStateToProps = state => ({ ...state.addSourceWizard.view });

--- a/client/src/components/addSourceWizard/addSourceWizardField.js
+++ b/client/src/components/addSourceWizard/addSourceWizardField.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Grid } from 'patternfly-react';
 import helpers from '../../common/helpers';
 
-const AddSourceWizardField = ({ children, colLabel = 3, colField = 9, id, label, error, errorMessage, ...props }) => {
+const AddSourceWizardField = ({ children, colLabel, colField, id, label, error, errorMessage, ...props }) => {
   const setId = id || helpers.generateId();
 
   return (
@@ -27,6 +27,15 @@ AddSourceWizardField.propTypes = {
   label: PropTypes.node,
   error: PropTypes.string,
   errorMessage: PropTypes.string
+};
+
+AddSourceWizardField.defaultProps = {
+  colLabel: 3,
+  colField: 9,
+  id: null,
+  label: null,
+  error: null,
+  errorMessage: null
 };
 
 export { AddSourceWizardField as default, AddSourceWizardField };

--- a/client/src/components/addSourceWizard/addSourceWizardStepOne.js
+++ b/client/src/components/addSourceWizard/addSourceWizardStepOne.js
@@ -27,6 +27,15 @@ class AddSourceWizardStepOne extends React.Component {
     });
   }
 
+  onChangeSourceType = event => {
+    this.setState(
+      {
+        sourceType: event.target.value
+      },
+      () => this.validateStep()
+    );
+  };
+
   validateStep() {
     const { sourceType } = this.state;
     const { source } = this.props;
@@ -38,15 +47,6 @@ class AddSourceWizardStepOne extends React.Component {
       });
     }
   }
-
-  onChangeSourceType = event => {
-    this.setState(
-      {
-        sourceType: event.target.value
-      },
-      () => this.validateStep()
-    );
-  };
 
   render() {
     const { sourceType, sourceTypeError } = this.state;
@@ -87,6 +87,10 @@ class AddSourceWizardStepOne extends React.Component {
 
 AddSourceWizardStepOne.propTypes = {
   source: PropTypes.object
+};
+
+AddSourceWizardStepOne.defaultProps = {
+  source: {}
 };
 
 const mapStateToProps = state => ({ ...state.addSourceWizard.view });

--- a/client/src/components/addSourceWizard/addSourceWizardStepThree.js
+++ b/client/src/components/addSourceWizard/addSourceWizardStepThree.js
@@ -44,6 +44,10 @@ AddSourceWizardStepThree.propTypes = {
   view: PropTypes.object
 };
 
+AddSourceWizardStepThree.defaultProps = {
+  view: {}
+};
+
 const mapStateToProps = state => ({ view: state.addSourceWizard.view });
 
 const ConnectedAddSourceWizardStepThree = connect(mapStateToProps)(AddSourceWizardStepThree);

--- a/client/src/components/addSourceWizard/addSourceWizardStepTwo.js
+++ b/client/src/components/addSourceWizard/addSourceWizardStepTwo.js
@@ -9,52 +9,9 @@ import DropdownSelect from '../dropdownSelect/dropdownSelect';
 import { AddSourceWizardField as FieldGroup } from './addSourceWizardField';
 import { apiTypes } from '../../constants';
 import { sourcesTypes, credentialsTypes } from '../../redux/constants';
-import { getWizardCredentials } from '../../redux/actions/credentialsActions';
+import { reduxActions } from '../../redux/actions';
 
 class AddSourceWizardStepTwo extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.initialState = {
-      sourceName: '',
-      sourceNameError: null,
-      multiHostDisplay: '',
-      hosts: [],
-      hostsError: null,
-      credentials: [],
-      credentialsError: null,
-      port: '',
-      portError: null,
-      singleHostPortDisplay: '',
-      sslCertVerify: ''
-    };
-
-    this.state = { ...this.initialState };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const nextSourceType = _.get(nextProps, ['source', apiTypes.API_SOURCE_TYPE]);
-
-    if (nextSourceType !== _.get(this.props, ['source', apiTypes.API_SOURCE_TYPE])) {
-      let sslCertVerify = '';
-
-      if (nextSourceType === 'vcenter' || nextSourceType === 'satellite') {
-        sslCertVerify = _.get(nextProps.source, ['options', apiTypes.API_SOURCE_SSL_CERT], true);
-      }
-
-      this.setState(Object.assign({ ...this.initialState }, { sslCertVerify }), () => {
-        AddSourceWizardStepTwo.invalidateStep();
-      });
-    }
-  }
-
-  componentDidMount() {
-    this.setState({ ...AddSourceWizardStepTwo.initializeState(this.props) }, () => {
-      this.props.getWizardCredentials();
-      this.validateStep();
-    });
-  }
-
   static initializeState(nextProps) {
     if (nextProps.source) {
       const credentials = _.get(nextProps.source, apiTypes.API_SOURCE_CREDENTIALS, []);
@@ -96,72 +53,12 @@ class AddSourceWizardStepTwo extends React.Component {
     });
   }
 
-  validateStep() {
-    const {
-      sourceName,
-      sourceNameError,
-      hosts,
-      hostsError,
-      port,
-      portError,
-      credentials,
-      credentialsError,
-      sslCertVerify
-    } = this.state;
-    const { source } = this.props;
-
-    if (
-      sourceName !== '' &&
-      !sourceNameError &&
-      hosts.length &&
-      !hostsError &&
-      !portError &&
-      credentials.length &&
-      !credentialsError
-    ) {
-      const updatedSource = {};
-
-      _.set(updatedSource, apiTypes.API_SOURCE_NAME, sourceName);
-      _.set(updatedSource, apiTypes.API_SOURCE_HOSTS, hosts);
-      _.set(updatedSource, apiTypes.API_SOURCE_CREDENTIALS, credentials.map(value => parseInt(value, 10)));
-
-      if (port !== '') {
-        _.set(updatedSource, apiTypes.API_SOURCE_PORT, port);
-      }
-
-      if (sslCertVerify !== '') {
-        _.set(updatedSource, ['options', apiTypes.API_SOURCE_SSL_CERT], sslCertVerify);
-      }
-
-      Store.dispatch({
-        type: sourcesTypes.UPDATE_SOURCE_WIZARD_STEPTWO,
-        source: Object.assign({ ...source }, updatedSource)
-      });
-    } else {
-      AddSourceWizardStepTwo.invalidateStep();
-    }
-  }
-
   static validateSourceName(value) {
     if (value === '') {
       return 'You must enter a source name';
     }
 
     return null;
-  }
-
-  onChangeSourceName = event => {
-    this.setState(
-      {
-        sourceName: event.target.value,
-        sourceNameError: AddSourceWizardStepTwo.validateSourceName(event.target.value)
-      },
-      () => this.validateStep()
-    );
-  };
-
-  credentialInfo(id) {
-    return _.find(this.props.allCredentials, { id }) || {};
   }
 
   static validateCredentials(value) {
@@ -171,41 +68,6 @@ class AddSourceWizardStepTwo extends React.Component {
 
     return null;
   }
-
-  onChangeCredential = (event, value) => {
-    const { credentials } = this.state;
-    const { source } = this.props;
-
-    const sourceType = _.get(source, apiTypes.API_SOURCE_TYPE);
-    let submitCreds = [];
-
-    if (sourceType === 'vcenter' || sourceType === 'satellite') {
-      submitCreds = [value.id];
-    } else {
-      submitCreds = [...credentials];
-      const credentialIndex = submitCreds.indexOf(value.id);
-
-      if (credentialIndex < 0) {
-        submitCreds.push(value.id);
-      } else {
-        submitCreds.splice(credentialIndex, 1);
-      }
-    }
-
-    this.setState(
-      { credentials: submitCreds, credentialsError: AddSourceWizardStepTwo.validateCredentials(submitCreds) },
-      () => this.validateStep()
-    );
-  };
-
-  onClickCredential = () => {
-    const { source } = this.props;
-
-    Store.dispatch({
-      type: credentialsTypes.CREATE_CREDENTIAL_SHOW,
-      credentialType: _.get(source, apiTypes.API_SOURCE_TYPE)
-    });
-  };
 
   static validateHosts(value) {
     let validation = null;
@@ -253,6 +115,96 @@ class AddSourceWizardStepTwo extends React.Component {
 
     return null;
   }
+
+  constructor(props) {
+    super(props);
+
+    this.initialState = {
+      sourceName: '',
+      sourceNameError: null,
+      multiHostDisplay: '',
+      hosts: [],
+      hostsError: null,
+      credentials: [],
+      credentialsError: null,
+      port: '',
+      portError: null,
+      singleHostPortDisplay: '',
+      sslCertVerify: ''
+    };
+
+    this.state = { ...this.initialState };
+  }
+
+  componentDidMount() {
+    const { getWizardCredentials } = this.props;
+
+    this.setState({ ...AddSourceWizardStepTwo.initializeState(this.props) }, () => {
+      getWizardCredentials();
+      this.validateStep();
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const nextSourceType = _.get(nextProps, ['source', apiTypes.API_SOURCE_TYPE]);
+
+    if (nextSourceType !== _.get(this.props, ['source', apiTypes.API_SOURCE_TYPE])) {
+      let sslCertVerify = '';
+
+      if (nextSourceType === 'vcenter' || nextSourceType === 'satellite') {
+        sslCertVerify = _.get(nextProps.source, ['options', apiTypes.API_SOURCE_SSL_CERT], true);
+      }
+
+      this.setState(Object.assign({ ...this.initialState }, { sslCertVerify }), () => {
+        AddSourceWizardStepTwo.invalidateStep();
+      });
+    }
+  }
+
+  onChangeSourceName = event => {
+    this.setState(
+      {
+        sourceName: event.target.value,
+        sourceNameError: AddSourceWizardStepTwo.validateSourceName(event.target.value)
+      },
+      () => this.validateStep()
+    );
+  };
+
+  onChangeCredential = (event, value) => {
+    const { credentials } = this.state;
+    const { source } = this.props;
+
+    const sourceType = _.get(source, apiTypes.API_SOURCE_TYPE);
+    let submitCreds = [];
+
+    if (sourceType === 'vcenter' || sourceType === 'satellite') {
+      submitCreds = [value.id];
+    } else {
+      submitCreds = [...credentials];
+      const credentialIndex = submitCreds.indexOf(value.id);
+
+      if (credentialIndex < 0) {
+        submitCreds.push(value.id);
+      } else {
+        submitCreds.splice(credentialIndex, 1);
+      }
+    }
+
+    this.setState(
+      { credentials: submitCreds, credentialsError: AddSourceWizardStepTwo.validateCredentials(submitCreds) },
+      () => this.validateStep()
+    );
+  };
+
+  onClickCredential = () => {
+    const { source } = this.props;
+
+    Store.dispatch({
+      type: credentialsTypes.CREATE_CREDENTIAL_SHOW,
+      credentialType: _.get(source, apiTypes.API_SOURCE_TYPE)
+    });
+  };
 
   onChangePort = targetValue => {
     const { source } = this.props;
@@ -336,6 +288,58 @@ class AddSourceWizardStepTwo extends React.Component {
     );
   };
 
+  validateStep() {
+    const {
+      sourceName,
+      sourceNameError,
+      hosts,
+      hostsError,
+      port,
+      portError,
+      credentials,
+      credentialsError,
+      sslCertVerify
+    } = this.state;
+    const { source } = this.props;
+
+    if (
+      sourceName !== '' &&
+      !sourceNameError &&
+      hosts.length &&
+      !hostsError &&
+      !portError &&
+      credentials.length &&
+      !credentialsError
+    ) {
+      const updatedSource = {};
+
+      _.set(updatedSource, apiTypes.API_SOURCE_NAME, sourceName);
+      _.set(updatedSource, apiTypes.API_SOURCE_HOSTS, hosts);
+      _.set(updatedSource, apiTypes.API_SOURCE_CREDENTIALS, credentials.map(value => parseInt(value, 10)));
+
+      if (port !== '') {
+        _.set(updatedSource, apiTypes.API_SOURCE_PORT, port);
+      }
+
+      if (sslCertVerify !== '') {
+        _.set(updatedSource, ['options', apiTypes.API_SOURCE_SSL_CERT], sslCertVerify);
+      }
+
+      Store.dispatch({
+        type: sourcesTypes.UPDATE_SOURCE_WIZARD_STEPTWO,
+        source: Object.assign({ ...source }, updatedSource)
+      });
+    } else {
+      AddSourceWizardStepTwo.invalidateStep();
+    }
+  }
+
+  credentialInfo(id) {
+    const { allCredentials } = this.props;
+
+    return _.find(allCredentials, { id }) || {};
+  }
+
   renderHosts() {
     const { hostsError, port, portError, multiHostDisplay, singleHostPortDisplay } = this.state;
     const { source } = this.props;
@@ -346,7 +350,7 @@ class AddSourceWizardStepTwo extends React.Component {
       case 'network':
         return (
           <React.Fragment>
-            <FieldGroup label={'Search Addresses'} error={hostsError} errorMessage={hostsError}>
+            <FieldGroup label="Search Addresses" error={hostsError} errorMessage={hostsError}>
               <Form.FormControl
                 componentClass="textarea"
                 name="hosts"
@@ -360,7 +364,7 @@ class AddSourceWizardStepTwo extends React.Component {
                 ranges.
               </Form.HelpBlock>
             </FieldGroup>
-            <FieldGroup label={'Port'} error={portError} errorMessage={portError}>
+            <FieldGroup label="Port" error={portError} errorMessage={portError}>
               <Form.FormControl
                 name="port"
                 type="text"
@@ -377,7 +381,7 @@ class AddSourceWizardStepTwo extends React.Component {
         return (
           <React.Fragment>
             <FieldGroup
-              label={'IP Address or Hostname'}
+              label="IP Address or Hostname"
               error={hostsError || portError}
               errorMessage={hostsError || portError}
             >
@@ -419,7 +423,7 @@ class AddSourceWizardStepTwo extends React.Component {
     }
 
     return (
-      <FieldGroup label={'Credentials'} error={credentialsError} errorMessage={credentialsError}>
+      <FieldGroup label="Credentials" error={credentialsError} errorMessage={credentialsError}>
         <Form.InputGroup>
           <div className="quipucords-dropdownselect">
             <DropdownSelect
@@ -473,7 +477,7 @@ class AddSourceWizardStepTwo extends React.Component {
       case 'vcenter':
       case 'satellite':
         return (
-          <FieldGroup label={'Options'}>
+          <FieldGroup label="Options">
             <div className="quipucords-checkbox">
               <Checkbox checked={sslCertVerify} bsClass="" onChange={this.onChangeSslCertVerify}>
                 &nbsp; Verify SSL Certificate
@@ -494,7 +498,7 @@ class AddSourceWizardStepTwo extends React.Component {
 
     return (
       <Form horizontal>
-        <FieldGroup label={'Name'} error={sourceNameError} errorMessage={sourceNameError}>
+        <FieldGroup label="Name" error={sourceNameError} errorMessage={sourceNameError}>
           <Form.FormControl
             type="text"
             name="sourceName"
@@ -517,8 +521,14 @@ AddSourceWizardStepTwo.propTypes = {
   allCredentials: PropTypes.array
 };
 
+AddSourceWizardStepTwo.defaultProps = {
+  getWizardCredentials: helpers.noop,
+  source: {},
+  allCredentials: []
+};
+
 const mapDispatchToProps = dispatch => ({
-  getWizardCredentials: () => dispatch(getWizardCredentials())
+  getWizardCredentials: () => dispatch(reduxActions.credentials.getWizardCredentials())
 });
 
 const mapStateToProps = state => ({ ...state.addSourceWizard.view });

--- a/client/src/components/app.js
+++ b/client/src/components/app.js
@@ -5,8 +5,7 @@ import { withRouter } from 'react-router';
 import { Alert, EmptyState, Modal, VerticalNav } from 'patternfly-react';
 import _ from 'lodash';
 import { routes } from '../routes';
-import { authorizeUser, getUser, logoutUser } from '../redux/actions/userActions';
-import { getStatus } from '../redux/actions/statusActions';
+import { reduxActions } from '../redux/actions';
 import helpers from '../common/helpers';
 import About from './about/about';
 import AddSourceWizard from './addSourceWizard/addSourceWizard';
@@ -26,33 +25,35 @@ class App extends React.Component {
     this.state = {
       aboutShown: false
     };
-
-    helpers.bindMethods(this, ['showAbout', 'closeAbout']);
   }
 
   componentDidMount() {
-    this.props.authorizeUser();
-    this.props.getStatus();
+    const { authorizeUser, getStatus } = this.props;
+
+    authorizeUser();
+    getStatus();
   }
 
   componentWillReceiveProps(nextProps) {
+    const { getUser } = this.props;
+
     if (_.get(nextProps, 'session.loggedIn') && !_.get(this.props, 'session.loggedIn')) {
-      this.props.getUser();
+      getUser();
     }
   }
 
-  navigateTo(path) {
+  onNavigateTo = path => {
     const { history } = this.props;
     history.push(path);
-  }
+  };
 
-  showAbout() {
+  onShowAbout = () => {
     this.setState({ aboutShown: true });
-  }
+  };
 
-  closeAbout() {
+  onCloseAbout = () => {
     this.setState({ aboutShown: false });
-  }
+  };
 
   renderMenuItems() {
     const { location } = this.props;
@@ -65,7 +66,7 @@ class App extends React.Component {
         title={item.title}
         iconClass={item.iconClass}
         active={item === activeItem || (!activeItem && item.redirect)}
-        onClick={() => this.navigateTo(item.to)}
+        onClick={() => this.onNavigateTo(item.to)}
       />
     ));
   }
@@ -74,7 +75,7 @@ class App extends React.Component {
     const { logoutUser } = this.props;
 
     return [
-      <VerticalNav.Item key="about" className="collapsed-nav-item" title="About" onClick={() => this.showAbout()} />,
+      <VerticalNav.Item key="about" className="collapsed-nav-item" title="About" onClick={() => this.onShowAbout()} />,
       <VerticalNav.Item key="logout" className="collapsed-nav-item" title="Logout" onClick={logoutUser} />
     ];
   }
@@ -121,7 +122,7 @@ class App extends React.Component {
         <Content />
         <ToastNotificationsList key="toastList" />
         <ConfirmationModal key="confirmationModal" />
-        <About user={user} status={status} shown={aboutShown} onClose={this.closeAbout} />
+        <About user={user} status={status} shown={aboutShown} onClose={this.onCloseAbout} />
         <AddSourceWizard />
         <CreateCredentialDialog />
       </React.Fragment>
@@ -157,7 +158,7 @@ class App extends React.Component {
         <VerticalNav persistentSecondary={false}>
           <VerticalNav.Masthead>
             <VerticalNav.Brand titleImg={titleImg} />
-            <MastheadOptions user={user} showAboutModal={this.showAbout} logoutUser={logoutUser} />
+            <MastheadOptions user={user} showAboutModal={this.onShowAbout} logoutUser={logoutUser} />
           </VerticalNav.Masthead>
           {this.renderMenuItems()}
           {this.renderMenuActions()}
@@ -182,11 +183,22 @@ App.propTypes = {
   }).isRequired
 };
 
+App.defaultProps = {
+  authorizeUser: helpers.noop,
+  getUser: helpers.noop,
+  getStatus: helpers.noop,
+  logoutUser: helpers.noop,
+  session: {},
+  user: {},
+  status: {},
+  location: {}
+};
+
 const mapDispatchToProps = dispatch => ({
-  authorizeUser: () => dispatch(authorizeUser()),
-  getUser: () => dispatch(getUser()),
-  logoutUser: () => dispatch(logoutUser()),
-  getStatus: () => dispatch(getStatus())
+  authorizeUser: () => dispatch(reduxActions.user.authorizeUser()),
+  getUser: () => dispatch(reduxActions.user.getUser()),
+  logoutUser: () => dispatch(reduxActions.user.logoutUser()),
+  getStatus: () => dispatch(reduxActions.status.getStatus())
 });
 
 const mapStateToProps = state => ({

--- a/client/src/components/confirmationModal/__tests__/__snapshots__/confirmationModal.test.js.snap
+++ b/client/src/components/confirmationModal/__tests__/__snapshots__/confirmationModal.test.js.snap
@@ -101,6 +101,7 @@ exports[`ConfirmationModal Component should shallow render a basic component 1`]
       bsClass="btn"
       bsStyle="primary"
       disabled={false}
+      onClick={[Function]}
     >
       Confirm
     </Button>

--- a/client/src/components/confirmationModal/confirmationModal.js
+++ b/client/src/components/confirmationModal/confirmationModal.js
@@ -2,34 +2,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Modal, Button, Icon } from 'patternfly-react';
-import helpers from '../../common/helpers';
 import Store from '../../redux/store';
 import { confirmationModalTypes } from '../../redux/constants';
+import helpers from '../../common/helpers';
 
 class ConfirmationModal extends React.Component {
-  constructor() {
-    super();
+  onClose = () => {
+    const { onCancel } = this.props;
 
-    helpers.bindMethods(this, ['cancel']);
-  }
-
-  cancel() {
-    if (this.props.onCancel) {
-      this.props.onCancel();
+    if (onCancel) {
+      onCancel();
     } else {
       Store.dispatch({
         type: confirmationModalTypes.CONFIRMATION_MODAL_HIDE
       });
     }
-  }
+  };
 
   render() {
     const { show, title, heading, body, icon, confirmButtonText, cancelButtonText, onConfirm } = this.props;
 
     return (
-      <Modal show={show} onHide={this.cancel}>
+      <Modal show={show} onHide={this.onClose}>
         <Modal.Header>
-          <button type="button" className="close" onClick={this.cancel} aria-hidden="true" aria-label="Close">
+          <button type="button" className="close" onClick={this.onClose} aria-hidden="true" aria-label="Close">
             <Icon type="pf" name="close" />
           </button>
           <Modal.Title>{title}</Modal.Title>
@@ -46,7 +42,7 @@ class ConfirmationModal extends React.Component {
           </div>
         </Modal.Body>
         <Modal.Footer>
-          <Button autoFocus bsStyle="default" className="btn-cancel" onClick={this.cancel}>
+          <Button autoFocus bsStyle="default" className="btn-cancel" onClick={this.onClose}>
             {cancelButtonText}
           </Button>
           <Button bsStyle="primary" onClick={onConfirm}>
@@ -75,7 +71,10 @@ ConfirmationModal.defaultProps = {
   heading: null,
   body: null,
   icon: <Icon type="pf" name="warning-triangle-o" />,
-  confirmButtonText: 'Confirm'
+  confirmButtonText: 'Confirm',
+  cancelButtonText: '',
+  onConfirm: helpers.noop,
+  onCancel: null
 };
 
 const mapStateToProps = state => ({ ...state.confirmationModal });

--- a/client/src/components/content/__tests__/__snapshots__/content.test.js.snap
+++ b/client/src/components/content/__tests__/__snapshots__/content.test.js.snap
@@ -7,17 +7,17 @@ exports[`ConfirmationModal Component should shallow render a basic component 1`]
   <Switch>
     <Route
       component={[Function]}
-      key="0"
+      key="/sources"
       path="/sources"
     />
     <Route
       component={[Function]}
-      key="1"
+      key="/scans"
       path="/scans"
     />
     <Route
       component={[Function]}
-      key="2"
+      key="/credentials"
       path="/credentials"
     />
     <Redirect

--- a/client/src/components/content/content.js
+++ b/client/src/components/content/content.js
@@ -7,12 +7,12 @@ class Content extends React.Component {
     let redirectRoot = null;
 
     return {
-      renderRoutes: routes().map((item, index) => {
+      renderRoutes: routes().map(item => {
         if (item.redirect === true) {
           redirectRoot = <Redirect from="/" to={item.to} />;
         }
 
-        return <Route key={index} path={item.to} component={item.component} />;
+        return <Route key={item.to} path={item.to} component={item.component} />;
       }),
       redirectRoot
     };

--- a/client/src/components/createCredentialDialog/__tests__/__snapshots__/createCredentialDialog.test.js.snap
+++ b/client/src/components/createCredentialDialog/__tests__/__snapshots__/createCredentialDialog.test.js.snap
@@ -242,6 +242,7 @@ exports[`CreateCredentialDialog Component should shallow render a basic componen
   >
     <Button
       active={false}
+      autoFocus={false}
       block={false}
       bsClass="btn"
       bsStyle="default"

--- a/client/src/components/credentials/__tests__/__snapshots__/credentialsListItem.test.js.snap
+++ b/client/src/components/credentials/__tests__/__snapshots__/credentialsListItem.test.js.snap
@@ -80,7 +80,9 @@ exports[`CredentialListItem Component should render a basic component with a cre
             <span
               class="quipucords-description-right"
             >
-              <span />
+              <span>
+                Username and Password
+              </span>
             </span>
           </div>
         </div>

--- a/client/src/components/credentials/credentialsEmptyState.js
+++ b/client/src/components/credentials/credentialsEmptyState.js
@@ -42,4 +42,9 @@ CredentialsEmptyState.propTypes = {
   onAddSource: PropTypes.func
 };
 
+CredentialsEmptyState.defaultProps = {
+  onAddCredential: helpers.noop,
+  onAddSource: helpers.noop
+};
+
 export { CredentialsEmptyState as default, CredentialsEmptyState };

--- a/client/src/components/dropdownSelect/dropdownSelect.js
+++ b/client/src/components/dropdownSelect/dropdownSelect.js
@@ -67,4 +67,9 @@ DropdownSelect.propTypes = {
   multiselect: PropTypes.bool
 };
 
+DropdownSelect.defaultProps = {
+  id: null,
+  multiselect: false
+};
+
 export { DropdownSelect as default, DropdownSelect };

--- a/client/src/components/listStatusItem/listStatusItem.js
+++ b/client/src/components/listStatusItem/listStatusItem.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import { Icon, ListView } from 'patternfly-react';
 import _ from 'lodash';
 import SimpleTooltip from '../simpleTooltIp/simpleTooltip';
+import helpers from '../../common/helpers';
 
 const ListStatusItem = ({
   id,
@@ -16,20 +17,20 @@ const ListStatusItem = ({
   toggleExpand,
   iconInfo
 }) => {
-  const renderExpandContent = (iconInfo, count, text) => {
-    if (iconInfo) {
-      const classes = cx('list-view-compound-item-icon', ..._.get(iconInfo, 'classNames', []));
+  const renderExpandContent = (displayIconInfo, displayCount, text) => {
+    if (displayIconInfo) {
+      const classes = cx('list-view-compound-item-icon', ..._.get(displayIconInfo, 'classNames', []));
       return (
         <React.Fragment>
-          <Icon className={classes} type={iconInfo.type} name={iconInfo.name} />
-          <strong>{count}</strong>
+          <Icon className={classes} type={displayIconInfo.type} name={displayIconInfo.name} />
+          <strong>{displayCount}</strong>
         </React.Fragment>
       );
     }
 
     return (
       <span>
-        <strong>{count}</strong>
+        <strong>{displayCount}</strong>
         {` ${text}`}
       </span>
     );
@@ -71,6 +72,18 @@ ListStatusItem.propTypes = {
   expandType: PropTypes.string,
   toggleExpand: PropTypes.func,
   iconInfo: PropTypes.object
+};
+
+ListStatusItem.defaultProps = {
+  id: null,
+  count: 0,
+  emptyText: null,
+  tipSingular: null,
+  tipPlural: null,
+  expanded: false,
+  expandType: null,
+  toggleExpand: helpers.noop,
+  iconInfo: null
 };
 
 export { ListStatusItem as default, ListStatusItem };

--- a/client/src/components/mastheadOptions/mastheadOptions.js
+++ b/client/src/components/mastheadOptions/mastheadOptions.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown, Icon, MenuItem } from 'patternfly-react';
+import helpers from '../../common/helpers';
 
 const MastheadOptions = ({ user, logoutUser, showAboutModal }) => (
   <nav className="collapse navbar-collapse">
@@ -29,6 +30,12 @@ MastheadOptions.propTypes = {
   user: PropTypes.object,
   logoutUser: PropTypes.func,
   showAboutModal: PropTypes.func
+};
+
+MastheadOptions.defaultProps = {
+  user: {},
+  logoutUser: helpers.noop,
+  showAboutModal: helpers.noop
 };
 
 export { MastheadOptions as default, MastheadOptions };

--- a/client/src/components/refreshTimeButton/__tests__/__snapshots__/refreshTimeButton.test.js.snap
+++ b/client/src/components/refreshTimeButton/__tests__/__snapshots__/refreshTimeButton.test.js.snap
@@ -12,7 +12,7 @@ exports[`RefreshTimeButton Component should render 1`] = `
   <span
     class="last-refresh-time"
   >
-    Refreshed 
+    Refreshed 0
   </span>
 </button>
 `;

--- a/client/src/components/refreshTimeButton/refreshTimeButton.js
+++ b/client/src/components/refreshTimeButton/refreshTimeButton.js
@@ -2,13 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Icon } from 'patternfly-react';
 import * as moment from 'moment';
-import helpers from '../../common/helpers';
 
 class RefreshTimeButton extends React.Component {
   constructor(props) {
     super(props);
-
-    helpers.bindMethods(this, ['doUpdate']);
 
     this.pollingInterval = null;
     this.mounted = false;
@@ -18,24 +15,24 @@ class RefreshTimeButton extends React.Component {
     this.mounted = true;
   }
 
-  componentWillUnmount() {
-    this.stopPolling();
-    this.mounted = false;
-  }
-
   componentWillReceiveProps(nextProps) {
     if (nextProps.lastRefresh && !this.lastRefresh) {
       this.startPolling();
     }
   }
 
-  doUpdate() {
-    this.forceUpdate();
+  componentWillUnmount() {
+    this.stopPolling();
+    this.mounted = false;
   }
+
+  onDoUpdate = () => {
+    this.forceUpdate();
+  };
 
   startPolling() {
     if (!this.pollingInterval && this.mounted) {
-      this.pollingInterval = setInterval(this.doUpdate, 3000);
+      this.pollingInterval = setInterval(this.onDoUpdate, 3000);
     }
   }
 
@@ -68,6 +65,10 @@ class RefreshTimeButton extends React.Component {
 RefreshTimeButton.propTypes = {
   lastRefresh: PropTypes.number,
   onRefresh: PropTypes.func.isRequired
+};
+
+RefreshTimeButton.defaultProps = {
+  lastRefresh: 0
 };
 
 export { RefreshTimeButton as default, RefreshTimeButton };

--- a/client/src/components/scans/__tests__/__snapshots__/scanSourceList.test.js.snap
+++ b/client/src/components/scans/__tests__/__snapshots__/scanSourceList.test.js.snap
@@ -9,7 +9,7 @@ exports[`ScanSourceList Component should shallow render a basic component with s
   <Row
     bsClass="row"
     componentClass="div"
-    key="0"
+    key="15"
   >
     <Col
       bsClass="col"
@@ -22,6 +22,7 @@ exports[`ScanSourceList Component should shallow render a basic component with s
         type="pf"
       />
         
+      TestSource
     </Col>
     <Col
       bsClass="col"

--- a/client/src/components/scans/__tests__/scanSourceList.test.js
+++ b/client/src/components/scans/__tests__/scanSourceList.test.js
@@ -12,6 +12,8 @@ describe('ScanSourceList Component', () => {
       scan: {
         sources: [
           {
+            id: 15,
+            name: 'TestSource',
             source_type: 'network'
           }
         ]

--- a/client/src/components/scans/scanJobsList.js
+++ b/client/src/components/scans/scanJobsList.js
@@ -6,13 +6,11 @@ import { Dropdown, EmptyState, Grid, Icon, MenuItem, Pager } from 'patternfly-re
 import _ from 'lodash';
 import * as moment from 'moment/moment';
 import helpers from '../../common/helpers';
-import { getScanJobs } from '../../redux/actions/scansActions';
+import { reduxActions } from '../../redux/actions';
 
 class ScanJobsList extends React.Component {
   constructor() {
     super();
-
-    helpers.bindMethods(this, ['onNextPage', 'onPreviousPage']);
 
     this.state = {
       scanJobs: [],
@@ -29,24 +27,30 @@ class ScanJobsList extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    const { lastRefresh } = this.props;
     // Check for changes resulting in a fetch
-    if (!_.isEqual(nextProps.lastRefresh, this.props.lastRefresh)) {
+    if (!_.isEqual(nextProps.lastRefresh, lastRefresh)) {
       this.refresh();
     }
   }
 
-  onNextPage() {
-    this.setState({ page: this.state.page + 1 });
-    this.refresh(this.state.page + 1);
-  }
+  onNextPage = () => {
+    const { page } = this.state;
 
-  onPreviousPage() {
-    this.setState({ page: this.state.page - 1 });
-    this.refresh(this.state.page - 1);
-  }
+    this.setState({ page: page + 1 });
+    this.refresh(page + 1);
+  };
 
-  refresh(page) {
+  onPreviousPage = () => {
+    const { page } = this.state;
+
+    this.setState({ page: page - 1 });
+    this.refresh(page - 1);
+  };
+
+  refresh(passedPage) {
     const { scan, getScanJobs } = this.props;
+    const { page } = this.state;
 
     this.setState({
       scanJobsPending: true,
@@ -55,7 +59,7 @@ class ScanJobsList extends React.Component {
     });
 
     const queryObject = {
-      page: page === undefined ? this.state.page : page,
+      page: passedPage === undefined ? page : passedPage,
       page_size: 100,
       ordering: 'name'
     };
@@ -190,8 +194,16 @@ ScanJobsList.propTypes = {
   getScanJobs: PropTypes.func
 };
 
+ScanJobsList.defaultProps = {
+  scan: {},
+  lastRefresh: 0,
+  onSummaryDownload: helpers.noop,
+  onDetailedDownload: helpers.noop,
+  getScanJobs: helpers.noop
+};
+
 const mapDispatchToProps = dispatch => ({
-  getScanJobs: (id, query) => dispatch(getScanJobs(id, query))
+  getScanJobs: (id, query) => dispatch(reduxActions.scans.getScanJobs(id, query))
 });
 
 const mapStateToProps = () => ({});

--- a/client/src/components/scans/scanListItem.js
+++ b/client/src/components/scans/scanListItem.js
@@ -15,45 +15,15 @@ import ScanJobsList from './scanJobsList';
 import ListStatusItem from '../listStatusItem/listStatusItem';
 
 class ScanListItem extends React.Component {
-  constructor() {
-    super();
-
-    this.state = {
-      scanResultsPending: false,
-      scanResultsError: null,
-      scanResults: null,
-      scanJobsPending: false,
-      scanJobsError: null,
-      scanJobs: null
-    };
+  static isSelected(item, selectedSources) {
+    return _.find(selectedSources, nextSelected => nextSelected.id === item.id) !== undefined;
   }
 
   componentWillReceiveProps(nextProps) {
+    const { lastRefresh } = this.props;
     // Check for changes resulting in a fetch
-    if (!_.isEqual(nextProps.lastRefresh, this.props.lastRefresh)) {
+    if (!_.isEqual(nextProps.lastRefresh, lastRefresh)) {
       this.closeExpandIfNoData(this.expandType());
-    }
-  }
-
-  expandType() {
-    const { item, expandedScans } = this.props;
-
-    return _.get(_.find(expandedScans, nextExpanded => nextExpanded.id === item.id), 'expandType');
-  }
-
-  closeExpandIfNoData(expandType) {
-    const { item } = this.props;
-
-    const successHosts = _.get(item, 'most_recent.systems_scanned', 0);
-    const failedHosts = _.get(item, 'most_recent.systems_failed', 0);
-    const prevCount = Math.max(_.get(item, 'jobs', []).length - 1, 0);
-
-    if (
-      (expandType === 'systemsScanned' && successHosts === 0) ||
-      (expandType === 'systemsFailed' && failedHosts === 0) ||
-      (expandType === 'jobs' && prevCount === 0)
-    ) {
-      this.onCloseExpand();
     }
   }
 
@@ -85,10 +55,6 @@ class ScanListItem extends React.Component {
     });
   };
 
-  static isSelected(item, selectedSources) {
-    return _.find(selectedSources, nextSelected => nextSelected.id === item.id) !== undefined;
-  }
-
   onItemSelectChange = () => {
     const { item, selectedScans } = this.props;
 
@@ -98,6 +64,28 @@ class ScanListItem extends React.Component {
       item
     });
   };
+
+  expandType() {
+    const { item, expandedScans } = this.props;
+
+    return _.get(_.find(expandedScans, nextExpanded => nextExpanded.id === item.id), 'expandType');
+  }
+
+  closeExpandIfNoData(expandType) {
+    const { item } = this.props;
+
+    const successHosts = _.get(item, 'most_recent.systems_scanned', 0);
+    const failedHosts = _.get(item, 'most_recent.systems_failed', 0);
+    const prevCount = Math.max(_.get(item, 'jobs', []).length - 1, 0);
+
+    if (
+      (expandType === 'systemsScanned' && successHosts === 0) ||
+      (expandType === 'systemsFailed' && failedHosts === 0) ||
+      (expandType === 'jobs' && prevCount === 0)
+    ) {
+      this.onCloseExpand();
+    }
+  }
 
   renderDescription() {
     const { item } = this.props;
@@ -365,6 +353,18 @@ ScanListItem.propTypes = {
   onResume: PropTypes.func,
   selectedScans: PropTypes.array,
   expandedScans: PropTypes.array
+};
+
+ScanListItem.defaultProps = {
+  lastRefresh: 0,
+  onSummaryDownload: helpers.noop,
+  onDetailedDownload: helpers.noop,
+  onPause: helpers.noop,
+  onCancel: helpers.noop,
+  onStart: helpers.noop,
+  onResume: helpers.noop,
+  selectedScans: [],
+  expandedScans: []
 };
 
 const mapStateToProps = state => ({

--- a/client/src/components/scans/scansEmptyState.js
+++ b/client/src/components/scans/scansEmptyState.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, EmptyState, Grid, Row } from 'patternfly-react';
 import SourcesEmptyState from '../sources/sourcesEmptyState';
+import helpers from '../../common/helpers';
 
 const ScansEmptyState = ({ onAddSource, sourcesExist }) => {
   if (sourcesExist) {
@@ -29,6 +30,11 @@ const ScansEmptyState = ({ onAddSource, sourcesExist }) => {
 ScansEmptyState.propTypes = {
   onAddSource: PropTypes.func,
   sourcesExist: PropTypes.bool
+};
+
+ScansEmptyState.defaultProps = {
+  onAddSource: helpers.noop,
+  sourcesExist: false
 };
 
 export { ScansEmptyState as default, ScansEmptyState };

--- a/client/src/components/simpleTooltIp/simpleTooltip.js
+++ b/client/src/components/simpleTooltIp/simpleTooltip.js
@@ -22,6 +22,8 @@ SimpleTooltip.propTypes = {
 };
 
 SimpleTooltip.defaultProps = {
+  children: null,
+  tooltip: null,
   placement: 'top',
   trigger: ['hover'],
   delayShow: 500

--- a/client/src/components/sources/__tests__/__snapshots__/createScanDialog.test.js.snap
+++ b/client/src/components/sources/__tests__/__snapshots__/createScanDialog.test.js.snap
@@ -56,12 +56,7 @@ exports[`CreateScanDialog Component should render a basic component 1`] = `
                 class="col-sm-3 control-label"
                 for="scanName"
               >
-                <label
-                  class="control-label"
-                  for="scanName"
-                >
-                  Name
-                </label>
+                Name
               </label>
               <div
                 class="col-sm-9"

--- a/client/src/components/sources/sourceCredentialsList.js
+++ b/client/src/components/sources/sourceCredentialsList.js
@@ -10,8 +10,8 @@ const SourceCredentialsList = ({ source }) => {
 
   return (
     <Grid fluid>
-      {credentials.map((item, index) => (
-        <Grid.Row key={index}>
+      {credentials.map(item => (
+        <Grid.Row key={item.name}>
           <Grid.Col xs={12} sm={4}>
             <span>
               <Icon type="fa" name="id-card" />
@@ -26,6 +26,10 @@ const SourceCredentialsList = ({ source }) => {
 
 SourceCredentialsList.propTypes = {
   source: PropTypes.object
+};
+
+SourceCredentialsList.defaultProps = {
+  source: {}
 };
 
 export { SourceCredentialsList as default, SourceCredentialsList };

--- a/client/src/components/sources/sourceListItem.js
+++ b/client/src/components/sources/sourceListItem.js
@@ -14,21 +14,16 @@ import SimpleTooltip from '../simpleTooltIp/simpleTooltip';
 import ListStatusItem from '../listStatusItem/listStatusItem';
 
 class SourceListItem extends React.Component {
-  componentWillReceiveProps(nextProps) {
-    // Check for changes resulting in a fetch
-    if (!_.isEqual(nextProps.lastRefresh, this.props.lastRefresh)) {
-      this.closeExpandIfNoData(this.expandType());
-    }
-  }
-
-  expandType() {
-    const { item, expandedSources } = this.props;
-
-    return _.get(_.find(expandedSources, nextExpanded => nextExpanded.id === item.id), 'expandType');
-  }
-
   static isSelected(item, selectedSources) {
     return _.find(selectedSources, nextSelected => nextSelected.id === item.id) !== undefined;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { lastRefresh } = this.props;
+    // Check for changes resulting in a fetch
+    if (!_.isEqual(nextProps.lastRefresh, lastRefresh)) {
+      this.closeExpandIfNoData(this.expandType());
+    }
   }
 
   onItemSelectChange = () => {
@@ -40,19 +35,6 @@ class SourceListItem extends React.Component {
       item
     });
   };
-
-  closeExpandIfNoData(expandType) {
-    const { item } = this.props;
-
-    if (expandType === 'okHosts' || expandType === 'failedHosts') {
-      const okHostCount = _.get(item, 'connection.source_systems_scanned', 0);
-      const failedHostCount = _.get(item, 'connection.source_systems_failed', 0);
-
-      if ((expandType === 'okHosts' && okHostCount === 0) || (expandType === 'failedHosts' && failedHostCount === 0)) {
-        this.onCloseExpand();
-      }
-    }
-  }
 
   onToggleExpand = expandType => {
     const { item } = this.props;
@@ -81,6 +63,25 @@ class SourceListItem extends React.Component {
       item
     });
   };
+
+  expandType() {
+    const { item, expandedSources } = this.props;
+
+    return _.get(_.find(expandedSources, nextExpanded => nextExpanded.id === item.id), 'expandType');
+  }
+
+  closeExpandIfNoData(expandType) {
+    const { item } = this.props;
+
+    if (expandType === 'okHosts' || expandType === 'failedHosts') {
+      const okHostCount = _.get(item, 'connection.source_systems_scanned', 0);
+      const failedHostCount = _.get(item, 'connection.source_systems_failed', 0);
+
+      if ((expandType === 'okHosts' && okHostCount === 0) || (expandType === 'failedHosts' && failedHostCount === 0)) {
+        this.onCloseExpand();
+      }
+    }
+  }
 
   renderSourceType() {
     const { item } = this.props;
@@ -257,9 +258,8 @@ class SourceListItem extends React.Component {
         {item.hosts &&
           item.hosts.length > 1 && (
             <ul className="quipucords-popover-list">
-              hello
-              {item.hosts.map((host, index) => (
-                <li key={index}>{host}</li>
+              {item.hosts.map(host => (
+                <li>{host}</li>
               ))}
             </ul>
           )}
@@ -385,6 +385,15 @@ SourceListItem.propTypes = {
   onScan: PropTypes.func,
   selectedSources: PropTypes.array,
   expandedSources: PropTypes.array
+};
+
+SourceListItem.defaultProps = {
+  lastRefresh: 0,
+  onEdit: helpers.noop,
+  onDelete: helpers.noop,
+  onScan: helpers.noop,
+  selectedSources: [],
+  expandedSources: []
 };
 
 const mapStateToProps = state =>

--- a/client/src/components/sources/sourcesEmptyState.js
+++ b/client/src/components/sources/sourcesEmptyState.js
@@ -28,4 +28,8 @@ SourcesEmptyState.propTypes = {
   onAddSource: PropTypes.func
 };
 
+SourcesEmptyState.defaultProps = {
+  onAddSource: helpers.noop
+};
+
 export { SourcesEmptyState as default, SourcesEmptyState };

--- a/client/src/components/toastNotificationsList/toastNotificationsList.js
+++ b/client/src/components/toastNotificationsList/toastNotificationsList.js
@@ -4,6 +4,7 @@ import { ToastNotificationList, TimedToastNotification } from 'patternfly-react'
 import { connect } from 'react-redux';
 import Store from '../../redux/store';
 import { toastNotificationTypes } from '../../redux/constants';
+import helpers from '../../common/helpers';
 
 class ToastNotificationsList extends React.Component {
   onHover = () => {
@@ -31,7 +32,7 @@ class ToastNotificationsList extends React.Component {
             if (!toast.removed) {
               return (
                 <TimedToastNotification
-                  key={index}
+                  key={helpers.generateId('key')}
                   toastIndex={index}
                   type={toast.alertType}
                   paused={paused}
@@ -57,6 +58,11 @@ class ToastNotificationsList extends React.Component {
 ToastNotificationsList.propTypes = {
   toasts: PropTypes.array,
   paused: PropTypes.bool
+};
+
+ToastNotificationsList.defaultProps = {
+  toasts: [],
+  paused: false
 };
 
 const mapStateToProps = state => ({ ...state.toastNotifications });

--- a/client/src/components/viewPaginationRow/viewPaginationRow.js
+++ b/client/src/components/viewPaginationRow/viewPaginationRow.js
@@ -1,73 +1,59 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PaginationRow, PAGINATION_VIEW } from 'patternfly-react';
-import helpers from '../../common/helpers';
 import Store from '../../redux/store';
 import { viewPaginationTypes } from '../../redux/constants';
 
 class ViewPaginationRow extends React.Component {
-  constructor() {
-    super();
-
-    helpers.bindMethods(this, [
-      'onFirstPage',
-      'onLastPage',
-      'onPreviousPage',
-      'onNextPage',
-      'onPageInput',
-      'onPerPageSelect'
-    ]);
-  }
-
-  onFirstPage() {
+  onFirstPage = () => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_FIRST_PAGE,
       viewType
     });
-  }
+  };
 
-  onLastPage() {
+  onLastPage = () => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_LAST_PAGE,
       viewType
     });
-  }
+  };
 
-  onPreviousPage() {
+  onPreviousPage = () => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_PREVIOUS_PAGE,
       viewType
     });
-  }
+  };
 
-  onNextPage() {
+  onNextPage = () => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_NEXT_PAGE,
       viewType
     });
-  }
+  };
 
-  onPageInput(e) {
+  onPageInput = e => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.VIEW_PAGE_NUMBER,
       viewType,
       pageNumber: parseInt(e.target.value, 10)
     });
-  }
+  };
 
-  onPerPageSelect(eventKey) {
+  onPerPageSelect = eventKey => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewPaginationTypes.SET_PER_PAGE,
       viewType,
       pageSize: eventKey
     });
-  }
+  };
 
   render() {
     const perPageOptions = [10, 15, 25, 50, 100];
@@ -110,6 +96,14 @@ ViewPaginationRow.propTypes = {
   pageSize: PropTypes.number,
   totalCount: PropTypes.number,
   totalPages: PropTypes.number
+};
+
+ViewPaginationRow.defaultProps = {
+  viewType: null,
+  currentPage: 0,
+  pageSize: 0,
+  totalCount: 0,
+  totalPages: 0
 };
 
 export { ViewPaginationRow as default, ViewPaginationRow };

--- a/client/src/components/viewToolbar/__tests__/__snapshots__/viewToolbar.test.js.snap
+++ b/client/src/components/viewToolbar/__tests__/__snapshots__/viewToolbar.test.js.snap
@@ -21,8 +21,28 @@ exports[`ViewPaginationRow Component should render 1`] = `
           >
             <div
               class="input-group"
-            />
+            >
+              <input
+                class="form-control"
+                value=""
+              />
+            </div>
           </div>
+        </div>
+        <div
+          class="form-group"
+        >
+          <span>
+            <button
+              class="btn btn-link"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+                class="fa fa-sort-numeric-asc sort-direction"
+              />
+            </button>
+          </span>
         </div>
         <div
           class="form-group"
@@ -38,7 +58,7 @@ exports[`ViewPaginationRow Component should render 1`] = `
             <span
               class="last-refresh-time"
             >
-              Refreshed 
+              Refreshed 0
             </span>
           </button>
         </div>

--- a/client/src/components/viewToolbar/viewToolbar.js
+++ b/client/src/components/viewToolbar/viewToolbar.js
@@ -2,42 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Filter, Sort, Toolbar } from 'patternfly-react';
 import _ from 'lodash';
-import helpers from '../../common/helpers';
 import Store from '../../redux/store';
 import { viewToolbarTypes } from '../../redux/constants';
 import SimpleTooltip from '../simpleTooltIp/simpleTooltip';
 import RefreshTimeButton from '../refreshTimeButton/refreshTimeButton';
+import helpers from '../../common/helpers';
 
 class ViewToolbar extends React.Component {
-  constructor() {
-    super();
-
-    helpers.bindMethods(this, [
-      'updateCurrentValue',
-      'onValueKeyPress',
-      'selectFilterType',
-      'filterValueSelected',
-      'filterAdded',
-      'removeFilter',
-      'clearFilters',
-      'updateCurrentSortType',
-      'toggleCurrentSortDirection'
-    ]);
-  }
-
   componentDidMount() {
     const { filterType, sortType, filterFields, sortFields } = this.props;
 
     if (!filterType) {
-      this.selectFilterType(filterFields[0]);
+      this.onSelectFilterType(filterFields[0]);
     }
 
     if (!sortType) {
-      this.updateCurrentSortType(sortFields[0]);
+      this.onUpdateCurrentSortType(sortFields[0]);
     }
   }
 
-  filterAdded(field, value) {
+  onFilterAdded = (field, value) => {
     const { viewType } = this.props;
 
     let filterText = '';
@@ -60,33 +44,32 @@ class ViewToolbar extends React.Component {
       viewType,
       filter
     });
-  }
+  };
 
-  selectFilterType(filterType) {
+  onSelectFilterType = filterType => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.SET_FILTER_TYPE,
       viewType,
       filterType
     });
-  }
+  };
 
-  filterValueSelected(newFilterValue) {
+  onFilterValueSelected = newFilterValue => {
     const { filterType, viewType } = this.props;
-    const filterValue = newFilterValue;
 
     Store.dispatch({
       type: viewToolbarTypes.SET_FILTER_VALUE,
       viewType,
-      filterValue
+      filterValue: newFilterValue
     });
 
     if (newFilterValue) {
-      this.filterAdded(filterType, newFilterValue);
+      this.onFilterAdded(filterType, newFilterValue);
     }
-  }
+  };
 
-  updateCurrentValue(event) {
+  onUpdateCurrentValue = event => {
     const { viewType } = this.props;
     const filterValue = event.target.value;
 
@@ -95,51 +78,51 @@ class ViewToolbar extends React.Component {
       viewType,
       filterValue
     });
-  }
+  };
 
-  onValueKeyPress(keyEvent) {
+  onValueKeyPress = keyEvent => {
     const { filterType, filterValue } = this.props;
 
     if (keyEvent.key === 'Enter' && filterValue && filterValue.length) {
-      this.filterAdded(filterType, filterValue);
+      this.onFilterAdded(filterType, filterValue);
       keyEvent.stopPropagation();
       keyEvent.preventDefault();
     }
-  }
+  };
 
-  removeFilter(filter) {
+  onRemoveFilter = filter => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.REMOVE_FILTER,
       viewType,
       filter
     });
-  }
+  };
 
-  clearFilters() {
+  onClearFilters = () => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.CLEAR_FILTERS,
       viewType
     });
-  }
+  };
 
-  updateCurrentSortType(sortType) {
+  onUpdateCurrentSortType = sortType => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.SET_SORT_TYPE,
       viewType,
       sortType
     });
-  }
+  };
 
-  toggleCurrentSortDirection() {
+  onToggleCurrentSortDirection = () => {
     const { viewType } = this.props;
     Store.dispatch({
       type: viewToolbarTypes.TOGGLE_SORT_ASCENDING,
       viewType
     });
-  }
+  };
 
   renderFilterInput() {
     const { filterType, filterValue } = this.props;
@@ -154,7 +137,7 @@ class ViewToolbar extends React.Component {
           filterValues={filterType.filterValues}
           currentValue={filterValue}
           placeholder={filterType.placeholder}
-          onFilterValueSelected={this.filterValueSelected}
+          onFilterValueSelected={this.onFilterValueSelected}
         />
       );
     }
@@ -165,7 +148,7 @@ class ViewToolbar extends React.Component {
         type={filterType.filterType}
         value={filterValue}
         placeholder={filterType.placeholder}
-        onChange={e => this.updateCurrentValue(e)}
+        onChange={e => this.onUpdateCurrentValue(e)}
         onKeyPress={e => this.onValueKeyPress(e)}
       />
     );
@@ -180,7 +163,7 @@ class ViewToolbar extends React.Component {
           <Filter.TypeSelector
             filterTypes={filterFields}
             currentFilterType={filterType}
-            onFilterTypeSelected={this.selectFilterType}
+            onFilterTypeSelected={this.onSelectFilterType}
           />
           {this.renderFilterInput()}
         </Filter>
@@ -199,13 +182,13 @@ class ViewToolbar extends React.Component {
           <Sort.TypeSelector
             sortTypes={sortFields}
             currentSortType={sortType}
-            onSortTypeSelected={this.updateCurrentSortType}
+            onSortTypeSelected={this.onUpdateCurrentSortType}
           />
           <SimpleTooltip id="sortTip" tooltip={`Sort by ${sortType.title}`}>
             <Sort.DirectionSelector
               isNumeric={sortType.isNumeric}
               isAscending={sortAscending}
-              onClick={() => this.toggleCurrentSortDirection()}
+              onClick={() => this.onToggleCurrentSortDirection()}
             />
           </SimpleTooltip>
         </Sort>
@@ -244,13 +227,13 @@ class ViewToolbar extends React.Component {
       return [
         <Filter.ActiveLabel key="label">Active Filters:</Filter.ActiveLabel>,
         <Filter.List key="list">
-          {activeFilters.map((item, index) => (
-            <Filter.Item key={index} onRemove={this.removeFilter} filterData={item}>
+          {activeFilters.map(item => (
+            <Filter.Item key={item.label} onRemove={this.onRemoveFilter} filterData={item}>
               {item.label}
             </Filter.Item>
           ))}
         </Filter.List>,
-        <Button bsStyle="link" key="clear" onClick={this.clearFilters}>
+        <Button bsStyle="link" key="clear" onClick={this.onClearFilters}>
           Clear All Filters
         </Button>
       ];
@@ -296,8 +279,21 @@ ViewToolbar.propTypes = {
 };
 
 ViewToolbar.defaultProps = {
+  viewType: null,
+  totalCount: 0,
+  selectedCount: 0,
+  filterFields: [],
+  sortFields: [],
+  onRefresh: helpers.noop,
+  lastRefresh: 0,
+  actions: null,
   itemsType: '',
-  itemsTypePlural: ''
+  itemsTypePlural: '',
+  filterType: {},
+  filterValue: '',
+  activeFilters: [],
+  sortType: {},
+  sortAscending: true
 };
 
 export { ViewToolbar as default, ViewToolbar };

--- a/client/src/redux/actions/index.js
+++ b/client/src/redux/actions/index.js
@@ -18,6 +18,15 @@ const actions = {
 
 const reduxActions = { ...actions };
 
-export { reduxActions, actions };
-
-export default reduxActions;
+export {
+  reduxActions as default,
+  reduxActions,
+  actions,
+  credentialsActions,
+  factsActions,
+  reportsActions,
+  scansActions,
+  sourcesActions,
+  statusActions,
+  userActions
+};

--- a/client/src/redux/reducers/__tests__/toastNotificationsReducer.test.js
+++ b/client/src/redux/reducers/__tests__/toastNotificationsReducer.test.js
@@ -4,7 +4,8 @@ describe('toastNotificationsReducer', () => {
   it('should return the initial state', () => {
     const initialState = {
       toasts: [],
-      paused: false
+      paused: false,
+      displayedToasts: 0
     };
 
     expect(toastNotificationsReducer(undefined, {})).toEqual(initialState);

--- a/client/src/redux/reducers/toastNotificationsReducer.js
+++ b/client/src/redux/reducers/toastNotificationsReducer.js
@@ -2,7 +2,8 @@ import { toastNotificationTypes } from '../constants';
 
 const initialState = {
   toasts: [],
-  paused: false
+  paused: false,
+  displayedToasts: 0
 };
 
 const toastNotificationsReducer = (state = initialState, action) => {
@@ -15,30 +16,45 @@ const toastNotificationsReducer = (state = initialState, action) => {
         persistent: action.persistent
       };
 
-      return Object.assign({}, state, {
-        toasts: [...state.toasts, newToast],
-        displayedToasts: state.displayedToasts + 1
-      });
+      return {
+        ...state,
+        ...{
+          toasts: [...state.toasts, newToast],
+          displayedToasts: state.displayedToasts + 1
+        }
+      };
 
     case toastNotificationTypes.TOAST_REMOVE:
-      const index = state.toasts.indexOf(action.toast);
-      action.toast.removed = true;
-
       const displayedToast = state.toasts.find(toast => !toast.removed);
+      let updatedToasts = [];
 
-      if (!displayedToast) {
-        return Object.assign({}, state, { toasts: [] });
+      if (displayedToast) {
+        updatedToasts = [...state.toasts];
+        updatedToasts[state.toasts.indexOf(action.toast)].removed = true;
       }
 
-      return Object.assign({}, state, {
-        toasts: [...state.toasts.slice(0, index), action.toast, ...state.toasts.slice(index + 1)]
-      });
+      return {
+        ...state,
+        ...{
+          toasts: updatedToasts
+        }
+      };
 
     case toastNotificationTypes.TOAST_PAUSE:
-      return Object.assign({}, state, { paused: true });
+      return {
+        ...state,
+        ...{
+          paused: true
+        }
+      };
 
     case toastNotificationTypes.TOAST_RESUME:
-      return Object.assign({}, state, { paused: false });
+      return {
+        ...state,
+        ...{
+          paused: false
+        }
+      };
 
     default:
       return state;

--- a/client/src/redux/reducers/viewOptionsReducer.js
+++ b/client/src/redux/reducers/viewOptionsReducer.js
@@ -50,11 +50,11 @@ const viewOptionsReducer = (state = initialState, action) => {
     });
   };
 
-  const selectedIndex = (state, item) =>
-    _.findIndex(state.selectedItems, nextSelected => nextSelected.id === _.get(item, 'id'));
+  const selectedIndex = (stateObj, item) =>
+    _.findIndex(stateObj.selectedItems, nextSelected => nextSelected.id === _.get(item, 'id'));
 
-  const expandedIndex = (state, item) =>
-    _.findIndex(state.expandedItems, nextExpanded => nextExpanded.id === _.get(item, 'id'));
+  const expandedIndex = (stateObj, item) =>
+    _.findIndex(stateObj.expandedItems, nextExpanded => nextExpanded.id === _.get(item, 'id'));
 
   switch (action.type) {
     case viewToolbarTypes.SET_FILTER_TYPE:


### PR DESCRIPTION
**Leaving this PR broken into multiple commits temporarily for review... will rebase accordingly**

### What's included

fix(ui linter): ui activate linter
* react/sort-comp
* react/no-unused-state
* react/destructuring-assignment
* no-shadow
* no-param-reassign
   * final push to remove helper.bindMethods
   * converted toastNotificationsReducer, test updated
   * credential authType display relocated to item, snapshot updated
* react/require-default-props
* react/jsx-curly-brace-presence
* react/jsx-wrap-multilines
* react/no-access-state-in-setstate
* react/no-array-index-key
* jsx-a11y/label-has-associated-control

### Notes
* This is an incremental client linter update avoiding UI behavior changes
* minor copy clean up, remove the word "hello"
* final convert from helpers bindMethods on select lint’d files
* heads up... there was some quirkiness around adding default props, had a couple of client side errors pop up, fixed most of them, but was unable to recreate one of them since it popped up and disappeared on refresh

### Updates issue
updates #1520 