### PR TITLE
chore: fix Makefile clean to work on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ help:
 all: lint test-coverage
 
 clean:
-	rm -rf .pytest_cache quipucords.egg-info dist build $(shell find . | grep -P '(.*\.pyc)|(\.coverage(\..+)*)$$|__pycache__')
+	rm -rf .pytest_cache quipucords.egg-info dist build $(shell find . | grep -E '(.*\.pyc)|(\.coverage(\..+)*)$$|__pycache__')
 
 clean-ui:
 	rm -rf quipucords/client


### PR DESCRIPTION
The -P option to grep for handline perl-flavored regex is not included in the default grep on MacOS. While a different can be installed with brew to support perl, there is nothing perl specific in that regexp in the Makefile that can't be handled with ERE, so using grep -E (aka egrep) does the trick and works on both Linux/CentOS/RHEL and MacOS.