### PR TITLE
fix: extra % character in logging message

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -287,7 +287,7 @@ class ScanJob(models.Model):
             f" systems_scanned={systems_scanned:d},"
             f" systems_failed={systems_failed:d},"
             f" systems_unreachable={systems_unreachable:d},"
-            f" system_fingerprint_count=%{system_fingerprint_count:d}"
+            f" system_fingerprint_count={system_fingerprint_count:d}"
         )
         self.log_message(message)
 


### PR DESCRIPTION

fix: extra % character in logging message


The system_fingerprint_count included a % prefix to the count in the log message.

  INFO Job 3 (inspect, elapsed_time: 6s) - FAILURE STATS. Stats: systems_count=10, systems_scanned=0, systems_failed=0, systems_unreachable=10, system_fingerprint_count=%0

That should just be:

  INFO Job 3 (inspect, elapsed_time: 6s) - FAILURE STATS. Stats: systems_count=10, systems_scanned=0, systems_failed=0, systems_unreachable=10, system_fingerprint_count=0