### PR TITLE
Changed installer image tar.gz name to match installer changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 def qpc_version = "1.0.0"
 def image_name = "quipucords:${qpc_version}"
-def tarfile = "quipucords.${qpc_version}.tar"
+def tarfile = "quipucords_server_image.tar"
 def targzfile = "${tarfile}.gz"
 def postgres_version = "9.6.10"
 def postgres_image_name = "postgres:${postgres_version}"


### PR DESCRIPTION
I edited the docker image name for the server to match what the installer expects. I then ran this branch through Jenkins and everything seemed to build without issue, and naming the artifact `quipucords_server_image.tar.gz`.

I think this should close out the rest of [quipucords-installer issue #10](https://github.com/quipucords/quipucords-installer/issues/10).