### PR TITLE
Bugfix/UI loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,9 @@ build-ui: $(QUIPUCORDS_UI_PATH) clean-ui
 fetch-ui: clean-ui
 	curl -k -SL https://github.com/quipucords/quipucords-ui/releases/download/$(QUIPUCORDS_UI_RELEASE)/quipucords-ui-dist.tar.gz -o ui-dist.tar.gz &&\
     tar -xzvf ui-dist.tar.gz &&\
-	mkdir -p quipucords/quipucords/templates quipucords/client &&\
-    mv dist/templates quipucords/quipucords/templates &&\
-    mv dist/client quipucords/client &&\
+	mkdir -p quipucords/quipucords/ &&\
+    mv dist/templates quipucords/quipucords/. &&\
+    mv dist/client quipucords/. &&\
     rm -rf ui-dist* dist
 
 qpc_on_ui_dir = ${QUIPUCORDS_UI_PATH}/.qpc/quipucords

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -25,6 +25,7 @@ pylint-pytest==1.1.2
 pylint==2.12.2
 
 # other dev tools
+beautifulsoup4
 docker-compose
 pip-tools
 pytest-docker-tools

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -40,6 +40,10 @@ bcrypt==3.2.0 \
     --hash=sha256:cd1ea2ff3038509ea95f687256c46b79f5fc382ad0aa3664d200047546d511d1 \
     --hash=sha256:cdcdcb3972027f83fe24a48b1e90ea4b584d35f1cc279d76de6fc4b13376239d
     # via paramiko
+beautifulsoup4==4.11.1 \
+    --hash=sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30 \
+    --hash=sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
+    # via -r dev-requirements.in
 black==22.1.0 \
     --hash=sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2 \
     --hash=sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71 \
@@ -724,6 +728,10 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via pydocstyle
+soupsieve==2.3.2.post1 \
+    --hash=sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759 \
+    --hash=sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d
+    # via beautifulsoup4
 sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
     --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d

--- a/quipucords/tests/integration/conftest.py
+++ b/quipucords/tests/integration/conftest.py
@@ -20,7 +20,7 @@ from tests.utils.container_wrappers import (
     QuipucordsContainer,
     ScanTargetContainer,
 )
-from tests.utils.http import ApiClient, QPCAuth
+from tests.utils.http import BaseUrlClient, QPCAuth
 
 # pylint: disable=no-value-for-parameter
 postgres_container = container(
@@ -88,7 +88,7 @@ scan_target_container = container(
 @pytest.fixture(scope="class")
 def apiclient(qpc_server_container: QuipucordsContainer):
     """QPC api client configured make requests to containerized qpc server."""
-    client = ApiClient(
+    client = BaseUrlClient(
         base_url=urljoin(qpc_server_container.server_url, "api/v1/"),
     )
     client.auth = QPCAuth(

--- a/quipucords/tests/integration/conftest.py
+++ b/quipucords/tests/integration/conftest.py
@@ -97,3 +97,11 @@ def apiclient(qpc_server_container: QuipucordsContainer):
         password=constants.QPC_SERVER_PASSWORD,
     )
     return client
+
+
+@pytest.fixture(scope="class")
+def qpc_client(qpc_server_container: QuipucordsContainer):
+    """QPC client configured make requests to containerized qpc server."""
+    return BaseUrlClient(
+        base_url=qpc_server_container.server_url,
+    )

--- a/quipucords/tests/integration/test_ui_rendering.py
+++ b/quipucords/tests/integration/test_ui_rendering.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2022  Red Hat, Inc.
+
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+
+"""Smoke test to ensure UI is served."""
+
+from urllib.parse import urljoin
+
+import pytest
+from bs4 import BeautifulSoup
+
+
+def _parse_html(raw_html_string) -> BeautifulSoup:
+    return BeautifulSoup(raw_html_string, "html.parser")
+
+
+# pylint: disable=no-self-use
+@pytest.mark.slow
+@pytest.mark.integration
+class TestUIRendering:
+    """Smoke test UI rendering."""
+
+    def test_home_redirect(self, qpc_client):
+        """Check if an unauthenticated user will be redirected to login page."""
+        response = qpc_client.get("/")
+        assert response.ok, response.content
+        assert len(response.history)
+        assert any(resp.status_code in [301, 302] for resp in response.history)
+        assert response.url == urljoin(qpc_client.base_url, "login/")
+
+    def test_django_templates(self, qpc_client):
+        """Sanity checks for django templates and styling."""
+        response = qpc_client.get("/")
+        assert response.ok, response.content
+        parsed_html = _parse_html(response.text)
+        assert parsed_html.title.string.strip() == "Quipucords"
+        link_list = [link["href"] for link in parsed_html.head.find_all("link")]
+        responses = [qpc_client.get(link) for link in link_list]
+        assert all(response.ok for response in responses), [
+            r.status_code for r in responses
+        ]
+
+    def test_client(self, qpc_client):
+        """Check if spa part of the application is loaded properly."""
+        response = qpc_client.get("/client")
+        assert response.ok, response.content
+        parsed_html = _parse_html(response.text)
+        js_path = parsed_html.script["src"]
+        js_response = qpc_client.get(js_path)
+        assert js_response.ok, js_response.status_code

--- a/quipucords/tests/utils/container_wrappers.py
+++ b/quipucords/tests/utils/container_wrappers.py
@@ -14,7 +14,7 @@ from abc import ABCMeta, abstractmethod
 from pytest_docker_tools import wrappers
 
 from tests.constants import POSTGRES_USER
-from tests.utils.http import ApiClient
+from tests.utils.http import BaseUrlClient
 
 SYSTEMCTL_ACTIVE_STATUS_STRING = "Active: active (running)"
 
@@ -66,6 +66,6 @@ class QuipucordsContainer(ReadinessProbeMixin, wrappers.Container):
 
     def readiness_probe(self):
         """Return true if quipucords api is responsive."""
-        client = ApiClient(base_url=self.server_url)
+        client = BaseUrlClient(base_url=self.server_url)
         response = client.get("api/v1/status/")
         return response.ok

--- a/quipucords/tests/utils/http.py
+++ b/quipucords/tests/utils/http.py
@@ -15,7 +15,7 @@ from urllib.parse import urljoin
 import requests
 
 
-class ApiClient(requests.Session):
+class BaseUrlClient(requests.Session):
     """Specialized request session with a configurable base_url."""
 
     def __init__(self, *, base_url=None, auth=None, verify=False, **kwargs):
@@ -42,7 +42,7 @@ class QPCAuth(requests.auth.AuthBase):
 
     def __init__(self, *, base_url, username, password):
         """Initialize QPCAuth."""
-        self._qpc_client = ApiClient(base_url=base_url)
+        self._qpc_client = BaseUrlClient(base_url=base_url)
         self._username = username
         self._password = password
 


### PR DESCRIPTION
closes #2159

Fixes a bug preventing UI to be properly rendered.

It also includes an integration test making sure all UI resources are loaded properly so this won't happen again.

## Why was this happening
UI assets were not placed in the correct folder. Instead of placing them on `/app/quipucords/quipucords/template` and `/app/quipucords/client` they were placed at  `/app/quipucords/quipucords/template/template` and `/app/quipucords/client/client`
The tests added on this PR are making sure HTML templates, stylesheets and JS scripts can be properly loaded.

## Steps to reproduce and context
added to the issue #2159

## How to verify this works
Build quipucords from this branch and repeat steps to reproduce (see #2159) replacing `quay.io/quipucords/quipucords:1.0.0` with the name or id of the image built.

