### PR TITLE
fix: Incorrectly mapped fact in network scanner

### DIFF
--- a/quipucords/fingerprinter/task.py
+++ b/quipucords/fingerprinter/task.py
@@ -1258,7 +1258,11 @@ class FingerprintTaskRunner(ScanTaskRunner):
 
         # Set subscription manager id
         self._add_fact_to_fingerprint(
-            source, "subman_virt_uuid", fact, "subscription_manager_id", fingerprint
+            source,
+            "subscription_manager_id",
+            fact,
+            "subscription_manager_id",
+            fingerprint,
         )
 
         # System information

--- a/quipucords/fingerprinter/tests_fingerprint_task.py
+++ b/quipucords/fingerprinter/tests_fingerprint_task.py
@@ -62,7 +62,7 @@ EXPECTED_FINGERPRINT_MAP_NETWORK = {
     "os_version": "etc_release_version",
     "redhat_certs": "redhat_packages_certs",
     "redhat_package_count": "redhat_packages_gpg_num_rh_packages",
-    "subscription_manager_id": "subman_virt_uuid",
+    "subscription_manager_id": "subscription_manager_id",
     "system_addons": "system_purpose_json__addons",
     "system_last_checkin_date": "connection_timestamp",
     "system_memory_bytes": "system_memory_bytes",
@@ -162,6 +162,7 @@ class EngineTest(TestCase):
         dmi_system_uuid=1234,
         subman_virt_uuid=4567,
         subman_consumed=SUBMAN_CONSUMED,
+        subscription_manager_id=42,
         connection_uuid="a037f26f-2988-57bd-85d8-de7617a3aab0",
         connection_host="1.2.3.4",
         connection_port=22,
@@ -217,6 +218,7 @@ class EngineTest(TestCase):
             fact["subman_virt_uuid"] = subman_virt_uuid
         if subman_consumed:
             fact["subman_consumed"] = subman_consumed
+        fact["subscription_manager_id"] = subscription_manager_id
         if connection_uuid:
             fact["connection_uuid"] = connection_uuid
         if connection_host:
@@ -420,7 +422,8 @@ class EngineTest(TestCase):
 
         self.assertEqual(fact.get("dmi_system_uuid"), fingerprint.get("bios_uuid"))
         self.assertEqual(
-            fact.get("subman_virt_uuid"), fingerprint.get("subscription_manager_id")
+            fact.get("subscription_manager_id"),
+            fingerprint.get("subscription_manager_id"),
         )
 
         self.assertEqual(

--- a/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
@@ -131,3 +131,20 @@
   set_fact:
     subman_consumed: "{{internal_subman_consumed}}"
   ignore_errors: yes
+
+#  subscription_manager_id fact
+- name: gather subscription_manager_id fact
+  raw: |
+    subscription-manager identity 2>/dev/null | 
+    grep 'system identity:' |
+    sed 's/system identity:\s*//'
+  register: internal_subscription_manager_id_cmd
+  ignore_errors: yes
+  become: yes
+  when: 'user_has_sudo and internal_have_subscription_manager'
+
+- name: extract result value for subscription_manager_id
+  set_fact:
+    subscription_manager_id: "{{ internal_subscription_manager_id_cmd['stdout'] | trim | default(None) }}"
+  ignore_errors: yes
+  when: '"stdout" in internal_subscription_manager_id_cmd'

--- a/quipucords/tests/integration/test_network_scan.py
+++ b/quipucords/tests/integration/test_network_scan.py
@@ -164,6 +164,7 @@ def expected_network_scan_facts():
         "subman_virt_host_type",
         "subman_virt_is_guest",
         "subman_virt_uuid",
+        "subscription_manager_id",
         "system_memory_bytes",
         "system_purpose_json",
         "system_user_count",
@@ -216,7 +217,7 @@ def fingerprint_fact_map():
         "os_version": "etc_release_version",
         "redhat_certs": "redhat_packages_certs",
         "redhat_package_count": "redhat_packages_gpg_num_rh_packages",
-        "subscription_manager_id": "subman_virt_uuid",
+        "subscription_manager_id": "subscription_manager_id",
         "system_addons": "system_purpose_json__addons",
         "system_creation_date": "date_yum_history/date_filesystem_create/date_anaconda_log/registration_time/date_machine_id",  # noqa:E501
         "system_last_checkin_date": "connection_timestamp",


### PR DESCRIPTION
subscription-manager-id fingerprint (and the homonymous field in insights reports) was incorrectly mapped to subman_virt_uuid in network scanner.

This adds a new fact "subscription_manager_id" that collects that value and maps it to its fingerprint.

Fix: DISCOVERY-264