### PR TITLE
Feature/node collection implementation

### DIFF
--- a/quipucords/scanner/openshift/api.py
+++ b/quipucords/scanner/openshift/api.py
@@ -23,7 +23,14 @@ from kubernetes.client import (
 from openshift.dynamic import DynamicClient
 from urllib3.exceptions import MaxRetryError
 
-from scanner.openshift.entities import OCPCluster, OCPDeployment, OCPError, OCPProject
+from scanner.openshift.entities import (
+    NodeResources,
+    OCPCluster,
+    OCPDeployment,
+    OCPError,
+    OCPNode,
+    OCPProject,
+)
 
 logger = getLogger(__name__)
 
@@ -117,6 +124,14 @@ class OpenShiftApi:
             project_list.append(ocp_project)
         return project_list
 
+    def retrieve_nodes(self, **kwargs) -> List[OCPNode]:
+        """Retrieve nodes under OCP host."""
+        node_list = []
+        for node in self._list_nodes(**kwargs).items:
+            ocp_node = self._init_ocp_nodes(node)
+            node_list.append(ocp_node)
+        return node_list
+
     def retrieve_cluster(self, **kwargs) -> OCPCluster:
         """Retrieve cluster under OCP host."""
         clusters = self._list_clusters(**kwargs).items
@@ -138,6 +153,10 @@ class OpenShiftApi:
         return CoreV1Api(api_client=self._api_client)
 
     @cached_property
+    def _node_api(self):
+        return self._dynamic_client.resources.get(api_version="v1", kind="Node")
+
+    @cached_property
     def _apps_api(self):
         return AppsV1Api(api_client=self._api_client)
 
@@ -151,6 +170,10 @@ class OpenShiftApi:
     @wraps(CoreV1Api.list_namespace)
     def _list_projects(self, **kwargs):
         return self._core_api.list_namespace(**kwargs)
+
+    @catch_k8s_exception
+    def _list_nodes(self, **kwargs):
+        return self._node_api.get(**kwargs)
 
     @catch_k8s_exception
     def _list_clusters(self, **kwargs):
@@ -169,6 +192,30 @@ class OpenShiftApi:
         if retrieve_all:
             self.add_deployments_to_project(ocp_project)
         return ocp_project
+
+    def _init_ocp_nodes(self, node) -> OCPNode:
+        ocp_nodes = OCPNode(
+            name=node.metadata.name,
+            creation_timestamp=node.metadata.creationTimestamp,
+            labels=node.metadata.labels,
+            addresses=node.status["addresses"],
+            allocatable=NodeResources(
+                cpu=node.status["allocatable"]["cpu"],
+                memory_in_bytes=node.status["allocatable"]["memory"],
+                pods=node.status["allocatable"]["pods"],
+            ),
+            capacity=NodeResources(
+                cpu=node.status["capacity"]["cpu"],
+                memory_in_bytes=node.status["capacity"]["memory"],
+                pods=node.status["capacity"]["pods"],
+            ),
+            architecture=node.status["nodeInfo"]["architecture"],
+            kernel_version=node.status["nodeInfo"]["kernelVersion"],
+            machine_id=node.status["nodeInfo"]["machineID"],
+            operating_system=node.status["nodeInfo"]["operatingSystem"],
+            taints=node.spec["taints"],
+        )
+        return ocp_nodes
 
     def _init_cluster(self, cluster) -> OCPCluster:
         ocp_cluster = OCPCluster(

--- a/quipucords/scanner/openshift/entities.py
+++ b/quipucords/scanner/openshift/entities.py
@@ -11,12 +11,16 @@
 
 from __future__ import annotations
 
+import datetime
 import json
+import re
 from typing import Dict, List
 
-from pydantic import Field  # pylint: disable=no-name-in-module
+from pydantic import Field, validator  # pylint: disable=no-name-in-module
 
 from compat.pydantic import BaseModel, raises
+
+MEMORY_CONVERSION_ERROR = "This value couldn't be converted."
 
 
 def load_entity(data: dict) -> OCPBaseEntity:
@@ -82,6 +86,24 @@ class OCPCluster(OCPBaseEntity):
         return f"cluster:{self.uuid}"
 
 
+class OCPNode(OCPBaseEntity):
+    """Entity representing OpenShift Node."""
+
+    name: str
+    creation_timestamp: datetime.datetime = None
+    labels: Dict[str, str] = None
+    addresses: List[dict] = None
+    allocatable: NodeResources = None
+    capacity: NodeResources = None
+    architecture: str = None
+    kernel_version: str = None
+    machine_id: str = None
+    operating_system: str = None
+    taints: List[dict] = None
+    errors: Dict[str, OCPError] = Field(default_factory=dict)
+    _kind = "node"
+
+
 class OCPProject(OCPBaseEntity):
     """Entity representing OpenShift Projects/Namespaces."""
 
@@ -139,6 +161,50 @@ class OCPError(OCPBaseEntity):
     def __raise__(self):
         """Arguments for raised exception."""
         return (self.message,)
+
+
+class NodeResources(OCPBaseEntity):
+    """Class representing node's resources."""
+
+    cpu: float = None
+    memory_in_bytes: int = None
+    pods: int = None
+    _kind = "node-resources"
+
+    @validator("cpu", pre=True)
+    def _convert_cpu_value(cls, value):  # pylint: disable=no-self-argument
+        # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu
+        millicore_suffix = re.compile(r"^\d+m$")
+        if isinstance(value, str) and millicore_suffix.match(value):
+            value = float(value.replace("m", "")) / 1000
+        return value
+
+    @validator("memory_in_bytes", pre=True)
+    def _convert_memory_bytes(cls, value):  # pylint: disable=no-self-argument
+        # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+        if isinstance(value, str):
+            resources_regex = re.compile(r"^(\d+)([KMGTPE])(i?)$")
+            match = resources_regex.match(value)
+            if not match:
+                raise ValueError(MEMORY_CONVERSION_ERROR)
+            value = int(match.group(1))
+            power_name = match.group(2)
+            ends_with_i = match.group(3)
+            if ends_with_i:
+                base = 1024
+            else:
+                base = 1000
+            power = {
+                "K": 1,
+                "M": 2,
+                "G": 3,
+                "T": 4,
+                "P": 5,
+                "E": 6,
+            }[power_name]
+            return value * base**power
+
+        return value
 
 
 # update nested model references - this should always be the last thing to run

--- a/quipucords/scanner/openshift/test_entities.py
+++ b/quipucords/scanner/openshift/test_entities.py
@@ -12,8 +12,11 @@
 from copy import deepcopy
 
 import pytest
+from pydantic import ValidationError  # pylint: disable=no-name-in-module
 
 from scanner.openshift.entities import (
+    MEMORY_CONVERSION_ERROR,
+    NodeResources,
     OCPBaseEntity,
     OCPDeployment,
     OCPError,
@@ -145,3 +148,77 @@ class TestOCPBaseEntity:  # pylint: disable=missing-class-docstring, unused-vari
 
         entity = TestClass(name="foo")
         assert entity.kind is not None
+
+
+@pytest.mark.parametrize(
+    "value, expected_result, attr_value",
+    [
+        ("200m", 0.2, 0.2),
+        ("3500m", 3.5, 3.5),
+        (2.0, 2.0, 2.0),
+        (4, 4.0, 4.0),
+        ("2", "2", 2.0),
+    ],
+)
+# pylint: disable=no-value-for-parameter, protected-access
+def test_cpu_validator_with_convertible_values(value, expected_result, attr_value):
+    """Ensure cpu data is being converted appropriately."""
+    converted_value = NodeResources._convert_cpu_value(value)
+    assert converted_value == expected_result
+
+    node_resource = NodeResources(cpu=value)
+    assert node_resource.cpu == attr_value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["cpu_value", [2.0], "200k", {"cpu_value": "3500m"}],
+)
+def test_cpu_validator_with_inappropriate_values(value):
+    """Ensure proper error is being raised for values that belong to wrong data type."""
+    with pytest.raises(ValidationError) as error_info:
+        NodeResources(cpu=value)
+    assert "value is not a valid float" in str(error_info.value)
+
+
+@pytest.mark.parametrize(
+    "value, expected_result",
+    [
+        ("1Ki", 1024),
+        ("1K", 1000),
+        ("10Gi", 10737418240),
+        ("1P", 1000000000000000),
+        ("150Mi", 157286400),
+        (123, 123),
+    ],
+)
+# pylint: disable=no-value-for-parameter, protected-access
+def test_memory_validator_with_convertible_values(value, expected_result):
+    """Ensure memory data is being converted appropriately."""
+    converted_value = NodeResources._convert_memory_bytes(value)
+    assert converted_value == expected_result
+
+    node_resources = NodeResources(memory_in_bytes=value)
+    assert node_resources.memory_in_bytes == expected_result
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["15000GI", "15000L", "1500mi"],
+)
+# pylint: disable=no-value-for-parameter, protected-access
+def test_memory_validator_with_uncovertible_values(value):
+    """Ensure proper error is being raised for values that can't be converted."""
+    with pytest.raises(ValueError, match=MEMORY_CONVERSION_ERROR):
+        NodeResources._convert_memory_bytes(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[2.0], {"memory_value": "15500Ki"}, ("1500Ki",)],
+)
+def test_memory_validator_with_inappropriate_values(value):
+    """Ensure proper error is being raised for wrong data types."""
+    with pytest.raises(ValidationError) as exc_info:
+        NodeResources(memory_in_bytes=value)
+    assert "value is not a valid integer" in str(exc_info.value)


### PR DESCRIPTION
- Create node and nodeResources entities for the
proper modeling and collection of node facts.
- Create validators for cpu and memory_bytes fields,
aiming the convertion of the received values to the desired
data type.
- Add api functions in order to retrieve desired facts from openshift api. 
- Modify scan task inspection functions to see nodes as systems instead of projects. 

ps: Lint is complaining about a variable found in the cluster commit. I wont correct it since it's probably fixed in bruno's [pr ](https://github.com/quipucords/quipucords/pull/2224)

This feature is part of the implementation of [DISCOVERY-227](https://issues.redhat.com/browse/DISCOVERY-227)