### PR TITLE
[DISCOVERY-198] Allow turning off django DEBUG mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pip install -r requirements.txt
 
 # Fetch UI code
 COPY Makefile .
-ARG UI_RELEASE="0.11.1"
+ARG UI_RELEASE="1.0.0"
 RUN make fetch-ui -e QUIPUCORDS_UI_RELEASE=${UI_RELEASE}
 
 # Create /etc/ssl/qpc

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -130,7 +130,7 @@ else:
     SECRET_KEY = DJANGO_SECRET_PATH.read_text(encoding="utf-8").strip()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(os.environ.get("DJANGO_DEBUG", True))
+DEBUG = os.environ.get("DJANGO_DEBUG", True)
 if isinstance(DEBUG, str):
     DEBUG = DEBUG.lower() == "true"
 


### PR DESCRIPTION
This is a security risk for servers accessible outside of the user network.

Fix DISCOVERY-198.

NOTE: UI templates also require a small change - otherwise the application will always crash on login page if DEBUG mode is disabled.