### PR TITLE
fix(netscan): Avoid data duplication in raw facts

### DIFF
--- a/quipucords/scanner/network/utils.py
+++ b/quipucords/scanner/network/utils.py
@@ -172,6 +172,11 @@ def collect_all_fact_names():
 
 
 @cache
+def get_fact_names():
+    """List fact names set on ansible rules."""
+    return list(sorted(collect_all_fact_names()))
+
+
 def raw_facts_template():
     """Results template for fact collection on network scans."""
-    return {fact_name: None for fact_name in sorted(collect_all_fact_names())}
+    return {fact_name: None for fact_name in get_fact_names()}


### PR DESCRIPTION
The template for raw facts was incorrectly cached, overriding the null values with the values of each system.
This was causing issues on scans where some data should be missing.

Fix: DISCOVERY-262