### PR TITLE
[DISCOVERY-239] - update server-version upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,6 @@ VOLUME /var/log
 RUN mkdir -p /var/data
 VOLUME /var/data
 
-# Set production environment
-ARG BUILD_COMMIT=master
-ENV QUIPUCORDS_COMMIT=$BUILD_COMMIT
-
 # Copy server code
 COPY . .
 

--- a/quipucords/quipucords/environment.py
+++ b/quipucords/quipucords/environment.py
@@ -25,15 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 def commit():
-    """Collect the build number for the server.
-
-    :returns: A build number
-    """
-    commit_info = os.environ.get("QUIPUCORDS_COMMIT", None)
-    if commit_info is None:
+    """Collect the commit for the server."""
+    commit_info = os.environ.get("QUIPUCORDS_COMMIT", "").strip()
+    if not commit_info:
         try:
             commit_info = subprocess.check_output(
-                ["git", "describe", "--always"]
+                ["git", "rev-parse", "--verify", "HEAD"]
             ).strip()
             commit_info = commit_info.decode("utf-8")
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Fix: DISCOVERY-239

## How to test

`curl --insecure  https://localhost:9443/api/v1/status/ | jq '.server_version'`

the final part of the version should match current commit version instead of "master"