### PR TITLE
Force quipucords-ui to version 0.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pip install -r requirements.txt
 
 # Fetch UI code
 COPY Makefile .
-ARG UI_RELEASE="0.11.0"
+ARG UI_RELEASE="0.11.1"
 RUN make fetch-ui -e QUIPUCORDS_UI_RELEASE=${UI_RELEASE}
 
 # Create /etc/ssl/qpc

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pip install -r requirements.txt
 
 # Fetch UI code
 COPY Makefile .
-ARG UI_RELEASE=latest
+ARG UI_RELEASE="0.11.0"
 RUN make fetch-ui -e QUIPUCORDS_UI_RELEASE=${UI_RELEASE}
 
 # Create /etc/ssl/qpc

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,11 @@ build-ui: $(QUIPUCORDS_UI_PATH) clean-ui
 	cp -rf $(QUIPUCORDS_UI_PATH)/dist/templates quipucords/quipucords/templates
 
 fetch-ui: clean-ui
-	@DOWNLOAD_URL=`curl -s https://api.github.com/repos/quipucords/quipucords-ui/releases/$(QUIPUCORDS_UI_RELEASE) | jq -r '.assets[] | select(.name | test("quipucords-ui-dist.tar.gz")) | .browser_download_url'`; \
+	@if [[ $(QUIPUCORDS_UI_RELEASE) = "latest" ]]; then \
+		DOWNLOAD_URL=`curl -s https://api.github.com/repos/quipucords/quipucords-ui/releases/$(QUIPUCORDS_UI_RELEASE) | jq -r '.assets[] | select(.name | test("quipucords-ui-dist.tar.gz")) | .browser_download_url'`; \
+	else \
+		DOWNLOAD_URL="https://github.com/quipucords/quipucords-ui/releases/download/$(QUIPUCORDS_UI_RELEASE)/quipucords-ui-dist.tar.gz"; \
+	fi; \
 	echo "download_url=$${DOWNLOAD_URL}"; \
 	curl -k -SL "$${DOWNLOAD_URL}" -o ui-dist.tar.gz &&\
     tar -xzvf ui-dist.tar.gz &&\


### PR DESCRIPTION
The layer fetching UI on quay.io is already cached with an older version of the UI. In order to update it we will need to force it to update by changing UI_RELEASE value.