### PR TITLE
Remove drf-generators & drf-url-filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,6 @@ serve:
 	$(PYTHON) quipucords/manage.py runserver --nostatic
 
 build-ui:
-	cd ../quipucords-ui;npm install;npm run build
+	cd ../quipucords-ui;yarn;yarn build
 	cp -rf ../quipucords-ui/dist/client quipucords/client
 	cp -rf ../quipucords-ui/dist/templates quipucords/quipucords/templates

--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,7 @@ You must have `Docker installed <https://docs.docker.com/engine/installation/>`_
 
 2. *Optional* - Build UI.::
 
+    brew install yarn (if you don't already have yarn)
     make build-ui
 
   **NOTE:** You will need to install NodeJS.  See `<https://nodejs.org/>`_.

--- a/quipucords/api/credential/view.py
+++ b/quipucords/api/credential/view.py
@@ -28,8 +28,6 @@ from django_filters.rest_framework import (CharFilter,
                                            DjangoFilterBackend,
                                            FilterSet)
 
-from filters import mixins
-
 from rest_framework import status
 from rest_framework.authentication import (SessionAuthentication)
 from rest_framework.filters import OrderingFilter
@@ -94,9 +92,8 @@ class CredentialFilter(FilterSet):
         model = Credential
         fields = ['name', 'cred_type', 'search_by_name']
 
-
 # pylint: disable=too-many-ancestors
-class CredentialViewSet(mixins.FiltersMixin, ModelViewSet):
+class CredentialViewSet(ModelViewSet):
     """A view set for the Credential model."""
 
     authentication_enabled = os.getenv('QPC_DISABLE_AUTHENTICATION') != 'True'
@@ -116,7 +113,6 @@ class CredentialViewSet(mixins.FiltersMixin, ModelViewSet):
     def list(self, request):
         """List the host credentials."""
         queryset = self.filter_queryset(self.get_queryset())
-
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/quipucords/api/credential/view.py
+++ b/quipucords/api/credential/view.py
@@ -92,6 +92,7 @@ class CredentialFilter(FilterSet):
         model = Credential
         fields = ['name', 'cred_type', 'search_by_name']
 
+
 # pylint: disable=too-many-ancestors
 class CredentialViewSet(ModelViewSet):
     """A view set for the Credential model."""

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -133,9 +133,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'rest_framework.authtoken',
-    'filters',
     'django_filters',
-    'drf_generators',
     'api',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ ansible==2.8.0
 Django==2.2.2
 django-filter==2.1.0
 djangorestframework==3.9.4
-drf-generators==0.4.0
-drf-url-filters==0.5.1
 jmespath==0.9.4
 paramiko==2.4.2
 pexpect==4.7.0


### PR DESCRIPTION
Closes #1946 
Closes #1947 

You can find a comment to why I don't think these packages are needed in the issues listed above. 

**How I tested:**
- [x] Run the setup_quipucords.sh with `network`, `vcenter` & `satellite`
- [ ] Next I ran this [bash](https://drive.google.com/open?id=1dpcMm84FKa7-ks4fv_n5s7ZyC-Yb8Caz) script, which executes every qpc cli cred command option. (`add`, `edit`, `show`, `clear`, `list`)
- [ ]  Then I ran a `network`, `vcenter` and `satellite` scan to confirm the creds are working. 
- I was able to use the browsable api locally on:
        - http://127.0.0.1:8000/api/v1/credentials/
        - http://127.0.0.1:8000/api/v1/reports/1/deployments/
        - http://127.0.0.1:8000/api/v1/reports/1/details/
        - http://127.0.0.1:8000/api/v1/scans/

**When testing in container:**
- [ ] make  build-docker version=<release_version> 
- [ ] make test-all
**(On each os):** 
- [ ] make install-offline version=0.0.46
- [ ] make  add-qpc-data
```
qpc cred show --name VCreds
qpc cred edit --name VCreds --username cmyers && qpc cred show --name VCreds
qpc cred add --name NKeyCred --type network --username root --password
qpc cred clear --name NKeyCred
```