### PR TITLE
[DISCOVERY-177] - Fix older RHEL detection bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "*"
   pull_request:
-    branches: [ master ]
+    branches: [master, "release/*"]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+    branches: [master, "release/*"]
 
 jobs:
   test:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -449,9 +449,9 @@ packaging==21.3 \
     #   ansible-runner
     #   build
     #   pytest
-paramiko==2.11.0 \
-    --hash=sha256:003e6bee7c034c21fbb051bf83dc0a9ee4106204dd3c53054c71452cc4ec3938 \
-    --hash=sha256:655f25dc8baf763277b933dfcea101d636581df8d6b9774d1fb653426b72c270
+paramiko==2.8.1 \
+    --hash=sha256:7b5910f5815a00405af55da7abcc8a9e0d9657f57fcdd9a89894fdbba1c6b8a8 \
+    --hash=sha256:85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438
     # via
     #   -r requirements.in
     #   docker
@@ -721,7 +721,6 @@ six==1.16.0 \
     #   ansible-runner
     #   dockerpty
     #   jsonschema
-    #   paramiko
     #   python-dateutil
     #   pyvmomi
     #   requests-mock

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ Django<4
 django-filter
 djangorestframework
 jmespath
-paramiko
+paramiko<2.9
 pexpect
 pyvmomi
 PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -221,9 +221,9 @@ packaging==21.3 \
     # via
     #   ansible-base
     #   ansible-runner
-paramiko==2.11.0 \
-    --hash=sha256:003e6bee7c034c21fbb051bf83dc0a9ee4106204dd3c53054c71452cc4ec3938 \
-    --hash=sha256:655f25dc8baf763277b933dfcea101d636581df8d6b9774d1fb653426b72c270
+paramiko==2.8.1 \
+    --hash=sha256:7b5910f5815a00405af55da7abcc8a9e0d9657f57fcdd9a89894fdbba1c6b8a8 \
+    --hash=sha256:85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438
     # via -r requirements.in
 pexpect==4.8.0 \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \
@@ -354,7 +354,6 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   ansible-runner
-    #   paramiko
     #   pyvmomi
 sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \


### PR DESCRIPTION
Since discovery 1.0.0, ansible is **always** using `paramiko` to connect to hosts (regardless of the option we chose when configuring sources).
A regression introduced in paramiko 2.9 is the culprit for RHEL-6 not being properly detected.