### PR TITLE
[DISCOVERY-202] - Add OpenShift integration info to OpenApi spec

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -87,6 +87,7 @@ paths:
             - network
             - vcenter
             - satellite
+            - openshift
         - name: "page"
           in: "query"
           description: "Value for selecting a page of results"
@@ -284,6 +285,7 @@ paths:
             - network
             - vcenter
             - satellite
+            - openshift
         - name: "page"
           in: "query"
           description: "Value for selecting a page of results"
@@ -1192,9 +1194,6 @@ definitions:
     type: "object"
     required:
       - name
-      - username
-      - password
-      - ssh_keyfile
     properties:
         name:
           type: "string"
@@ -1207,6 +1206,7 @@ definitions:
             - network
             - vcenter
             - satellite
+            - openshift
         username:
           type: "string"
           example: "admin"
@@ -1219,6 +1219,10 @@ definitions:
           type: "string"
           example: "~/.ssh/id_rsa"
           description: "The connection private ssh keyfile for the credential"
+        auth_token:
+          type: "string"
+          example: "<someToken>"
+          description: "The auth token for the credential."
         ssh_passphrase:
           type: "string"
           example: "********"
@@ -1398,6 +1402,7 @@ definitions:
           - network
           - vcenter
           - satellite
+          - openshift
       facts:
         type: "array"
         items:
@@ -2058,6 +2063,7 @@ definitions:
           - network
           - vcenter
           - satellite
+          - openshift
       port:
         type: "integer"
         format: "int32"
@@ -2125,6 +2131,7 @@ definitions:
           - network
           - vcenter
           - satellite
+          - openshift
   SourceMostRecentConnectionJob:
     type: "object"
     properties:


### PR DESCRIPTION
## Acceptance criteria
- updated swagger.yml MUST pass swagger validation (running with `make serve-swagger`  should be served on http://localhost:5050/docs/api)
- must not break `yarn start` on QUIPUCORDS-UI side

Suggestion: on quipucords-ui edit [FILE variable](https://github.com/quipucords/quipucords-ui/blob/68ea5d9e4e5907ce35c87254ca315bccc1dfd2ae/scripts/api.sh#L301) to point to the modified version here and then run `yarn start`
