### PR TITLE
Downgrade paramiko to 2.7.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -449,9 +449,9 @@ packaging==21.3 \
     #   ansible-runner
     #   build
     #   pytest
-paramiko==2.8.1 \
-    --hash=sha256:7b5910f5815a00405af55da7abcc8a9e0d9657f57fcdd9a89894fdbba1c6b8a8 \
-    --hash=sha256:85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438
+paramiko==2.7.2 \
+    --hash=sha256:4f3e316fef2ac628b05097a637af35685183111d4bc1b5979bd397c2ab7b5898 \
+    --hash=sha256:7f36f4ba2c0d81d219f4595e35f70d56cc94f9ac40a6acdf51d6ca210ce65035
     # via
     #   -r requirements.in
     #   docker

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ Django<4
 django-filter
 djangorestframework
 jmespath
-paramiko<2.9
+paramiko<2.8
 pexpect
 pyvmomi
 PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -221,9 +221,9 @@ packaging==21.3 \
     # via
     #   ansible-base
     #   ansible-runner
-paramiko==2.8.1 \
-    --hash=sha256:7b5910f5815a00405af55da7abcc8a9e0d9657f57fcdd9a89894fdbba1c6b8a8 \
-    --hash=sha256:85b1245054e5d7592b9088cc6d08da22445417912d3a3e48138675c7a8616438
+paramiko==2.7.2 \
+    --hash=sha256:4f3e316fef2ac628b05097a637af35685183111d4bc1b5979bd397c2ab7b5898 \
+    --hash=sha256:7f36f4ba2c0d81d219f4595e35f70d56cc94f9ac40a6acdf51d6ca210ce65035
     # via -r requirements.in
 pexpect==4.8.0 \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \


### PR DESCRIPTION
Later versions of paramiko are impairing detection of hosts using
only [legacy cryptographic algorithms](http://www.openssh.com/legacy.html).