### PR TITLE
Enable running UI over Django's dev server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ server-static:
 	$(PYTHON) quipucords/manage.py collectstatic --settings quipucords.settings --no-input
 
 serve:
-	$(PYTHON) quipucords/manage.py runserver
+	$(PYTHON) quipucords/manage.py runserver --nostatic
 
 build-ui:
 	cd client;npm install;npm run build


### PR DESCRIPTION
The staticfiles app automatically serve the static files over the
`STATIC_URL` setting when running Django's dev server. Even though
quipucords has URL entries to serve the UI it was not working with the
dev server because the staticfiles was taking precedence.

This change to the Makefile runs Django's dev server with the
`--nostatic` option which removes the automatic static serving and allow
the URLs defined on the quipucords.urls to work. This now allows running
the UI locally after running `make build-ui` using Django's dev server.