### PR TITLE
handle multi-line output of dmi system uuid command

### DIFF
--- a/quipucords/scanner/network/processing/__init__.py
+++ b/quipucords/scanner/network/processing/__init__.py
@@ -24,3 +24,4 @@ from . import system_purpose
 from . import yum
 from . import virt
 from . import redhat_packages
+from . import dmi

--- a/quipucords/scanner/network/processing/dmi.py
+++ b/quipucords/scanner/network/processing/dmi.py
@@ -12,6 +12,7 @@
 from scanner.network.processing import process
 
 
+# pylint: disable=too-few-public-methods
 class ProcessDmiSystemUuid(process.Processor):
     """Process the dmi system uuid."""
 

--- a/quipucords/scanner/network/processing/dmi.py
+++ b/quipucords/scanner/network/processing/dmi.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+
+"""Initial processing of the shell output from the dmi role."""
+
+from scanner.network.processing import process
+
+
+class ProcessDmiSystemUuid(process.Processor):
+    """Process the dmi system uuid."""
+
+    KEY = 'dmi_system_uuid'
+
+    DEPS = ['internal_dmi_system_uuid']
+    REQUIRE_DEPS = False
+
+    @staticmethod
+    def process(output, dependencies):
+        """Pass the output back through."""
+        dmi_system_uuid = dependencies.get('internal_dmi_system_uuid')
+        if dmi_system_uuid and dmi_system_uuid.get('rc') == 0:
+            result = dmi_system_uuid.get('stdout_lines')
+            if result:
+                if result[0] == '' and len(result) > 1:
+                    return result[1]
+                return result[0]
+        return ''

--- a/quipucords/scanner/network/processing/test_dmi.py
+++ b/quipucords/scanner/network/processing/test_dmi.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+"""Unit tests for initial processing of dmi facts."""
+
+
+import unittest
+
+from scanner.network.processing import dmi
+from scanner.network.processing.util_for_test import ansible_result
+
+
+class TestProcessDmiSystemUuidr(unittest.TestCase):
+    """Test ProcessDmiSystemUuid."""
+
+    def test_success_case(self):
+        """Found cpu model ver."""
+        # stdout_lines looks like ['a', 'b', 'c']
+        dependencies = {'internal_dmi_system_uuid':
+                        ansible_result('a\nb\nc')}
+        self.assertEqual(
+            dmi.ProcessDmiSystemUuid.process(
+                'QPC_FORCE_POST_PROCESS', dependencies),
+            'a')
+        # stdout_lines looks like ['', 'b']
+        dependencies['internal_dmi_system_uuid'] = \
+            ansible_result('\nb\n')
+        self.assertEqual(
+            dmi.ProcessDmiSystemUuid.process(
+                'QPC_FORCE_POST_PROCESS', dependencies),
+            'b')
+        dependencies['internal_dmi_system_uuid'] = ansible_result('Failed', 1)
+        self.assertEqual(
+            dmi.ProcessDmiSystemUuid.process(
+                'QPC_FORCE_POST_PROCESS', dependencies),
+            '')
+
+    def test_not_found(self):
+        """Did not find dmi system uuid."""
+        dependencies = {}
+        self.assertEqual(
+            dmi.ProcessDmiSystemUuid.process(
+                'QPC_FORCE_POST_PROCESS', dependencies),
+            '')

--- a/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
@@ -87,14 +87,12 @@
   become: yes
   when: 'user_has_sudo and internal_have_dmidecode'
 
-- name: extract result value for dmi.system-uuid
+- name: set internal_dmi_system_uuid fact
   set_fact:
-    dmi_system_uuid: "{{  internal_dmi_system_uuid_cmd['stdout'] | trim if internal_have_dmidecode else '' }}"
+    internal_dmi_system_uuid: "{{ internal_dmi_system_uuid_cmd}}"
   ignore_errors: yes
-  when: '"stdout" in internal_dmi_system_uuid_cmd'
 
-- name: handle failure value for dmi.system-uuid
+- name: initialize dmi_system_uuid
   set_fact:
-    dmi_system_uuid: ""
+    dmi_system_uuid: "QPC_FORCE_POST_PROCESS"
   ignore_errors: yes
-  when: '"stdout" not in internal_dmi_system_uuid_cmd'


### PR DESCRIPTION
Closes #1825 

To test you can run a large network scan on both master & on my branch & download the corresponding deployment reports. Then you can run the compare script against the two reports. 