### PR TITLE
refactor: black before flake8 for quicker feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-integration:
 swagger-valid:
 	node_modules/swagger-cli/swagger-cli.js validate docs/swagger.yml
 
-lint: lint-isort lint-flake8 lint-black lint-ansible
+lint: lint-isort lint-black lint-flake8 lint-ansible
 
 lint-isort:
 	poetry run isort . --check --diff


### PR DESCRIPTION
On my system, `lint-black` completes in 4 seconds whereas `lint-flake8` needs about 39 seconds. Putting black before flake8 means I get feedback about formatting issues quicker.