### PR TITLE
fix: minor serialzer typos in doc strings

### DIFF
--- a/quipucords/api/connresult/serializer.py
+++ b/quipucords/api/connresult/serializer.py
@@ -17,7 +17,7 @@ class SystemConnectionResultSerializer(NotEmptySerializer):
     )
 
     class Meta:
-        """Metadata for serialzer."""
+        """Metadata for serializer."""
 
         model = SystemConnectionResult
         fields = ["name", "status", "source", "credential"]
@@ -28,7 +28,7 @@ class TaskConnectionResultSerializer(NotEmptySerializer):
     """Serializer for the TaskConnectionResult model."""
 
     class Meta:
-        """Metadata for serialzer."""
+        """Metadata for serializer."""
 
         model = TaskConnectionResult
         fields = ["source", "systems"]
@@ -39,7 +39,7 @@ class JobConnectionResultSerializer(NotEmptySerializer):
     """Serializer for the JobConnectionResult model."""
 
     class Meta:
-        """Metadata for serialzer."""
+        """Metadata for serializer."""
 
         model = JobConnectionResult
         fields = ["task_results"]

--- a/quipucords/api/inspectresult/serializer.py
+++ b/quipucords/api/inspectresult/serializer.py
@@ -17,7 +17,7 @@ class RawFactSerializer(NotEmptySerializer):
     value = CustomJSONField(required=True)
 
     class Meta:
-        """Metadata for serialzer."""
+        """Metadata for serializer."""
 
         model = RawFact
         fields = ["name", "value"]
@@ -33,7 +33,7 @@ class SystemInspectionResultSerializer(NotEmptySerializer):
     )
 
     class Meta:
-        """Metadata for serialzer."""
+        """Metadata for serializer."""
 
         model = SystemInspectionResult
         fields = ["name", "status", "source", "facts"]
@@ -44,7 +44,7 @@ class TaskInspectionResultSerializer(NotEmptySerializer):
     """Serializer for the TaskInspectionResult model."""
 
     class Meta:
-        """Metadata for serialzer."""
+        """Metadata for serializer."""
 
         model = TaskInspectionResult
         fields = ["source", "systems"]
@@ -55,7 +55,7 @@ class JobInspectionResultSerializer(NotEmptySerializer):
     """Serializer for the JobInspectionResult model."""
 
     class Meta:
-        """Metadata for serialzer."""
+        """Metadata for serializer."""
 
         model = JobInspectionResult
         fields = ["task_results"]


### PR DESCRIPTION
fix: minor typos in doc strings

Replacing serialzer with serializer.