### PR TITLE
Add ability to set the username/password/email for a user during installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN mkdir -p /deploy
 COPY deploy/gunicorn.conf.py  /deploy
 COPY deploy/docker_run.sh  /deploy
 COPY deploy/server_run.sh  /deploy
+COPY deploy/setup_user.py  /deploy
 
 # Config supervisor
 COPY deploy/supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ server-migrate:
 	$(PYTHON) quipucords/manage.py migrate --settings quipucords.settings -v 3
 
 server-set-superuser:
-	echo "from django.contrib.auth.models import User; admin_not_present = User.objects.filter(email='admin@example.com').count() == 0;User.objects.create_superuser('admin', 'admin@example.com', 'pass') if admin_not_present else print('admin present');print(User.objects.filter(email='admin@example.com'))" | $(PYTHON) quipucords/manage.py shell --settings quipucords.settings -v 3
+	echo "from django.contrib.auth.models import User; admin_not_present = User.objects.filter(email='admin@example.com').count() == 0;User.objects.create_superuser('admin', 'admin@example.com', 'qpcpassw0rd') if admin_not_present else print('admin present');print(User.objects.filter(email='admin@example.com'))" | $(PYTHON) quipucords/manage.py shell --settings quipucords.settings -v 3
 
 server-init: server-migrate server-set-superuser
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ server-migrate:
 	$(PYTHON) quipucords/manage.py migrate --settings quipucords.settings -v 3
 
 server-set-superuser:
-	echo "from django.contrib.auth.models import User; admin_not_present = User.objects.filter(email='admin@example.com').count() == 0;User.objects.create_superuser('admin', 'admin@example.com', 'qpcpassw0rd') if admin_not_present else print('admin present');print(User.objects.filter(email='admin@example.com'))" | $(PYTHON) quipucords/manage.py shell --settings quipucords.settings -v 3
+	cat ./deploy/setup_user.py | python quipucords/manage.py shell --settings quipucords.settings -v 3
 
 server-init: server-migrate server-set-superuser
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To initialize the server with Postgres, run the following command:
 make server-init
 ```
 
-Both of the above commands create a superuser with name `admin` and password of `pass`.
+Both of the above commands create a superuser with name `admin` and password of `qpcpassw0rd`.
 
 ## Running the Server
 To run the development server using Postgres, run the following command:

--- a/deploy/server_run.sh
+++ b/deploy/server_run.sh
@@ -2,11 +2,7 @@
 
 source ~/venv/bin/activate
 
-make server-migrate -C /app
-
-python --version
-
-cat /app/deploy/setup_user.py | python /app/quipucords/manage.py shell --settings quipucords.settings -v 3
+make server-migrate server-set-superuser -C /app
 
 if [[ ${USE_SUPERVISORD,,} = "false" ]]; then
     cd /app/quipucords

--- a/deploy/server_run.sh
+++ b/deploy/server_run.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 source ~/venv/bin/activate
-make server-migrate server-set-superuser -C /app
+
+make server-migrate -C /app
+
+python --version
+
+cat /app/deploy/setup_user.py | python /app/quipucords/manage.py shell --settings quipucords.settings -v 3
 
 if [[ ${USE_SUPERVISORD,,} = "false" ]]; then
     cd /app/quipucords

--- a/deploy/setup_user.py
+++ b/deploy/setup_user.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+#
+
+"""Setup admin user for quipucords server."""
+
+import os
+
+from django.contrib.auth.models import User
+
+QPC_SERVER_USERNAME = os.environ.get('QPC_SERVER_USERNAME', 'admin')
+QPC_SERVER_USER_EMAIL = os.environ.get(
+    'QPC_SERVER_USER_EMAIL', 'admin@example.com')
+QPC_SERVER_PASSWORD = os.environ.get('QPC_SERVER_PASSWORD', 'qpcpassw0rd')
+
+ADMIN_NOT_PRESENT = User.objects.filter(
+    username=QPC_SERVER_USERNAME).count() == 0
+
+if ADMIN_NOT_PRESENT:
+    User.objects.create_superuser(
+        QPC_SERVER_USERNAME,
+        QPC_SERVER_USER_EMAIL,
+        QPC_SERVER_PASSWORD)
+    print('User %s created' % QPC_SERVER_USERNAME)
+else:
+    print('User %s already exists' % QPC_SERVER_USERNAME)

--- a/deploy/setup_user.py
+++ b/deploy/setup_user.py
@@ -28,6 +28,6 @@ if ADMIN_NOT_PRESENT:
         QPC_SERVER_USERNAME,
         QPC_SERVER_USER_EMAIL,
         QPC_SERVER_PASSWORD)
-    print('User %s created' % QPC_SERVER_USERNAME)
+    print('Created username %s' % QPC_SERVER_USERNAME)
 else:
     print('User %s already exists' % QPC_SERVER_USERNAME)


### PR DESCRIPTION
This PR allows you to set the username/password/email for the quipucords server.  To test follow the instructions for building and running the container documented here --> https://github.com/quipucords/quipucords#container-image.  However, you must replace the run command for the quipucords server with:

```
docker run --name quipucords --link qpc-db:qpc-link -d -e QPC_SERVER_USERNAME=kevan -e QPC_SERVER_EMAIL=kholdawa@redhat.com -e QPC_SERVER_PASSWORD=nicekevan -e QPC_DBMS_HOST=qpc-db -p 9443:443 -v $QPC_VAR_DATA:/var/data -i quipucords:0.9.1
```

You can then docker exec and cat the quipucords logs to see that your user was created.

Now, if you `docker rm -f quipucords` and re-run just the run command and view logs you should see that the user already exists and will not be recreated.