### PR TITLE
feat(gui routing): issues/1920 add route for docs

### DIFF
--- a/quipucords/quipucords/urls.py
+++ b/quipucords/quipucords/urls.py
@@ -46,6 +46,12 @@ urlpatterns = [
             TemplateView.as_view(template_name='client/index.html'),
             name='client'),
 
+    # docs files
+    re_path(
+        r'^client/docs(/|)(index.html|)$',
+        RedirectView.as_view(url='/client/docs/index.html', permanent=False),
+        name='docs'),
+
     # static files (*.css, *.js, *.jpg etc.)
     re_path(r'^(?!/?client/)(?P<path>.*\..*)$',
             RedirectView.as_view(url='/client/%(path)s', permanent=False),


### PR DESCRIPTION
## What's included
* feat(gui routing): issues/1920 add route for docs

## Notes
Adds a `https://localhost:9443/client/docs` route that can be accessed either with `index.html` or without.

## Updates issue/story
* #1920 

## Additional
@jlprevatt et all. If the directory name needs to be altered from `docs` to something else, we can do that
