### PR TITLE
Fix incorrect usage of f-string

### DIFF
--- a/quipucords/fingerprinter/task.py
+++ b/quipucords/fingerprinter/task.py
@@ -270,7 +270,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
             deployment_report.status = DeploymentsReport.STATUS_FAILED
             deployment_report.save()
             error_message = (
-                "Fact collection f'{details_report.id} failed to be processed."
+                f"Fact collection {details_report.id} failed to be processed."
             )
 
             self.scan_task.log_message(
@@ -444,7 +444,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
             deployment_report.status = DeploymentsReport.STATUS_COMPLETE
         else:
             status_message = (
-                "FAILED to create report id=f'{deployment_report.report_id}' - "
+                f"FAILED to create report id={deployment_report.report_id} - "
                 "produced no valid fingerprints"
             )
             self.scan_task.log_message(status_message, log_level=logging.ERROR)
@@ -475,7 +475,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
         if not insights_hosts:
             insights_message = (
                 "FAILED to create Insights report "
-                "id=f'{deployment_report.report_id}' - produced no valid hosts"
+                f"id={deployment_report.report_id} - produced no valid hosts"
             )
             self.scan_task.log_message(insights_message,
                                        log_level=logging.WARN)

--- a/quipucords/scanner/satellite/utils.py
+++ b/quipucords/scanner/satellite/utils.py
@@ -155,15 +155,13 @@ def status(scan_task):
     except SatelliteException:
         message = (
             "Satellite 6 status check failed with error:"
-            f' f"{SatelliteException}". Attempting Satellite 5.'
+            f' "{SatelliteException}". Attempting Satellite 5.'
         )
         scan_task.log_message(message)
     try:
         return _status5(scan_task)
     except SatelliteException:
-        message = (
-            f"Satellite 5 status check failed with error: f'{SatelliteException}'."
-        )
+        message = f'Satellite 5 status check failed with error: "{SatelliteException}".'
         scan_task.log_message(message, log_level=logging.ERROR)
     except xmlrpc.client.ProtocolError:
         message = 'Satellite 5 status check endpoint not found. '

--- a/quipucords/scanner/satellite/utils.py
+++ b/quipucords/scanner/satellite/utils.py
@@ -152,16 +152,16 @@ def status(scan_task):
     """
     try:
         return _status6(scan_task)
-    except SatelliteException:
+    except SatelliteException as error:
         message = (
             "Satellite 6 status check failed with error:"
-            f' "{SatelliteException}". Attempting Satellite 5.'
+            f' "{error}". Attempting Satellite 5.'
         )
         scan_task.log_message(message)
     try:
         return _status5(scan_task)
-    except SatelliteException:
-        message = f'Satellite 5 status check failed with error: "{SatelliteException}".'
+    except SatelliteException as error:
+        message = f'Satellite 5 status check failed with error: "{error}".'
         scan_task.log_message(message, log_level=logging.ERROR)
     except xmlrpc.client.ProtocolError:
         message = 'Satellite 5 status check endpoint not found. '

--- a/quipucords/scanner/vcenter/inspect.py
+++ b/quipucords/scanner/vcenter/inspect.py
@@ -80,20 +80,18 @@ class InspectTaskRunner(ScanTaskRunner):
         self.connect_scan_task = self.scan_task.prerequisites.first()
         if self.connect_scan_task.status != ScanTask.COMPLETED:
             error_message = (
-                "Prerequisites scan task f'{self.connect_scan_task.sequence_number}'"
+                f"Prerequisites scan task {self.connect_scan_task.sequence_number}"
                 " failed."
             )
             return error_message, ScanTask.FAILED
 
         try:
             self.inspect()
-        except vim.fault.InvalidLogin as vm_error:  # pylint: disable=unused-variable # noqa
+        except vim.fault.InvalidLogin as vm_error:
             error_message = (
-                "Unable to connect to VCenter source, f'{source.name}', "
-                "with supplied credential, f'{credential.name}'.\n"
-            )
-            error_message += (
-                "Discovery scan failed for f'{self.scan_task,}'." "f'{vm_error}'"
+                f"Unable to connect to VCenter source, {source.name}, "
+                f"with supplied credential, {credential.name}.\n"
+                f"Discovery scan failed for {self.scan_task,}. {vm_error}"
             )
             return error_message, ScanTask.FAILED
 


### PR DESCRIPTION
Improper usage introduced on these commits:
- f660946e8ba87108f838c47cc4d4484cfd97ee1e
- f7e73cb7d039f12cff61955f51d1c17008da40cb

When reviewing I suggest taking those into consideration (their diff will show the original formatting of the messages).