### PR TITLE
fix(scans): Scans raise exceptions when running on MacOS.

### DIFF
--- a/quipucords/manage.py
+++ b/quipucords/manage.py
@@ -10,10 +10,14 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt.
 #
 """Django server management module."""
+import multiprocessing
 import os
 import sys
 
 if __name__ == "__main__":
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "quipucords.settings")
     try:
         from django.core.management import execute_from_command_line


### PR DESCRIPTION
Starting scans on MacOS cause an exception pertaining to the Django app not properly initialized and unable to use gettext for defining messages.

The issue is that for the scanner jobs, we create a Process for each. With Processes, MacOS (and Windows) spawn a new process instead of a fork as in Linux.  With the former, the Django is not passed through, so in which case, we need to import django and do a django.setup() similar to how a Celery app config is initialized.

This needs to be done early before any of the other imports are done like importing api models where gettext is used that requires django to be setup.