### PR TITLE
fix(gui routing): issues/1974 additional docs routes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,7 @@ requests-mock==1.6.0
 
 
 # Linting
+pydocstyle==3.0.0
 flake8==3.7.7
 flake8-docstrings==1.3.0
 flake8-import-order==0.18.1

--- a/quipucords/quipucords/urls.py
+++ b/quipucords/quipucords/urls.py
@@ -48,8 +48,13 @@ urlpatterns = [
 
     # docs files
     re_path(
-        r'^client/docs(/|)(index.html|)$',
-        RedirectView.as_view(url='/client/docs/index.html', permanent=False),
+        r'^client/docs(/|)(index.html|use.html|)$',
+        RedirectView.as_view(url='/client/docs/use.html', permanent=False),
+        name='docs'),
+
+    re_path(
+        r'^client/docs(/|)(install.html|)$',
+        RedirectView.as_view(url='/client/docs/install.html', permanent=False),
         name='docs'),
 
     # static files (*.css, *.js, *.jpg etc.)


### PR DESCRIPTION
## What's included
* fix(gui routing): issues/1974 additional docs routes
  * additional route for install and usage docs
  * default to usage doc

## Notes
- Adds a `https://localhost:9443/client/docs/use.html` route that can be accessed either with `use.html`, `index.html` or without.
- Adds a `https://localhost:9443/client/docs/install.html` route

## Examples
This example highlights an updated GUI based on https://github.com/quipucords/quipucords-ui/pull/62

To test you'll most likely need to navigate directly to the routes
- `/client/docs/install.html`
- `/client/docs/use.html`

And they will most likely throw some type of 404... this is expected until the GUI PR is merged/integrated.

![Jul-11-2019 10-15-26](https://user-images.githubusercontent.com/3761375/61058478-54512680-a3c5-11e9-96c5-ea549040f439.gif)


## Updates issue/story
* #1974 
* relates to #1920 

## Additional
@jlprevatt
