### PR TITLE
Fingerprint facts for Vcenter and Satellite and theirs tests 

### DIFF
--- a/quipucords/fingerprinter/task.py
+++ b/quipucords/fingerprinter/task.py
@@ -1528,10 +1528,14 @@ class FingerprintTaskRunner(ScanTaskRunner):
                 name.endswith(tuple(['-' + str(num) for num in range(1, 10)])):
             infrastructure_type = SystemFingerprint.HYPERVISOR
             metadata_source = 'hostname'
-        if infrastructure_type:
-            self._add_fact_to_fingerprint(source, metadata_source, fact,
-                                          'infrastructure_type', fingerprint,
-                                          fact_value=infrastructure_type)
+        self._add_fact_to_fingerprint(
+            source,
+            metadata_source,
+            fact,
+            "infrastructure_type",
+            fingerprint,
+            fact_value=infrastructure_type,
+        )
         # Satellite specific facts
         self._add_fact_to_fingerprint(source, 'cores', fact,
                                       'cpu_core_count', fingerprint)
@@ -1542,23 +1546,32 @@ class FingerprintTaskRunner(ScanTaskRunner):
         reg_time = fact.get('registration_time')
         if reg_time:
             reg_time = strip_suffix(reg_time, ' UTC')
-            self._add_fact_to_fingerprint(source, 'registration_time', fact,
-                                          'registration_time', fingerprint,
-                                          fact_value=reg_time)
+        self._add_fact_to_fingerprint(
+            source,
+            "registration_time",
+            fact,
+            "registration_time",
+            fingerprint,
+            fact_value=reg_time,
+        )
 
-        last_checkin = fact.get('last_checkin_time')
-        if last_checkin:
-            last_checkin = \
-                self._multi_format_dateparse(source,
-                                             'last_checkin_time',
-                                             last_checkin,
-                                             ['%Y-%m-%d %H:%M:%S',
-                                              '%Y-%m-%d %H:%M:%S %z'])
+        last_checkin = None
+        if fact.get("last_checkin_time"):
+            last_checkin = self._multi_format_dateparse(
+                source,
+                "last_checkin_time",
+                last_checkin,
+                ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S %z"],
+            )
 
-            self._add_fact_to_fingerprint(source, 'last_checkin_time',
-                                          fact, 'system_last_checkin_date',
-                                          fingerprint,
-                                          fact_value=last_checkin)
+        self._add_fact_to_fingerprint(
+            source,
+            "last_checkin_time",
+            fact,
+            "system_last_checkin_date",
+            fingerprint,
+            fact_value=last_checkin,
+        )
 
         self._add_entitlements_to_fingerprint(source, 'entitlements',
                                               fact, fingerprint)

--- a/quipucords/fingerprinter/task.py
+++ b/quipucords/fingerprinter/task.py
@@ -1361,12 +1361,12 @@ class FingerprintTaskRunner(ScanTaskRunner):
 
         # Common facts
         # Set name
-        if fact.get('vm.dns_name'):
-            self._add_fact_to_fingerprint(
-                source, 'vm.dns_name', fact, 'name', fingerprint)
+        if fact.get("vm.dns_name"):
+            raw_fact = "vm.dns_name"
         else:
-            self._add_fact_to_fingerprint(
-                source, 'vm.name', fact, 'name', fingerprint)
+            raw_fact = "vm.name"
+
+        self._add_fact_to_fingerprint(source, raw_fact, fact, "name", fingerprint)
 
         self._add_fact_to_fingerprint(source, "vm.os", fact, "os_release", fingerprint)
         vcenter_os_release = default_getter(fact, "vm.os", "")
@@ -1398,15 +1398,20 @@ class FingerprintTaskRunner(ScanTaskRunner):
         self._add_fact_to_fingerprint(source, 'vm.uuid', fact,
                                       'vm_uuid', fingerprint)
 
+        last_checkin = None
         if fact.get('vm.last_check_in'):
             last_checkin = self._multi_format_dateparse(
                 source, 'vm.last_check_in',
                 fact['vm.last_check_in'],
                 ['%Y-%m-%d %H:%M:%S'])
-            self._add_fact_to_fingerprint(source, 'vm.last_check_in',
-                                          fact, 'system_last_checkin_date',
-                                          fingerprint,
-                                          fact_value=last_checkin)
+        self._add_fact_to_fingerprint(
+            source,
+            "vm.last_check_in",
+            fact,
+            "system_last_checkin_date",
+            fingerprint,
+            fact_value=last_checkin,
+        )
 
         self._add_fact_to_fingerprint(source, 'vm.dns_name', fact,
                                       'vm_dns_name', fingerprint)

