### PR TITLE
[Discovery 173] fix container image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,7 @@ package-lock.json
 quipucords.egg-info
 quipucords/client
 quipucords/db.sqlite3
-quipucords/quipucords/template
+quipucords/quipucords/templates
 quipucords/staticfiles
 quipucords/tests
 var

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ help:
 	@echo "  manpage             to build the manpage"
 	@echo "  build-ui            to build ui and place result in django server"
 	@echo "  fetch-ui            to fetch prebuilt ui and place it in django server"
+	@echo "  build-container     to build the container image for quipucords"
 
 all: lint test-coverage
 
@@ -127,3 +128,8 @@ $(qpc_on_ui_dir): $(QUIPUCORDS_UI_PATH)
 
 serve-swagger: $(qpc_on_ui_dir)
 	cd $(QUIPUCORDS_UI_PATH);yarn;node ./scripts/swagger.js
+
+build-container:
+	podman build \
+		--build-arg UI_RELEASE=$(QUIPUCORDS_UI_RELEASE) \
+		-t quipucords .


### PR DESCRIPTION
* Fix a typo in `.dockerignore` that may produce the side-effect of leaving the container image with UI broken (blank screen after logged in). `quipucords/quipucords/template` -> `quipucords/quipucords/templates`
* Create a Makefile rule to build the container image by passing the `UI_RELEASE` - Note: should we keep the release number inside the `ARG UI_RELEASE`?