### PR TITLE
Fix build with Docker on mac regarding /var/data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY deploy/*  /deploy/
 VOLUME /var/log
 
 # Create /var/data
+RUN mkdir -p /var/data
 VOLUME /var/data
 
 # Create /etc/ansible/roles/


### PR DESCRIPTION
```
 => ERROR [15/15] RUN make server-static                                   0.5s
------                                                                          
 > [15/15] RUN make server-static:                                              
#19 0.329 /opt/venv/bin/python quipucords/manage.py collectstatic --settings quipucords.settings --no-input
#19 0.472 Traceback (most recent call last):
#19 0.472   File "/app/quipucords/manage.py", line 34, in <module>
#19 0.472     execute_from_command_line(sys.argv)
#19 0.472   File "/opt/venv/lib64/python3.9/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
#19 0.472     utility.execute()
#19 0.472   File "/opt/venv/lib64/python3.9/site-packages/django/core/management/__init__.py", line 345, in execute
#19 0.473     settings.INSTALLED_APPS
#19 0.473   File "/opt/venv/lib64/python3.9/site-packages/django/conf/__init__.py", line 82, in __getattr__
#19 0.473     self._setup(name)
#19 0.473   File "/opt/venv/lib64/python3.9/site-packages/django/conf/__init__.py", line 69, in _setup
#19 0.473     self._wrapped = Settings(settings_module)
#19 0.473   File "/opt/venv/lib64/python3.9/site-packages/django/conf/__init__.py", line 170, in __init__
#19 0.473     mod = importlib.import_module(self.SETTINGS_MODULE)
#19 0.473   File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
#19 0.473     return _bootstrap._gcd_import(name[level:], package, level)
#19 0.473   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
#19 0.474   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
#19 0.474   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
#19 0.474   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
#19 0.474   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
#19 0.474   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
#19 0.475   File "/app/quipucords/quipucords/settings.py", line 114, in <module>
#19 0.475     with open(DJANGO_SECRET_PATH, 'w') as secret_file:
#19 0.475 FileNotFoundError: [Errno 2] No such file or directory: '/var/data/secret.txt'
#19 0.496 make: *** [Makefile:99: server-static] Error 1
```