### PR TITLE
refat: simplify entity returning as forcedlist

### DIFF
--- a/quipucords/api/common/entities.py
+++ b/quipucords/api/common/entities.py
@@ -56,6 +56,13 @@ class HostEntity:
             return super().__getattribute__(attr)
         return getattr(self._fingerprints, attr)
 
+    def as_list(self):
+        """Return a list containing this instance."""
+        # HBI expects some fields to be formatted as an array of objects, which
+        # sometimes is not applicable
+        # (e.g.: Hosts.facts, SystemProfile.network_interfaces)
+        return [self]
+
     @property
     def number_of_cpus(self):
         """Retrieve number of cpus."""

--- a/quipucords/api/common/serializer.py
+++ b/quipucords/api/common/serializer.py
@@ -16,7 +16,6 @@ from collections import OrderedDict
 from rest_framework.serializers import (
     ChoiceField,
     Field,
-    ListSerializer,
     ModelSerializer,
     ValidationError,
 )
@@ -105,13 +104,3 @@ class CustomJSONField(Field):
         if value == "":
             return value
         return json.loads(value)
-
-
-class ForcedListSerializer(ListSerializer):  # pylint: disable=abstract-method
-    """Serializer that forces data output as list."""
-
-    def to_representation(self, data):
-        """Force instance as list."""
-        if not isinstance(data, list):
-            data = [data]
-        return super().to_representation(data)

--- a/quipucords/api/insights_report/serializers.py
+++ b/quipucords/api/insights_report/serializers.py
@@ -18,7 +18,7 @@ from rest_framework.serializers import Serializer, SerializerMethodField
 
 from api.common.common_report import create_filename
 from api.common.entities import HostEntity
-from api.common.serializer import ForcedListSerializer, NotEmptyMixin
+from api.common.serializer import NotEmptyMixin
 from api.status import get_server_id
 from quipucords.environment import server_version
 
@@ -44,17 +44,6 @@ class FactsetSerializer(Serializer):
 
     namespace = fields.CharField(default="qpc")
     facts = FactsSerializer(source="*")
-
-    def __init__(self, instance=None, **kwargs):
-        """Ininialize factset serializer."""
-        if instance is not None and not isinstance(instance, list):
-            instance = [instance]
-        super().__init__(instance, **kwargs)
-
-    class Meta:
-        """Serializer configuration."""
-
-        list_serializer_class = ForcedListSerializer
 
 
 class SystemProfileSerializer(NotEmptyMixin, Serializer):
@@ -102,7 +91,7 @@ class YupanaHostSerializer(NotEmptyMixin, Serializer):
     subscription_manager_id = fields.CharField(**default_kwargs)
     etc_machine_id = fields.CharField(**default_kwargs)
     vm_uuid = fields.CharField(**default_kwargs)
-    facts = FactsetSerializer(source="*", many=True)
+    facts = FactsetSerializer(source="as_list", many=True)
     system_profile = SystemProfileSerializer(source="*", **default_kwargs)
     tags = SerializerMethodField()
 

--- a/quipucords/api/insights_report/test_serializers.py
+++ b/quipucords/api/insights_report/test_serializers.py
@@ -31,7 +31,7 @@ def report_entity():
 def test_factset_serializer(db, report_entity):
     """Test FactsetSerializer."""
     serializer = FactsetSerializer(
-        report_entity.hosts[0],
+        report_entity.hosts[0].as_list(),
         many=True,
     )
     assert isinstance(serializer.data, list)


### PR DESCRIPTION
Insights require some fields to be arrays, so instead of using a class in Meta to force this conversion, create method that will return the entity instance as a list.
This is a recurrent problem, this will be used again to send network_interfaces information to SystemProfile.