### PR TITLE
chore(refact): Moving functions out of __init__.py

### DIFF
--- a/quipucords/api/status/misc.py
+++ b/quipucords/api/status/misc.py
@@ -7,9 +7,14 @@
 # along with this software; if not, see
 # https://www.gnu.org/licenses/gpl-3.0.txt.
 
-"""Status module."""
+"""Status misc module."""
 
 from functools import lru_cache
 
-from .misc import get_server_id
 from .model import ServerInformation
+
+
+@lru_cache
+def get_server_id():
+    """Get server_id and cache it."""
+    return ServerInformation.create_or_retreive_server_id()

--- a/quipucords/utils/__init__.py
+++ b/quipucords/utils/__init__.py
@@ -18,13 +18,4 @@ import json
 from .deepget import deepget
 from .default_getter import default_getter
 from .get_from_object_or_dict import get_from_object_or_dict
-
-
-def get_choice_ids(choices):
-    """Retrieve choice ids."""
-    return [choice[0] for choice in choices]
-
-
-def load_json_from_tarball(json_filename, tarball):
-    """Extract a json as dict from given TarFile interface."""
-    return json.loads(tarball.extractfile(json_filename).read())
+from .misc import get_choice_ids, load_json_from_tarball

--- a/quipucords/utils/misc.py
+++ b/quipucords/utils/misc.py
@@ -7,9 +7,15 @@
 # along with this software; if not, see
 # https://www.gnu.org/licenses/gpl-3.0.txt.
 
-"""Status module."""
+"""Misc utils for quipucords."""
+import json
 
-from functools import lru_cache
 
-from .misc import get_server_id
-from .model import ServerInformation
+def get_choice_ids(choices):
+    """Retrieve choice ids."""
+    return [choice[0] for choice in choices]
+
+
+def load_json_from_tarball(json_filename, tarball):
+    """Extract a json as dict from given TarFile interface."""
+    return json.loads(tarball.extractfile(json_filename).read())


### PR DESCRIPTION
Keeping PyCharm and the Python demi-gods happy, moving functions out of __init__.py and into separate files.