### PR TITLE
Disable problematic pylint-pytest check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,11 @@ load-plugins = [
     "pylint_pytest",
 ]
 
-[tool.pylint.message_control]
+[tool.pylint.messages_control]
 disable = [
-    "wrong-import-order",
+    # flakeheaven lint with --diff parameter seems to be incompatible with this check
+    "cannot-enumerate-pytest-fixtures",
+    "wrong-import-order",  
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
When  https://github.com/reverbc/pylint-pytest/pull/22 gets merged we might
reenable this check.