--- a/quipucords/fingerprinter/tests_fingerprint_task.py
+++ b/quipucords/fingerprinter/tests_fingerprint_task.py
@@ -79,8 +79,24 @@ EXPECTED_FINGERPRINT_MAP_SATELLITE = {
     "infrastructure_type": "is_virtualized",
 }
 EXPECTED_FINGERPRINT_MAP_VCENTER = {
+    "name": "vm.name",
+    "os_release": "vm.os",
     "is_redhat": "vm.os",
     "infrastructure_type": "vcenter_source",
+    "mac_addresses": "vm.mac_addresses",
+    "ip_addresses": "vm.ip_addresses",
+    "cpu_count": "vm.cpu_count",
+    "architecture": "uname_processor",
+    "vm_state": "vm.state",
+    "vm_uuid": "vm.uuid",
+    "system_last_checkin_date": "vm.last_check_in",
+    "vm_dns_name": "vm.dns_name",
+    "virtual_host_name": "vm.host.name",
+    "virtual_host_uuid": "vm.host.uuid",
+    "vm_host_socket_count": "vm.host.cpu_count",
+    "vm_host_core_count": "vm.host.cpu_cores",
+    "vm_datacenter": "vm.datacenter",
+    "vm_cluster": "vm.cluster",
 }
 
 
@@ -1178,12 +1194,13 @@ class EngineTest(TestCase):
             metadata_dict,
         )
         expected_fingerprints = {
-            fingerprint_name: False
+            fingerprint_name: None
             for fingerprint_name in EXPECTED_FINGERPRINT_MAP_VCENTER
         }
+        expected_fingerprints["is_redhat"] = False
+        expected_fingerprints["infrastructure_type"] = SystemFingerprint.VIRTUALIZED
         expected_fingerprints[PRODUCTS_KEY] = []
         expected_fingerprints[ENTITLEMENTS_KEY] = []
-        expected_fingerprints["infrastructure_type"] = SystemFingerprint.VIRTUALIZED
         self.assertDictEqual(result, expected_fingerprints)
 
     def test_scan_all_facts_with_null_value_in_process_satellite_scan(self):

--- a/quipucords/fingerprinter/tests_fingerprint_task.py
+++ b/quipucords/fingerprinter/tests_fingerprint_task.py
@@ -75,8 +75,24 @@ EXPECTED_FINGERPRINT_MAP = {
     "virtualized_type": "virt_type",
 }
 EXPECTED_FINGERPRINT_MAP_SATELLITE = {
+    "name": "hostname",
+    "os_name": "os_name",
     "is_redhat": "os_release",
+    "os_release": "os_release",
+    "os_version": "os_version",
+    "mac_addresses": "mac_addresses",
+    "ip_addresses": "ip_addresses",
+    "cpu_count": "cores",
+    "architecture": "architecture",
+    "subscription_manager_id": "uuid",
+    "virtualized_type": "virt_type",
+    "virtual_host_name": "virtual_host_name",
+    "virtual_host_uuid": "virtual_host_uuid",
     "infrastructure_type": "is_virtualized",
+    "cpu_core_count": "cores",
+    "cpu_socket_count": "num_sockets",
+    "registration_time": "registration_time",
+    "system_last_checkin_date": "last_checkin_time",
 }
 EXPECTED_FINGERPRINT_MAP_VCENTER = {
     "name": "vm.name",
@@ -98,6 +114,13 @@ EXPECTED_FINGERPRINT_MAP_VCENTER = {
     "vm_datacenter": "vm.datacenter",
     "vm_cluster": "vm.cluster",
 }
+
+PRODUCTS = [
+    {"name": "JBoss EAP", "presence": "absent"},
+    {"name": "JBoss Fuse", "presence": "absent"},
+    {"name": "JBoss BRMS", "presence": "absent"},
+    {"name": "JBoss Web Server", "presence": "absent", "version": []},
+]
 
 
 class EngineTest(TestCase):
@@ -1228,12 +1251,23 @@ class EngineTest(TestCase):
             metadata_dict,
         )
         expected_fingerprints = {
-            fingerprint_name: False
+            fingerprint_name: None
             for fingerprint_name in EXPECTED_FINGERPRINT_MAP_SATELLITE
         }
-        expected_fingerprints[PRODUCTS_KEY] = mock.ANY
-        expected_fingerprints[ENTITLEMENTS_KEY] = []
+        expected_fingerprints["is_redhat"] = False
         expected_fingerprints["infrastructure_type"] = SystemFingerprint.UNKNOWN
+        expected_fingerprints[ENTITLEMENTS_KEY] = []
+
+        copy_products_list = deepcopy(PRODUCTS)
+        for product in copy_products_list:
+            product["metadata"] = {
+                "server_id": self.server_id,
+                "source_name": "source3",
+                "source_type": "satellite",
+                "raw_fact_key": None,
+            }
+        expected_fingerprints[PRODUCTS_KEY] = copy_products_list
+
         self.assertDictEqual(result, expected_fingerprints)
 
     ################################################################


### PR DESCRIPTION
Force optional VCenter fingerprint facts to always return
Force optional Satellite fingerprint facts to always return
Modifies test_scan_all_facts_with_null_value_in_process_vcenter_scan
Modifies test_scan_all_facts_with_null_value_in_process_satellite_scan