### PR TITLE
Refactor/centralized datasources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ profile = "black"
 known_first_party = [
     "api",
     "compat",
+    "constants",
     "fingerprinter",
     "log_messages",
     "quipucords",

--- a/quipucords/api/common/entities.py
+++ b/quipucords/api/common/entities.py
@@ -18,8 +18,9 @@ from api.common.enumerators import (
     SystemPurposeSla,
     SystemPurposeUsage,
 )
-from api.models import DeploymentsReport, Product, Source, SystemFingerprint
+from api.models import DeploymentsReport, Product, SystemFingerprint
 from compat.db import StringAgg
+from constants import DataSources
 
 CANONICAL_FACTS = (
     "fqdn",
@@ -316,7 +317,7 @@ class ReportEntity:
         # openshift sources won't make sense in insights reports.
         fingerprints = list(
             SystemFingerprint.objects.filter(deployment_report=deployment_report)
-            .exclude(sources__icontains=Source.OPENSHIFT_SOURCE_TYPE)
+            .exclude(sources__icontains=DataSources.OPENSHIFT)
             .annotate(
                 product_names=StringAgg(
                     "products__name",

--- a/quipucords/api/credential/model.py
+++ b/quipucords/api/credential/model.py
@@ -7,21 +7,17 @@ from django.utils.translation import gettext as _
 
 from api import messages
 from api.vault import encrypt_data_as_unicode
+from constants import DataSources
 
 
 class Credential(models.Model):
     """The credential for connecting to systems."""
 
-    NETWORK_CRED_TYPE = "network"
-    VCENTER_CRED_TYPE = "vcenter"
-    SATELLITE_CRED_TYPE = "satellite"
-    OPENSHIFT_CRED_TYPE = "openshift"
-    CRED_TYPE_CHOICES = (
-        (NETWORK_CRED_TYPE, NETWORK_CRED_TYPE),
-        (VCENTER_CRED_TYPE, VCENTER_CRED_TYPE),
-        (SATELLITE_CRED_TYPE, SATELLITE_CRED_TYPE),
-        (OPENSHIFT_CRED_TYPE, OPENSHIFT_CRED_TYPE),
-    )
+    NETWORK_CRED_TYPE = DataSources.NETWORK.value
+    VCENTER_CRED_TYPE = DataSources.VCENTER.value
+    SATELLITE_CRED_TYPE = DataSources.SATELLITE.value
+    OPENSHIFT_CRED_TYPE = DataSources.OPENSHIFT.value
+    CRED_TYPE_CHOICES = DataSources.choices
     BECOME_USER_DEFAULT = "root"
     BECOME_SUDO = "sudo"
     BECOME_SU = "su"

--- a/quipucords/api/credential/model.py
+++ b/quipucords/api/credential/model.py
@@ -13,11 +13,6 @@ from constants import DataSources
 class Credential(models.Model):
     """The credential for connecting to systems."""
 
-    NETWORK_CRED_TYPE = DataSources.NETWORK.value
-    VCENTER_CRED_TYPE = DataSources.VCENTER.value
-    SATELLITE_CRED_TYPE = DataSources.SATELLITE.value
-    OPENSHIFT_CRED_TYPE = DataSources.OPENSHIFT.value
-    CRED_TYPE_CHOICES = DataSources.choices
     BECOME_USER_DEFAULT = "root"
     BECOME_SUDO = "sudo"
     BECOME_SU = "su"
@@ -39,7 +34,7 @@ class Credential(models.Model):
     )
 
     name = models.CharField(max_length=64, unique=True)
-    cred_type = models.CharField(max_length=9, choices=CRED_TYPE_CHOICES, null=False)
+    cred_type = models.CharField(max_length=9, choices=DataSources.choices, null=False)
     username = models.CharField(max_length=64, null=True)
     password = models.CharField(max_length=1024, null=True)
     auth_token = models.CharField(max_length=1024, null=True)

--- a/quipucords/api/credential/test_serializer.py
+++ b/quipucords/api/credential/test_serializer.py
@@ -3,6 +3,7 @@ import pytest
 
 from api.credential.serializer import CredentialSerializer
 from api.models import Credential
+from constants import DataSources
 
 
 @pytest.fixture
@@ -10,7 +11,7 @@ def ocp_credential():
     """Previously created OCP Credential."""
     cred = Credential(
         name="cred1",
-        cred_type=Credential.OPENSHIFT_CRED_TYPE,
+        cred_type=DataSources.OPENSHIFT,
         auth_token="test_auth_token",
     )
     cred.save()
@@ -33,7 +34,7 @@ def test_openshift_cred_correct_fields():
     """Test if serializer is valid when passing mandatory fields."""
     data = {
         "name": "cred1",
-        "cred_type": Credential.OPENSHIFT_CRED_TYPE,
+        "cred_type": DataSources.OPENSHIFT,
         "auth_token": "test_auth_token",
     }
     serializer = CredentialSerializer(data=data)
@@ -45,7 +46,7 @@ def test_openshift_cred_unallowed_fields():
     """Test if serializer is invalid when passing unallowed fields."""
     data = {
         "name": "cred1",
-        "cred_type": Credential.OPENSHIFT_CRED_TYPE,
+        "cred_type": DataSources.OPENSHIFT,
         "auth_token": "test_auth_token",
         "password": "test_password",
         "become_password": "test_become_password",
@@ -59,7 +60,7 @@ def test_openshift_cred_empty_auth_token():
     """Test if serializer is invalid when auth token is empty."""
     data = {
         "name": "cred1",
-        "cred_type": Credential.OPENSHIFT_CRED_TYPE,
+        "cred_type": DataSources.OPENSHIFT,
         "auth_token": "",
     }
     serializer = CredentialSerializer(data=data)
@@ -71,7 +72,7 @@ def test_openshift_cred_absent_auth_token():
     """Test if serializer is invalid when auth token is absent."""
     data = {
         "name": "cred1",
-        "cred_type": Credential.OPENSHIFT_CRED_TYPE,
+        "cred_type": DataSources.OPENSHIFT,
     }
     serializer = CredentialSerializer(data=data)
     assert not serializer.is_valid(), serializer.errors
@@ -89,7 +90,7 @@ def test_openshift_cred_update(ocp_credential):
     assert serializer.is_valid(), serializer.errors
     serializer.save()
     assert ocp_credential.name == "cred2"
-    assert ocp_credential.cred_type == Credential.OPENSHIFT_CRED_TYPE
+    assert ocp_credential.cred_type == DataSources.OPENSHIFT
 
 
 @pytest.mark.django_db
@@ -104,7 +105,7 @@ def test_openshift_cred_update_no_token(ocp_credential):
     serializer.save()
     assert serializer.is_valid()
     assert ocp_credential.name == "cred2"
-    assert ocp_credential.cred_type == Credential.OPENSHIFT_CRED_TYPE
+    assert ocp_credential.cred_type == DataSources.OPENSHIFT
     assert ocp_credential.auth_token == original_auth_token
 
 

--- a/quipucords/api/credential/tests_credential.py
+++ b/quipucords/api/credential/tests_credential.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from api import messages
 from api.models import Credential, Source
 from api.vault import decrypt_data_as_unicode
+from constants import DataSources
 
 
 class CredentialTest(TestCase):
@@ -25,7 +26,7 @@ class CredentialTest(TestCase):
         name="test_cred",
         username="testuser",
         password="testpass",
-        cred_type=Credential.NETWORK_CRED_TYPE,
+        cred_type=DataSources.NETWORK,
     ):
         """Create a Credential model for use within test cases.
 
@@ -75,7 +76,7 @@ class CredentialTest(TestCase):
         """Ensure we can create a new host credential object via API."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
         }
@@ -87,7 +88,7 @@ class CredentialTest(TestCase):
         """Create with duplicate name should fail."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
         }
@@ -118,7 +119,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "password": "pass1",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
@@ -135,7 +136,7 @@ class CredentialTest(TestCase):
         data = {
             "name": "cred1",
             "username": "user1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
         }
         response = self.client.post(url, json.dumps(data), "application/json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -151,7 +152,7 @@ class CredentialTest(TestCase):
         data = {
             "name": "cred1",
             "username": "user1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "ssh_keyfile": "blah",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
@@ -246,7 +247,7 @@ class CredentialTest(TestCase):
         """Tests the list view with filter set of the Credential API."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
         }
@@ -254,7 +255,7 @@ class CredentialTest(TestCase):
 
         data = {
             "name": "cred2",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user2",
             "password": "pass2",
         }
@@ -268,7 +269,7 @@ class CredentialTest(TestCase):
         results = json_resp.get("results")
         self.assertEqual(len(results), 2)
 
-        resp = self.client.get(url, {"cred_type": Credential.VCENTER_CRED_TYPE})
+        resp = self.client.get(url, {"cred_type": DataSources.VCENTER})
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         json_resp = resp.json()
         self.assertTrue(json_resp.get("results") is not None)
@@ -280,7 +281,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
         }
@@ -288,7 +289,7 @@ class CredentialTest(TestCase):
 
         data = {
             "name": "cred2",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user2",
             "password": "pass2",
         }
@@ -306,7 +307,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
         }
@@ -314,7 +315,7 @@ class CredentialTest(TestCase):
 
         data = {
             "name": "cred2",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user2",
             "password": "pass2",
         }
@@ -347,7 +348,7 @@ class CredentialTest(TestCase):
         cred.save()
         source = Source(
             name="cred_source",
-            source_type=Source.NETWORK_SOURCE_TYPE,
+            source_type=DataSources.NETWORK,
             hosts=["1.2.3.4"],
         )
         source.save()
@@ -367,7 +368,7 @@ class CredentialTest(TestCase):
         """Ensure we can create a new vcenter credential."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user1",
             "password": "pass1",
         }
@@ -379,7 +380,7 @@ class CredentialTest(TestCase):
         """Vcenter cred with duplicate name should fail."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user1",
             "password": "pass1",
         }
@@ -395,7 +396,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user1",
             "ssh_keyfile": "keyfile",
         }
@@ -408,7 +409,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user1",
             "password": "pass1",
             "ssh_keyfile": "keyfile",
@@ -422,7 +423,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user1",
             "password": "pass1",
             "become_password": "pass2",
@@ -435,7 +436,7 @@ class CredentialTest(TestCase):
         """Ensure we can create and update a vcenter credential."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user1",
             "password": "pass1",
         }
@@ -449,7 +450,7 @@ class CredentialTest(TestCase):
         """Ensure we can set the default become_method via API."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
         }
@@ -461,7 +462,7 @@ class CredentialTest(TestCase):
         """Ensure we can set the credentials become method."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
             "become_method": "doas",
@@ -474,7 +475,7 @@ class CredentialTest(TestCase):
         """Ensure we can set the default become_user via API."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
         }
@@ -486,7 +487,7 @@ class CredentialTest(TestCase):
         """Ensure we can set the become user."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
             "become_method": "doas",
@@ -500,7 +501,7 @@ class CredentialTest(TestCase):
         """Ensure we can set the become password."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.NETWORK_CRED_TYPE,
+            "cred_type": DataSources.NETWORK,
             "username": "user1",
             "password": "pass1",
             "become_method": "doas",
@@ -517,7 +518,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.VCENTER_CRED_TYPE,
+            "cred_type": DataSources.VCENTER,
             "username": "user1",
             "password": "pass1",
             "ssh_passphrase": "pass2",
@@ -530,7 +531,7 @@ class CredentialTest(TestCase):
         """Ensure we can create a new satellite credential."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.SATELLITE_CRED_TYPE,
+            "cred_type": DataSources.SATELLITE,
             "username": "user1",
             "password": "pass1",
         }
@@ -542,7 +543,7 @@ class CredentialTest(TestCase):
         """Satellite cred with duplicate name should fail."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.SATELLITE_CRED_TYPE,
+            "cred_type": DataSources.SATELLITE,
             "username": "user1",
             "password": "pass1",
         }
@@ -558,7 +559,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.SATELLITE_CRED_TYPE,
+            "cred_type": DataSources.SATELLITE,
             "username": "user1",
             "ssh_keyfile": "keyfile",
         }
@@ -570,7 +571,7 @@ class CredentialTest(TestCase):
         """Ensure Satellite update doesn't allow adding ssh_keyfile."""
         data = {
             "name": "cred1",
-            "cred_type": Credential.SATELLITE_CRED_TYPE,
+            "cred_type": DataSources.SATELLITE,
             "username": "user1",
             "password": "pass1",
         }
@@ -591,7 +592,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.SATELLITE_CRED_TYPE,
+            "cred_type": DataSources.SATELLITE,
             "username": "user1",
             "password": "pass1",
             "ssh_keyfile": "keyfile",
@@ -605,7 +606,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.SATELLITE_CRED_TYPE,
+            "cred_type": DataSources.SATELLITE,
             "username": "user1",
             "password": "pass1",
             "become_password": "pass2",
@@ -619,7 +620,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "cred1",
-            "cred_type": Credential.SATELLITE_CRED_TYPE,
+            "cred_type": DataSources.SATELLITE,
             "username": "user1",
             "password": "pass1",
             "ssh_passphrase": "pass2",
@@ -632,7 +633,7 @@ class CredentialTest(TestCase):
         """Ensure we can create a new openshift credential."""
         data = {
             "name": "openshift_cred_1",
-            "cred_type": Credential.OPENSHIFT_CRED_TYPE,
+            "cred_type": DataSources.OPENSHIFT,
             "auth_token": "test_token",
         }
         self.create_expect_201(data)
@@ -644,7 +645,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "openshift_cred_1",
-            "cred_type": Credential.OPENSHIFT_CRED_TYPE,
+            "cred_type": DataSources.OPENSHIFT,
         }
         response = self.client.post(url, json.dumps(data), "application/json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -655,7 +656,7 @@ class CredentialTest(TestCase):
         url = reverse("cred-list")
         data = {
             "name": "openshift_cred_1",
-            "cred_type": Credential.OPENSHIFT_CRED_TYPE,
+            "cred_type": DataSources.OPENSHIFT,
             "auth_token": "test_token",
             "become_password": "test_become_password",
             "username": "test_username",

--- a/quipucords/api/deployments_report/tests_deployments_report.py
+++ b/quipucords/api/deployments_report/tests_deployments_report.py
@@ -15,6 +15,7 @@ from api.deployments_report.csv_renderer import DeploymentCSVRenderer
 from api.deployments_report.util import sanitize_row
 from api.details_report.tests_details_report import MockRequest
 from api.models import Credential, ServerInformation, Source
+from constants import DataSources
 
 EXPECTED_NUMBER_OF_FINGERPRINTS = 38
 
@@ -27,12 +28,12 @@ class DeploymentReportTest(TestCase):
         """Create test case setup."""
         management.call_command("flush", "--no-input")
         self.net_source = Source.objects.create(
-            name="test_source", source_type=Source.NETWORK_SOURCE_TYPE
+            name="test_source", source_type=DataSources.NETWORK
         )
 
         self.net_cred = Credential.objects.create(
             name="net_cred1",
-            cred_type=Credential.NETWORK_CRED_TYPE,
+            cred_type=DataSources.NETWORK,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/api/details_report/tests_details_report.py
+++ b/quipucords/api/details_report/tests_details_report.py
@@ -13,6 +13,7 @@ from api.common.common_report import create_report_version
 from api.common.report_json_gzip_renderer import ReportJsonGzipRenderer
 from api.details_report.csv_renderer import DetailsCSVRenderer
 from api.models import Credential, DetailsReport, ServerInformation, Source
+from constants import DataSources
 
 
 class MockRequest:
@@ -31,12 +32,12 @@ class DetailReportTest(TestCase):
         """Create test case setup."""
         management.call_command("flush", "--no-input")
         self.net_source = Source.objects.create(
-            name="test_source", source_type=Source.NETWORK_SOURCE_TYPE
+            name="test_source", source_type=DataSources.NETWORK
         )
 
         self.net_cred = Credential.objects.create(
             name="net_cred1",
-            cred_type=Credential.NETWORK_CRED_TYPE,
+            cred_type=DataSources.NETWORK,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/api/details_report/tests_sync_report_creation.py
+++ b/quipucords/api/details_report/tests_sync_report_creation.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from api import messages
 from api.common.common_report import create_report_version
 from api.models import Credential, DetailsReport, ServerInformation, Source
+from constants import DataSources
 
 
 class DetailsReportTest(TestCase):
@@ -20,12 +21,12 @@ class DetailsReportTest(TestCase):
     def setUp(self):
         """Create test case setup."""
         self.net_source = Source.objects.create(
-            name="test_source", source_type=Source.NETWORK_SOURCE_TYPE
+            name="test_source", source_type=DataSources.NETWORK
         )
 
         self.net_cred = Credential.objects.create(
             name="net_cred1",
-            cred_type=Credential.NETWORK_CRED_TYPE,
+            cred_type=DataSources.NETWORK,
             username="username",
             password="password",
             become_password=None,
@@ -223,9 +224,7 @@ class DetailsReportTest(TestCase):
         self.assertEqual(len(response_json["valid_sources"]), 0)
         self.assertEqual(len(response_json["invalid_sources"]), 1)
 
-        valid_choices = ", ".join(
-            [valid_type[0] for valid_type in Source.SOURCE_TYPE_CHOICES]
-        )
+        valid_choices = ", ".join(DataSources.values)
 
         self.assertEqual(
             response_json["invalid_sources"][0]["errors"]["source_type"],

--- a/quipucords/api/details_report/util.py
+++ b/quipucords/api/details_report/util.py
@@ -9,8 +9,9 @@ from django.utils.translation import gettext as _
 from api import messages
 from api.common.common_report import CSVHelper, create_report_version, sanitize_row
 from api.common.util import mask_data_general, validate_query_param_bool
-from api.models import DetailsReport, ScanTask, ServerInformation, Source
+from api.models import DetailsReport, ScanTask, ServerInformation
 from api.serializers import DetailsReportSerializer
+from constants import DataSources
 
 ERRORS_KEY = "errors"
 INVALID_SOURCES_KEY = "invalid_sources"
@@ -134,15 +135,9 @@ def _validate_source_json(source_json):
         has_error = True
         invalid_field_obj[SOURCE_NAME_KEY] = _(messages.FC_SOURCE_NAME_NOT_STR)
 
-    if not has_error and not [
-        valid_type
-        for valid_type in Source.SOURCE_TYPE_CHOICES
-        if valid_type[0] == source_type
-    ]:
+    if not has_error and source_type not in DataSources:
         has_error = True
-        valid_choices = ", ".join(
-            [valid_type[0] for valid_type in Source.SOURCE_TYPE_CHOICES]
-        )
+        valid_choices = ", ".join(DataSources.values)
         invalid_field_obj[SOURCE_TYPE_KEY] = _(
             messages.FC_MUST_BE_ONE_OF % valid_choices
         )

--- a/quipucords/api/merge_report/tests_async_merge_report.py
+++ b/quipucords/api/merge_report/tests_async_merge_report.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from api import messages
 from api.common.common_report import create_report_version
 from api.models import Credential, ScanTask, ServerInformation, Source
+from constants import DataSources
 from scanner.test_util import create_scan_job
 
 
@@ -26,12 +27,12 @@ class AsyncMergeReports(TestCase):
         """Create test case setup."""
         management.call_command("flush", "--no-input")
         self.net_source = Source.objects.create(
-            name="test_source", source_type=Source.NETWORK_SOURCE_TYPE
+            name="test_source", source_type=DataSources.NETWORK
         )
 
         self.net_cred = Credential.objects.create(
             name="net_cred1",
-            cred_type=Credential.NETWORK_CRED_TYPE,
+            cred_type=DataSources.NETWORK,
             username="username",
             password="password",
             become_password=None,
@@ -270,9 +271,7 @@ class AsyncMergeReports(TestCase):
         self.assertEqual(len(response_json["valid_sources"]), 0)
         self.assertEqual(len(response_json["invalid_sources"]), 1)
 
-        valid_choices = ", ".join(
-            [valid_type[0] for valid_type in Source.SOURCE_TYPE_CHOICES]
-        )
+        valid_choices = ", ".join(DataSources.values)
 
         self.assertEqual(
             response_json["invalid_sources"][0]["errors"]["source_type"],

--- a/quipucords/api/merge_report/tests_sync_merge_report.py
+++ b/quipucords/api/merge_report/tests_sync_merge_report.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from api import messages
 from api.common.common_report import create_report_version
 from api.models import Credential, ServerInformation, Source
+from constants import DataSources
 
 
 class SyncMergeReports(TestCase):
@@ -20,12 +21,12 @@ class SyncMergeReports(TestCase):
         """Create test case setup."""
         management.call_command("flush", "--no-input")
         self.net_source = Source.objects.create(
-            name="test_source", source_type=Source.NETWORK_SOURCE_TYPE
+            name="test_source", source_type=DataSources.NETWORK
         )
 
         self.net_cred = Credential.objects.create(
             name="net_cred1",
-            cred_type=Credential.NETWORK_CRED_TYPE,
+            cred_type=DataSources.NETWORK,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/api/reports/tests_reports.py
+++ b/quipucords/api/reports/tests_reports.py
@@ -15,6 +15,7 @@ from api.common.common_report import create_report_version
 from api.details_report.tests_details_report import MockRequest
 from api.models import Credential, ServerInformation, Source
 from api.reports.reports_gzip_renderer import ReportsGzipRenderer
+from constants import DataSources
 
 
 class ReportsTest(TestCase):
@@ -25,12 +26,12 @@ class ReportsTest(TestCase):
         """Create test case setup."""
         management.call_command("flush", "--no-input")
         self.net_source = Source.objects.create(
-            name="test_source", source_type=Source.NETWORK_SOURCE_TYPE
+            name="test_source", source_type=DataSources.NETWORK
         )
 
         self.net_cred = Credential.objects.create(
             name="net_cred1",
-            cred_type=Credential.NETWORK_CRED_TYPE,
+            cred_type=DataSources.NETWORK,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/api/source/model.py
+++ b/quipucords/api/source/model.py
@@ -9,6 +9,7 @@ from functools import cached_property
 from django.db import models
 
 from api.credential.model import Credential
+from constants import DataSources
 
 
 class SourceOptions(models.Model):
@@ -51,16 +52,11 @@ class SourceOptions(models.Model):
 class Source(models.Model):
     """A source connects a list of credentials and a list of hosts."""
 
-    NETWORK_SOURCE_TYPE = "network"
-    VCENTER_SOURCE_TYPE = "vcenter"
-    SATELLITE_SOURCE_TYPE = "satellite"
-    OPENSHIFT_SOURCE_TYPE = "openshift"
-    SOURCE_TYPE_CHOICES = (
-        (NETWORK_SOURCE_TYPE, NETWORK_SOURCE_TYPE),
-        (VCENTER_SOURCE_TYPE, VCENTER_SOURCE_TYPE),
-        (SATELLITE_SOURCE_TYPE, SATELLITE_SOURCE_TYPE),
-        (OPENSHIFT_SOURCE_TYPE, OPENSHIFT_SOURCE_TYPE),
-    )
+    NETWORK_SOURCE_TYPE = DataSources.NETWORK.value
+    VCENTER_SOURCE_TYPE = DataSources.VCENTER.value
+    SATELLITE_SOURCE_TYPE = DataSources.SATELLITE.value
+    OPENSHIFT_SOURCE_TYPE = DataSources.OPENSHIFT.value
+    SOURCE_TYPE_CHOICES = DataSources.choices
 
     name = models.CharField(max_length=64, unique=True)
     source_type = models.CharField(

--- a/quipucords/api/source/model.py
+++ b/quipucords/api/source/model.py
@@ -52,15 +52,9 @@ class SourceOptions(models.Model):
 class Source(models.Model):
     """A source connects a list of credentials and a list of hosts."""
 
-    NETWORK_SOURCE_TYPE = DataSources.NETWORK.value
-    VCENTER_SOURCE_TYPE = DataSources.VCENTER.value
-    SATELLITE_SOURCE_TYPE = DataSources.SATELLITE.value
-    OPENSHIFT_SOURCE_TYPE = DataSources.OPENSHIFT.value
-    SOURCE_TYPE_CHOICES = DataSources.choices
-
     name = models.CharField(max_length=64, unique=True)
     source_type = models.CharField(
-        max_length=12, choices=SOURCE_TYPE_CHOICES, null=False
+        max_length=12, choices=DataSources.choices, null=False
     )
     port = models.IntegerField(null=True)
     options = models.OneToOneField(SourceOptions, null=True, on_delete=models.CASCADE)

--- a/quipucords/api/source/serializer.py
+++ b/quipucords/api/source/serializer.py
@@ -22,6 +22,7 @@ from api.common.serializer import (
 )
 from api.common.util import check_for_existing_name
 from api.models import Credential, Source, SourceOptions
+from constants import DataSources
 from utils import get_from_object_or_dict
 
 
@@ -71,7 +72,8 @@ class SourceSerializer(NotEmptySerializer):
 
     name = CharField(required=True, max_length=64)
     source_type = ValidStringChoiceField(
-        required=False, choices=Source.SOURCE_TYPE_CHOICES
+        required=False,
+        choices=DataSources.choices,
     )
     port = IntegerField(required=False, min_value=0, allow_null=True)
     hosts = CustomJSONField(required=True)
@@ -97,7 +99,7 @@ class SourceSerializer(NotEmptySerializer):
         valid_sat_options = ["ssl_cert_verify", "ssl_protocol", "disable_ssl"]
         valid_openshift_options = ["ssl_cert_verify", "ssl_protocol", "disable_ssl"]
 
-        if source_type == Source.SATELLITE_SOURCE_TYPE:
+        if source_type == DataSources.SATELLITE:
             cls._check_for_disallowed_fields(
                 options,
                 messages.SAT_INVALID_OPTIONS,
@@ -106,7 +108,7 @@ class SourceSerializer(NotEmptySerializer):
             if options.get("ssl_cert_verify") is None:
                 options["ssl_cert_verify"] = True
 
-        elif source_type == Source.VCENTER_SOURCE_TYPE:
+        elif source_type == DataSources.VCENTER:
             cls._check_for_disallowed_fields(
                 options,
                 messages.VC_INVALID_OPTIONS,
@@ -115,13 +117,13 @@ class SourceSerializer(NotEmptySerializer):
             if options.get("ssl_cert_verify") is None:
                 options["ssl_cert_verify"] = True
 
-        elif source_type == Source.NETWORK_SOURCE_TYPE:
+        elif source_type == DataSources.NETWORK:
             cls._check_for_disallowed_fields(
                 options,
                 messages.NET_SSL_OPTIONS_NOT_ALLOWED,
                 valid_net_options,
             )
-        elif source_type == Source.OPENSHIFT_SOURCE_TYPE:
+        elif source_type == DataSources.OPENSHIFT:
             cls._check_for_disallowed_fields(
                 options,
                 messages.OPENSHIFT_INVALID_OPTIONS,
@@ -167,13 +169,13 @@ class SourceSerializer(NotEmptySerializer):
     def validate(self, attrs):
         """Validate if fields received are appropriate for each credential."""
         source_type = get_from_object_or_dict(self.instance, attrs, "source_type")
-        if source_type == Source.NETWORK_SOURCE_TYPE:
+        if source_type == DataSources.NETWORK:
             validated_data = self.validate_network_source(attrs, source_type)
-        elif source_type == Source.VCENTER_SOURCE_TYPE:
+        elif source_type == DataSources.VCENTER:
             validated_data = self.validate_vcenter_source(attrs, source_type)
-        elif source_type == Source.SATELLITE_SOURCE_TYPE:
+        elif source_type == DataSources.SATELLITE:
             validated_data = self.validate_satellite_source(attrs, source_type)
-        elif source_type == Source.OPENSHIFT_SOURCE_TYPE:
+        elif source_type == DataSources.OPENSHIFT:
             validated_data = self.validate_openshift_source(attrs, source_type)
         else:
             raise ValidationError({"source_type": messages.UNKNOWN_SOURCE_TYPE})
@@ -205,9 +207,9 @@ class SourceSerializer(NotEmptySerializer):
             options.save()
             source.options = options
         elif not options and source_type in (
-            Source.SATELLITE_SOURCE_TYPE,
-            Source.VCENTER_SOURCE_TYPE,
-            Source.OPENSHIFT_SOURCE_TYPE,
+            DataSources.SATELLITE,
+            DataSources.VCENTER,
+            DataSources.OPENSHIFT,
         ):
             self._options_with_ssl_cert_verify_true(source)
 

--- a/quipucords/api/source/test_serializer.py
+++ b/quipucords/api/source/test_serializer.py
@@ -4,6 +4,7 @@ import pytest
 from api import messages
 from api.models import Credential, Source, SourceOptions
 from api.source.serializer import SourceSerializer
+from constants import DataSources
 
 
 @pytest.fixture
@@ -11,7 +12,7 @@ def openshift_cred_id():
     """Return openshift credential."""
     openshift_credential = Credential.objects.create(
         name="openshift_cred",
-        cred_type=Credential.OPENSHIFT_CRED_TYPE,
+        cred_type=DataSources.OPENSHIFT,
         auth_token="openshift_token",
     )
     return openshift_credential.id
@@ -22,7 +23,7 @@ def satellite_cred_id():
     """Return satellite credential."""
     satellite_credential = Credential.objects.create(
         name="sat_cred",
-        cred_type=Credential.SATELLITE_CRED_TYPE,
+        cred_type=DataSources.SATELLITE,
         username="satellite_user",
         password="satellite_password",
         become_password=None,
@@ -36,7 +37,7 @@ def openshift_source(openshift_cred_id):
     """Openshift Source."""
     source = Source.objects.create(
         name="source_saved",
-        source_type=Source.OPENSHIFT_SOURCE_TYPE,
+        source_type=DataSources.OPENSHIFT,
         port=222,
         hosts='["1.2.3.4"]',
         options=SourceOptions.objects.create(ssl_cert_verify=True),
@@ -65,7 +66,7 @@ def test_wrong_cred_type(satellite_cred_id):
     error_message = messages.SOURCE_CRED_WRONG_TYPE
     data = {
         "name": "source2",
-        "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+        "source_type": DataSources.OPENSHIFT,
         "hosts": ["1.2.3.4"],
         "credentials": [satellite_cred_id],
     }
@@ -80,7 +81,7 @@ def test_openshift_source_green_path(openshift_cred_id):
     """Test if serializer is valid when passing mandatory fields."""
     data = {
         "name": "source3",
-        "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+        "source_type": DataSources.OPENSHIFT,
         "port": 222,
         "hosts": ["1.2.3.4"],
         "credentials": [openshift_cred_id],
@@ -98,7 +99,7 @@ def test_openshift_source_default_port(openshift_cred_id):
     """Test if serializer is valid when not passing port field."""
     data = {
         "name": "source3",
-        "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+        "source_type": DataSources.OPENSHIFT,
         "hosts": ["1.2.3.4"],
         "credentials": [openshift_cred_id],
     }
@@ -121,7 +122,7 @@ def test_openshift_source_update(openshift_source, openshift_cred_id):
     assert serializer.is_valid(), serializer.errors
     serializer.save()
     assert openshift_source.name == "source_updated"
-    assert openshift_source.source_type == Source.OPENSHIFT_SOURCE_TYPE
+    assert openshift_source.source_type == DataSources.OPENSHIFT
 
 
 @pytest.mark.django_db
@@ -138,5 +139,5 @@ def test_openshift_source_update_options(openshift_source, openshift_cred_id):
     assert serializer.is_valid(), serializer.errors
     serializer.save()
     assert openshift_source.name == "source_updated"
-    assert openshift_source.source_type == Source.OPENSHIFT_SOURCE_TYPE
+    assert openshift_source.source_type == DataSources.OPENSHIFT
     assert not openshift_source.options.ssl_cert_verify

--- a/quipucords/api/source/tests_source.py
+++ b/quipucords/api/source/tests_source.py
@@ -14,6 +14,7 @@ from api import messages
 from api.models import Credential, Scan, ScanTask, Source
 from api.serializers import SourceSerializer
 from api.source.view import format_source
+from constants import DataSources
 from scanner.test_util import create_scan_job
 
 
@@ -30,7 +31,7 @@ class SourceTest(TestCase):
         management.call_command("flush", "--no-input")
         self.net_cred = Credential.objects.create(
             name="net_cred1",
-            cred_type=Credential.NETWORK_CRED_TYPE,
+            cred_type=DataSources.NETWORK,
             username="username",
             password="password",
             become_password=None,
@@ -44,7 +45,7 @@ class SourceTest(TestCase):
 
         self.vc_cred = Credential.objects.create(
             name="vc_cred1",
-            cred_type=Credential.VCENTER_CRED_TYPE,
+            cred_type=DataSources.VCENTER,
             username="username",
             password="password",
             become_password=None,
@@ -55,7 +56,7 @@ class SourceTest(TestCase):
 
         self.sat_cred = Credential.objects.create(
             name="sat_cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
             become_password=None,
@@ -69,7 +70,7 @@ class SourceTest(TestCase):
 
         self.openshift_cred = Credential.objects.create(
             name="openshift_cred1",
-            cred_type=Credential.OPENSHIFT_CRED_TYPE,
+            cred_type=DataSources.OPENSHIFT,
             auth_token="openshift_token",
         )
         self.openshift_cred_for_upload = self.openshift_cred.id
@@ -131,7 +132,7 @@ class SourceTest(TestCase):
     #################################################
     def test_validate_opts(self):
         """Test the validate_opts function."""
-        source_type = Source.SATELLITE_SOURCE_TYPE
+        source_type = DataSources.SATELLITE
         options = {"use_paramiko": True}
         with self.assertRaises(ValidationError):
             SourceSerializer.validate_opts(options, source_type)
@@ -140,7 +141,7 @@ class SourceTest(TestCase):
         SourceSerializer.validate_opts(options, source_type)
         self.assertEqual(options["ssl_cert_verify"], True)
 
-        source_type = Source.VCENTER_SOURCE_TYPE
+        source_type = DataSources.VCENTER
         options = {"use_paramiko": True}
         with self.assertRaises(ValidationError):
             SourceSerializer.validate_opts(options, source_type)
@@ -149,7 +150,7 @@ class SourceTest(TestCase):
         SourceSerializer.validate_opts(options, source_type)
         self.assertEqual(options["ssl_cert_verify"], True)
 
-        source_type = Source.NETWORK_SOURCE_TYPE
+        source_type = DataSources.NETWORK
         options = {"disable_ssl": True}
         with self.assertRaises(ValidationError):
             SourceSerializer.validate_opts(options, source_type)
@@ -218,7 +219,7 @@ class SourceTest(TestCase):
         query = "?scan=False"
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": [self.net_cred_for_upload],
@@ -231,7 +232,7 @@ class SourceTest(TestCase):
         query = "?scan=True"
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": [self.net_cred_for_upload],
@@ -243,7 +244,7 @@ class SourceTest(TestCase):
         query = "?scan=Foo"
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": [self.net_cred_for_upload],
@@ -254,7 +255,7 @@ class SourceTest(TestCase):
         """A valid create request should succeed."""
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": [self.net_cred_for_upload],
@@ -266,7 +267,7 @@ class SourceTest(TestCase):
         """A valid create request should succeed without port."""
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "credentials": [self.net_cred_for_upload],
         }
@@ -277,7 +278,7 @@ class SourceTest(TestCase):
         """A duplicate create should fail."""
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": [self.net_cred_for_upload],
@@ -290,7 +291,7 @@ class SourceTest(TestCase):
         """A valid create request with two hosts."""
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4", "1.2.3.5"],
             "port": "22",
             "credentials": [self.net_cred_for_upload],
@@ -302,7 +303,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "hosts": "1.2.3.4",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
             }
@@ -314,7 +315,7 @@ class SourceTest(TestCase):
             {
                 "name": 1,
                 "hosts": "1.2.3.4",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
             }
@@ -325,7 +326,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "\r\n",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": "1.2.3.4",
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -337,7 +338,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
             }
@@ -348,7 +349,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": [],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -360,7 +361,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": {"1.2.3.4": "1.2.3.4"},
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -372,7 +373,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": [1, 2, 3, 4],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -384,7 +385,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "A" * 100,
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -396,7 +397,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": -1,
                 "credentials": [self.net_cred_for_upload],
@@ -408,7 +409,7 @@ class SourceTest(TestCase):
         self.create_expect_201(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["10.10.181.9", ""],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -420,7 +421,7 @@ class SourceTest(TestCase):
         self.create_expect_201(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": [
                     "10.10.181.9",
                     "10.10.181.9/16",
@@ -446,7 +447,7 @@ class SourceTest(TestCase):
         self.create_expect_201(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": [
                     "10.10.181.8",
                     "10.10.181.9",
@@ -489,7 +490,7 @@ class SourceTest(TestCase):
         response = self.create(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": hosts,
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -505,7 +506,7 @@ class SourceTest(TestCase):
         response = self.create(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": hosts,
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -519,7 +520,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "-1",
                 "credentials": [self.net_cred_for_upload],
@@ -531,7 +532,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
             }
@@ -542,7 +543,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [],
@@ -554,7 +555,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [42],
@@ -566,7 +567,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": ["hi"],
@@ -578,7 +579,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.vc_cred_for_upload],
@@ -589,7 +590,7 @@ class SourceTest(TestCase):
         """Test network type doesn't allow ssl options."""
         data = {
             "name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": [self.vc_cred_for_upload],
@@ -601,7 +602,7 @@ class SourceTest(TestCase):
         """List all Source objects."""
         data = {
             "name": "source",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "port": "22",
             "hosts": ["1.2.3.4"],
             "credentials": [self.net_cred_for_upload],
@@ -620,7 +621,7 @@ class SourceTest(TestCase):
             {
                 "id": 1,
                 "name": "source0",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "port": 22,
                 "hosts": ["1.2.3.4"],
                 "credentials": [self.net_cred_for_response],
@@ -628,7 +629,7 @@ class SourceTest(TestCase):
             {
                 "id": 2,
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "port": 22,
                 "hosts": ["1.2.3.4"],
                 "credentials": [self.net_cred_for_response],
@@ -636,7 +637,7 @@ class SourceTest(TestCase):
             {
                 "id": 3,
                 "name": "source2",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "port": 22,
                 "hosts": ["1.2.3.4"],
                 "credentials": [self.net_cred_for_response],
@@ -649,7 +650,7 @@ class SourceTest(TestCase):
         """List all Source objects filtered by type."""
         data = {
             "name": "nsource",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "port": "22",
             "credentials": [self.net_cred_for_upload],
             "hosts": ["1.2.3.4"],
@@ -661,7 +662,7 @@ class SourceTest(TestCase):
 
         data = {
             "name": "vsource",
-            "source_type": Source.VCENTER_SOURCE_TYPE,
+            "source_type": DataSources.VCENTER,
             "credentials": [self.vc_cred_for_upload],
             "hosts": ["1.2.3.4"],
         }
@@ -672,7 +673,7 @@ class SourceTest(TestCase):
             self.create_expect_201(this_data)
 
         url = reverse("source-list")
-        response = self.client.get(url, {"source_type": Source.VCENTER_SOURCE_TYPE})
+        response = self.client.get(url, {"source_type": DataSources.VCENTER})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         content = response.json()
@@ -708,7 +709,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "exclude_hosts": ["1.2.3.4"],
                 "port": "22",
@@ -741,7 +742,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source2",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -762,7 +763,7 @@ class SourceTest(TestCase):
 
         expected = {
             "name": "source2",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.5"],
             "port": 23,
             "credentials": [self.net_cred_for_response],
@@ -777,7 +778,7 @@ class SourceTest(TestCase):
         self.create_expect_201(
             {
                 "name": "source2-double",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -787,7 +788,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source2",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -811,7 +812,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -830,7 +831,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -854,7 +855,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -874,7 +875,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -898,7 +899,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -917,7 +918,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -943,7 +944,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source2",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -952,7 +953,7 @@ class SourceTest(TestCase):
 
         data = {
             "name": "source3",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.5"],
             "port": 23,
             "credentials": [self.net_cred.id],
@@ -968,7 +969,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source2",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -977,7 +978,7 @@ class SourceTest(TestCase):
 
         data = {
             "name": "source3",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.5"],
             "port": 23,
             "credentials": [self.vc_cred.id],
@@ -993,7 +994,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source3",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.net_cred_for_upload],
@@ -1013,7 +1014,7 @@ class SourceTest(TestCase):
         """Delete a Source."""
         data = {
             "name": "source3",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": [self.net_cred_for_upload],
@@ -1030,7 +1031,7 @@ class SourceTest(TestCase):
         cred.save()
         source = Source(
             name="cred_source",
-            source_type=Source.NETWORK_SOURCE_TYPE,
+            source_type=DataSources.NETWORK,
             hosts=["1.2.3.4"],
         )
         source.save()
@@ -1057,7 +1058,7 @@ class SourceTest(TestCase):
         """A valid create request should succeed."""
         data = {
             "name": "source1",
-            "source_type": Source.VCENTER_SOURCE_TYPE,
+            "source_type": DataSources.VCENTER,
             "hosts": ["1.2.3.4"],
             "credentials": [self.vc_cred_for_upload],
         }
@@ -1069,7 +1070,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4"],
                 "credentials": [self.vc_cred_for_upload, self.net_cred_for_upload],
             }
@@ -1080,7 +1081,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "credentials": [self.vc_cred_for_upload],
             }
         )
@@ -1090,7 +1091,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": [],
                 "credentials": [self.vc_cred_for_upload],
             }
@@ -1101,7 +1102,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4", "1.2.3.5"],
                 "credentials": [self.vc_cred_for_upload],
             }
@@ -1112,7 +1113,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4"],
                 "exclude_hosts": ["1.2.3.4"],
                 "credentials": [self.vc_cred_for_upload],
@@ -1124,7 +1125,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4/5"],
                 "credentials": [self.vc_cred_for_upload],
             }
@@ -1135,7 +1136,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.vc_cred_for_upload],
@@ -1159,7 +1160,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.vc_cred_for_upload],
@@ -1183,7 +1184,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.vc_cred_for_upload],
@@ -1208,7 +1209,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.vc_cred_for_upload],
@@ -1232,7 +1233,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.vc_cred_for_upload],
@@ -1270,7 +1271,7 @@ class SourceTest(TestCase):
         """A valid create request should succeed."""
         data = {
             "name": "source1",
-            "source_type": Source.SATELLITE_SOURCE_TYPE,
+            "source_type": DataSources.SATELLITE,
             "hosts": ["1.2.3.4"],
             "credentials": [self.sat_cred_for_upload],
         }
@@ -1281,7 +1282,7 @@ class SourceTest(TestCase):
         """A valid create request should succeed."""
         data = {
             "name": "source1",
-            "source_type": Source.SATELLITE_SOURCE_TYPE,
+            "source_type": DataSources.SATELLITE,
             "hosts": ["1.2.3.4"],
             "credentials": [self.sat_cred_for_upload],
             "options": {"ssl_cert_verify": False},
@@ -1294,7 +1295,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "credentials": [self.sat_cred_for_upload, self.net_cred_for_upload],
             }
@@ -1305,7 +1306,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "credentials": [self.sat_cred_for_upload],
             }
         )
@@ -1315,7 +1316,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": [],
                 "credentials": [self.sat_cred_for_upload],
             }
@@ -1326,7 +1327,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4", "1.2.3.5"],
                 "credentials": [self.sat_cred_for_upload],
             }
@@ -1337,7 +1338,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "exclude_hosts": ["1.2.3.4"],
                 "credentials": [self.sat_cred_for_upload],
@@ -1349,7 +1350,7 @@ class SourceTest(TestCase):
         self.create_expect_400(
             {
                 "name": "source1",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4/5"],
                 "credentials": [self.sat_cred_for_upload],
             }
@@ -1360,7 +1361,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.sat_cred_for_upload],
@@ -1384,7 +1385,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.sat_cred_for_upload],
@@ -1419,7 +1420,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.sat_cred_for_upload],
@@ -1443,7 +1444,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.sat_cred_for_upload],
@@ -1468,7 +1469,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.sat_cred_for_upload],
@@ -1492,7 +1493,7 @@ class SourceTest(TestCase):
         initial = self.create_expect_201(
             {
                 "name": "source",
-                "source_type": Source.SATELLITE_SOURCE_TYPE,
+                "source_type": DataSources.SATELLITE,
                 "hosts": ["1.2.3.4"],
                 "port": "22",
                 "credentials": [self.sat_cred_for_upload],
@@ -1517,7 +1518,7 @@ class SourceTest(TestCase):
         """Ensure we can create a new openshift source."""
         data = {
             "name": "openshift_source_1",
-            "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+            "source_type": DataSources.OPENSHIFT,
             "hosts": ["1.2.3.4"],
             "credentials": [self.openshift_cred_for_upload],
         }
@@ -1530,7 +1531,7 @@ class SourceTest(TestCase):
         url = reverse("source-list")
         data = {
             "name": "openshift_source_1",
-            "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+            "source_type": DataSources.OPENSHIFT,
             "credentials": [self.openshift_cred_for_upload],
         }
         response = self.client.post(url, json.dumps(data), "application/json")
@@ -1542,7 +1543,7 @@ class SourceTest(TestCase):
         url = reverse("source-list")
         data = {
             "name": "openshift_source_1",
-            "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+            "source_type": DataSources.OPENSHIFT,
             "hosts": ["1.2.3.4"],
             "credentials": [self.openshift_cred_for_upload],
             "options": {"use_paramiko": True},
@@ -1556,7 +1557,7 @@ class SourceTest(TestCase):
         source_to_be_updated = self.create_expect_201(
             {
                 "name": "openshift_source_1",
-                "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+                "source_type": DataSources.OPENSHIFT,
                 "hosts": ["1.2.3.4"],
                 "credentials": [self.openshift_cred_for_upload],
             }
@@ -1578,7 +1579,7 @@ class SourceTest(TestCase):
         source_to_be_updated = self.create_expect_201(
             {
                 "name": "openshift_source_1",
-                "source_type": Source.OPENSHIFT_SOURCE_TYPE,
+                "source_type": DataSources.OPENSHIFT,
                 "hosts": ["1.2.3.4"],
                 "credentials": [self.openshift_cred_for_upload],
             }

--- a/quipucords/constants.py
+++ b/quipucords/constants.py
@@ -1,4 +1,4 @@
-"""Constants for quipucords"""
+"""Constants for quipucords."""
 
 from django.db.models.enums import TextChoices
 

--- a/quipucords/constants.py
+++ b/quipucords/constants.py
@@ -1,0 +1,12 @@
+"""Constants for quipucords"""
+
+from django.db.models.enums import TextChoices
+
+
+class DataSources(TextChoices):
+    """Django flavored enum for all data sources Quipucords can connect to."""
+
+    NETWORK = "network", "network"
+    VCENTER = "vcenter", "vcenter"
+    SATELLITE = "satellite", "satellite"
+    OPENSHIFT = "openshift", "openshift"

--- a/quipucords/fingerprinter/task.py
+++ b/quipucords/fingerprinter/task.py
@@ -17,8 +17,9 @@ from api.common.util import (
     is_int,
     mask_data_general,
 )
-from api.models import DeploymentsReport, Product, ScanTask, Source, SystemFingerprint
+from api.models import DeploymentsReport, Product, ScanTask, SystemFingerprint
 from api.serializers import SystemFingerprintSerializer
+from constants import DataSources
 from fingerprinter import formatters
 from fingerprinter.constants import (
     ENTITLEMENTS_KEY,
@@ -82,10 +83,10 @@ NAME_RELATED_FACTS = ["name", "vm_dns_name", "virtual_host_name"]
 
 # Fingerprint keys
 COMBINED_KEY = "combined_fingerprints"
-NETWORK_KEY = Source.NETWORK_SOURCE_TYPE
-VCENTER_KEY = Source.VCENTER_SOURCE_TYPE
-SATELLITE_KEY = Source.SATELLITE_SOURCE_TYPE
-OPENSHIFT_KEY = Source.OPENSHIFT_SOURCE_TYPE
+NETWORK_KEY = DataSources.NETWORK
+VCENTER_KEY = DataSources.VCENTER
+SATELLITE_KEY = DataSources.SATELLITE
+OPENSHIFT_KEY = DataSources.OPENSHIFT
 
 
 class FingerprintTaskRunner(ScanTaskRunner):
@@ -513,7 +514,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
             server_id = source.get("server_id")
             source_type = source.get("source_type")
             source_name = source.get("source_name")
-            if fact.get("cluster") and source_type == Source.OPENSHIFT_SOURCE_TYPE:
+            if fact.get("cluster") and source_type == DataSources.OPENSHIFT:
                 # skip cluster fact in openshift scans since this type of "system"
                 # won't generate a fingerprint
                 continue

--- a/quipucords/fingerprinter/test_fingerprint_process_sources.py
+++ b/quipucords/fingerprinter/test_fingerprint_process_sources.py
@@ -4,9 +4,9 @@ import logging
 
 import pytest
 
-from api.models import DetailsReport, ScanJob, ScanTask, Source
+from api.models import DetailsReport, ScanJob, ScanTask
+from constants import DataSources
 from fingerprinter.task import FingerprintTaskRunner
-from utils import get_choice_ids
 
 logger = logging.getLogger(__file__)
 
@@ -21,7 +21,7 @@ def details_report(mocker):
             "source_name": source_type,
             "server_id": "<ID>",
         }
-        for source_type in get_choice_ids(Source.SOURCE_TYPE_CHOICES)
+        for source_type in DataSources.values
     ]
     return report
 

--- a/quipucords/fingerprinter/tests_fingerprint_task.py
+++ b/quipucords/fingerprinter/tests_fingerprint_task.py
@@ -11,6 +11,7 @@ from django.test import TestCase
 
 from api.deployments_report.model import SystemFingerprint
 from api.models import DeploymentsReport, DetailsReport, ServerInformation, Source
+from constants import DataSources
 from fingerprinter.constants import ENTITLEMENTS_KEY, META_DATA_KEY, PRODUCTS_KEY
 from fingerprinter.task import (
     FINGERPRINT_GLOBAL_ID_KEY,
@@ -141,7 +142,7 @@ class EngineTest(TestCase):
         self,
         report_id=1,
         source_name="source1",
-        source_type=Source.NETWORK_SOURCE_TYPE,
+        source_type=DataSources.NETWORK,
         cpu_count=1,
         etc_release_name="RHEL",
         etc_release_version="7.4 (Maipo)",
@@ -257,7 +258,7 @@ class EngineTest(TestCase):
         self,
         report_id=1,
         source_name="source2",
-        source_type=Source.VCENTER_SOURCE_TYPE,
+        source_type=DataSources.VCENTER,
         vm_cpu_count=2,
         vm_os="RHEL 7.3",
         vm_mac_addresses=None,
@@ -324,7 +325,7 @@ class EngineTest(TestCase):
         self,
         report_id=1,
         source_name="source3",
-        source_type=Source.SATELLITE_SOURCE_TYPE,
+        source_type=DataSources.SATELLITE,
         hostname="9.8.7.6",
         os_name="RHEL",
         os_release="RHEL 7.3",
@@ -536,7 +537,7 @@ class EngineTest(TestCase):
         source = {
             "server_id": self.server_id,
             "source_name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "facts": n_details_report["facts"],
         }
         nfingerprints = self.fp_task_runner._process_source(source)
@@ -552,7 +553,7 @@ class EngineTest(TestCase):
         source = {
             "server_id": self.server_id,
             "source_name": "source2",
-            "source_type": Source.VCENTER_SOURCE_TYPE,
+            "source_type": DataSources.VCENTER,
             "facts": v_details_report["facts"],
         }
         vfingerprints = self.fp_task_runner._process_source(source)
@@ -567,7 +568,7 @@ class EngineTest(TestCase):
         source = {
             "server_id": self.server_id,
             "source_name": "source3",
-            "source_type": Source.SATELLITE_SOURCE_TYPE,
+            "source_type": DataSources.SATELLITE,
             "facts": s_details_report["facts"],
         }
         sfingerprints = self.fp_task_runner._process_source(source)
@@ -625,7 +626,7 @@ class EngineTest(TestCase):
         source = {
             "server_id": self.server_id,
             "source_name": "source1",
-            "source_type": Source.NETWORK_SOURCE_TYPE,
+            "source_type": DataSources.NETWORK,
             "facts": details_report["facts"],
         }
         fingerprints = self.fp_task_runner._process_source(source)
@@ -639,7 +640,7 @@ class EngineTest(TestCase):
         source = {
             "server_id": self.server_id,
             "source_name": "source1",
-            "source_type": Source.VCENTER_SOURCE_TYPE,
+            "source_type": DataSources.VCENTER,
             "facts": details_report["facts"],
         }
         fingerprints = self.fp_task_runner._process_source(source)
@@ -651,7 +652,7 @@ class EngineTest(TestCase):
         details_report = self._create_vcenter_fc_json(
             report_id=1,
             source_name="source2",
-            source_type=Source.VCENTER_SOURCE_TYPE,
+            source_type=DataSources.VCENTER,
             vm_cpu_count=2,
             vm_os="RHEL 7.3",
             vm_mac_addresses=None,
@@ -665,7 +666,7 @@ class EngineTest(TestCase):
         source = {
             "server_id": self.server_id,
             "source_name": "source1",
-            "source_type": Source.VCENTER_SOURCE_TYPE,
+            "source_type": DataSources.VCENTER,
             "facts": details_report["facts"],
         }
         fingerprints = self.fp_task_runner._process_source(source)
@@ -679,7 +680,7 @@ class EngineTest(TestCase):
         source = {
             "server_id": self.server_id,
             "source_name": "source1",
-            "source_type": Source.SATELLITE_SOURCE_TYPE,
+            "source_type": DataSources.SATELLITE,
             "facts": details_report["facts"],
         }
         fingerprints = self.fp_task_runner._process_source(source)
@@ -691,14 +692,14 @@ class EngineTest(TestCase):
         details_report = self._create_satellite_fc_json(
             report_id=1,
             source_name="source3",
-            source_type=Source.SATELLITE_SOURCE_TYPE,
+            source_type=DataSources.SATELLITE,
             hostname="virt-who-9384389442-5",
         )
         fact = details_report["facts"][0]
         source = {
             "server_id": self.server_id,
             "source_name": "source1",
-            "source_type": Source.SATELLITE_SOURCE_TYPE,
+            "source_type": DataSources.SATELLITE,
             "facts": details_report["facts"],
         }
         fingerprints = self.fp_task_runner._process_source(source)
@@ -710,14 +711,14 @@ class EngineTest(TestCase):
         details_report = self._create_satellite_fc_json(
             report_id=1,
             source_name="source3",
-            source_type=Source.SATELLITE_SOURCE_TYPE,
+            source_type=DataSources.SATELLITE,
             hostname="virt-who-9384389442-0",
         )
         fact = details_report["facts"][0]
         source = {
             "server_id": self.server_id,
             "source_name": "source1",
-            "source_type": Source.SATELLITE_SOURCE_TYPE,
+            "source_type": DataSources.SATELLITE,
             "facts": details_report["facts"],
         }
         fingerprints = self.fp_task_runner._process_source(source)
@@ -874,19 +875,19 @@ class EngineTest(TestCase):
         nmetadata = {
             "os_release": {
                 "source_name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "raw_fact_key": "etc_release_release",
             },
             "bios_uuid": {
                 "source_name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "raw_fact_key": "dmi_system_uuid",
             },
         }
         nsources = {
             "source1": {
                 "source_name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
             }
         }
         nfingerprint_to_merge = {
@@ -918,19 +919,19 @@ class EngineTest(TestCase):
         vmetadata = {
             "os_release": {
                 "source_name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "raw_fact_key": "etc_release_release",
             },
             "vm_uuid": {
                 "source_name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
                 "raw_fact_key": "vm.uuid",
             },
         }
         vsources = {
             "source1": {
                 "source_name": "source1",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
             }
         }
         vfingerprint_to_merge = {
@@ -973,7 +974,7 @@ class EngineTest(TestCase):
         merged_sources = {
             "source1": {
                 "source_name": "source1",
-                "source_type": Source.NETWORK_SOURCE_TYPE,
+                "source_type": DataSources.NETWORK,
             }
         }
 
@@ -1239,7 +1240,7 @@ class EngineTest(TestCase):
         source_dict = {
             "server_id": self.server_id,
             "source_name": "source2",
-            "source_type": Source.VCENTER_SOURCE_TYPE,
+            "source_type": DataSources.VCENTER,
         }
         facts_dict = vcenter_template()
         result = self.fp_task_runner._process_vcenter_fact(source_dict, facts_dict)
@@ -1251,7 +1252,7 @@ class EngineTest(TestCase):
             fingerprint_name: {
                 "server_id": self.server_id,
                 "source_name": "source2",
-                "source_type": Source.VCENTER_SOURCE_TYPE,
+                "source_type": DataSources.VCENTER,
                 "has_sudo": False,
                 "raw_fact_key": fact_name,
             }
@@ -1273,7 +1274,7 @@ class EngineTest(TestCase):
         source_dict = {
             "server_id": self.server_id,
             "source_name": "source3",
-            "source_type": Source.SATELLITE_SOURCE_TYPE,
+            "source_type": DataSources.SATELLITE,
         }
         facts_dict = satellite_template()
         result = self.fp_task_runner._process_satellite_fact(source_dict, facts_dict)
@@ -1288,7 +1289,7 @@ class EngineTest(TestCase):
                 fingerprint_name: {
                     "server_id": self.server_id,
                     "source_name": "source3",
-                    "source_type": Source.SATELLITE_SOURCE_TYPE,
+                    "source_type": DataSources.SATELLITE,
                     "has_sudo": False,
                     "raw_fact_key": fact_name,
                 }

--- a/quipucords/scanner/get_scanner.py
+++ b/quipucords/scanner/get_scanner.py
@@ -1,0 +1,11 @@
+"""get_scanner module."""
+
+import importlib
+
+
+def get_scanner(data_source):
+    """Get the appropriate scanner for given data_source."""
+    try:
+        return importlib.import_module(f"scanner.{data_source}")
+    except ModuleNotFoundError as error:
+        raise NotImplementedError(f"Unsupported source type: {data_source}") from error

--- a/quipucords/scanner/openshift/test_connect.py
+++ b/quipucords/scanner/openshift/test_connect.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from api.models import ScanTask, Source
+from api.models import ScanTask
+from constants import DataSources
 from scanner.openshift import ConnectTaskRunner
 from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.entities import OCPError
@@ -13,7 +14,7 @@ from tests.factories import ScanTaskFactory
 def scan_task():
     """Return a ScanTask for testing."""
     return ScanTaskFactory(
-        source__source_type=Source.OPENSHIFT_SOURCE_TYPE,
+        source__source_type=DataSources.OPENSHIFT,
         source__hosts='["1.2.3.4"]',
         source__port=4321,
         scan_type=ScanTask.SCAN_TYPE_CONNECT,

--- a/quipucords/scanner/openshift/test_inspect.py
+++ b/quipucords/scanner/openshift/test_inspect.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from api.models import ScanTask, Source
+from api.models import ScanTask
+from constants import DataSources
 from scanner.exceptions import ScanFailureError
 from scanner.openshift import InspectTaskRunner
 from scanner.openshift.api import OpenShiftApi
@@ -21,7 +22,7 @@ from tests.factories import ScanTaskFactory
 def scan_task():
     """Return a ScanTask for testing."""
     connect_task = ScanTaskFactory(
-        source__source_type=Source.OPENSHIFT_SOURCE_TYPE,
+        source__source_type=DataSources.OPENSHIFT,
         source__hosts='["1.2.3.4"]',
         source__port=4321,
         scan_type=ScanTask.SCAN_TYPE_CONNECT,

--- a/quipucords/scanner/satellite/tests_sat_connect.py
+++ b/quipucords/scanner/satellite/tests_sat_connect.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from requests import exceptions
 
 from api.models import Credential, ScanJob, ScanTask, Source
+from constants import DataSources
 from scanner.satellite.api import (
     SATELLITE_VERSION_5,
     SATELLITE_VERSION_6,
@@ -45,7 +46,7 @@ class ConnectTaskRunnerTest(TestCase):
         """Create test case setup."""
         self.cred = Credential(
             name="cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/scanner/satellite/tests_sat_factory.py
+++ b/quipucords/scanner/satellite/tests_sat_factory.py
@@ -2,6 +2,7 @@
 from django.test import TestCase
 
 from api.models import Credential, ScanTask, Source
+from constants import DataSources
 from scanner.satellite.api import SATELLITE_VERSION_5, SATELLITE_VERSION_6
 from scanner.satellite.factory import create
 from scanner.satellite.five import SatelliteFive
@@ -16,7 +17,7 @@ class SatelliteFactoryTest(TestCase):
         """Create test case setup."""
         self.cred = Credential(
             name="cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/scanner/satellite/tests_sat_five.py
+++ b/quipucords/scanner/satellite/tests_sat_five.py
@@ -16,6 +16,7 @@ from api.models import (
     SystemInspectionResult,
     TaskConnectionResult,
 )
+from constants import DataSources
 from scanner.satellite.api import SatelliteException
 from scanner.satellite.five import SatelliteFive, request_host_details
 from scanner.test_util import create_scan_job
@@ -34,7 +35,7 @@ class SatelliteFiveTest(TestCase):
         """Create test case setup."""
         self.cred = Credential(
             name="cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/scanner/satellite/tests_sat_inspect.py
+++ b/quipucords/scanner/satellite/tests_sat_inspect.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from requests import exceptions
 
 from api.models import Credential, ScanJob, ScanTask, Source
+from constants import DataSources
 from scanner.satellite.api import (
     SATELLITE_VERSION_5,
     SATELLITE_VERSION_6,
@@ -51,7 +52,7 @@ class InspectTaskRunnerTest(TestCase):
         """Create test case setup."""
         self.cred = Credential(
             name="cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
         )

--- a/quipucords/scanner/satellite/tests_sat_six.py
+++ b/quipucords/scanner/satellite/tests_sat_six.py
@@ -17,6 +17,7 @@ from api.models import (
     SystemInspectionResult,
     TaskConnectionResult,
 )
+from constants import DataSources
 from scanner.satellite.api import SatelliteException
 from scanner.satellite.six import (
     SatelliteSixV1,
@@ -57,7 +58,7 @@ class SatelliteSixV1Test(TestCase):
         """Create test case setup."""
         self.cred = Credential(
             name="cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
             become_password=None,
@@ -514,7 +515,7 @@ class SatelliteSixV2Test(TestCase):
         """Create test case setup."""
         self.cred = Credential(
             name="cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/scanner/satellite/tests_sat_utils.py
+++ b/quipucords/scanner/satellite/tests_sat_utils.py
@@ -6,6 +6,7 @@ import requests_mock
 from django.test import TestCase
 
 from api.models import Credential, ScanTask, Source, SourceOptions
+from constants import DataSources
 from scanner.satellite.api import (
     SATELLITE_VERSION_5,
     SATELLITE_VERSION_6,
@@ -38,7 +39,7 @@ class SatelliteUtilsTest(TestCase):
         """Create test case setup."""
         self.cred = Credential(
             name="cred1",
-            cred_type=Credential.SATELLITE_CRED_TYPE,
+            cred_type=DataSources.SATELLITE,
             username="username",
             password="password",
             become_password=None,

--- a/quipucords/scanner/test_get_scanner.py
+++ b/quipucords/scanner/test_get_scanner.py
@@ -1,0 +1,21 @@
+"""Sanity test for quipucords scanners."""
+
+import pytest
+
+from constants import DataSources
+from scanner.get_scanner import get_scanner
+from scanner.task import ScanTaskRunner
+
+
+@pytest.mark.parametrize("data_source", DataSources.values)
+def test_scanner_module(data_source):
+    """Sanity check scanner packages."""
+    scanner = get_scanner(data_source)
+    assert issubclass(scanner.ConnectTaskRunner, ScanTaskRunner)
+    assert issubclass(scanner.InspectTaskRunner, ScanTaskRunner)
+
+
+def test_scanner_invalid_source_type():
+    """Ensure get_scanner throws an error when a non-implemented scanner is provided."""
+    with pytest.raises(NotImplementedError):
+        get_scanner("UNKNOWN")

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -31,7 +31,7 @@ def system_fingerprint_source_types():
     """Return default source types for fingerprints."""
     all_types = set(DataSources.values)
     # OpenShift will be ignored by default for convenience on insights tests
-    ignored_types = {DataSources.OPENSHIFT.value}
+    ignored_types = {DataSources.OPENSHIFT}
     return all_types - ignored_types
 
 
@@ -203,7 +203,7 @@ class CredentialFactory(DjangoModelFactory):
     @factory.lazy_attribute
     def auth_token(self):
         """Set auth_token lazily."""
-        if self.cred_type == models.Credential.OPENSHIFT_CRED_TYPE:
+        if self.cred_type == DataSources.OPENSHIFT:
             return Faker().password()
         return None
 

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -8,7 +8,7 @@ from faker import Faker
 
 from api import models
 from api.status import get_server_id
-from utils import get_choice_ids
+from constants import DataSources
 
 
 def format_sources(obj):
@@ -29,9 +29,9 @@ def format_sources(obj):
 
 def system_fingerprint_source_types():
     """Return default source types for fingerprints."""
-    all_types = set(get_choice_ids(models.Source.SOURCE_TYPE_CHOICES))
+    all_types = set(DataSources.values)
     # OpenShift will be ignored by default for convenience on insights tests
-    ignored_types = {models.Source.OPENSHIFT_SOURCE_TYPE}
+    ignored_types = {DataSources.OPENSHIFT.value}
     return all_types - ignored_types
 
 
@@ -193,7 +193,7 @@ class CredentialFactory(DjangoModelFactory):
     """Factory for Credential model."""
 
     name = factory.Faker("slug")
-    cred_type = factory.Iterator(get_choice_ids(models.Credential.CRED_TYPE_CHOICES))
+    cred_type = factory.Iterator(DataSources.values)
 
     class Meta:
         """Factory options."""
@@ -221,7 +221,7 @@ class SourceFactory(DjangoModelFactory):
     """Factory for Source model."""
 
     name = factory.Faker("slug")
-    source_type = factory.Iterator(get_choice_ids(models.Source.SOURCE_TYPE_CHOICES))
+    source_type = factory.Iterator(DataSources.values)
     options = factory.SubFactory(SourceOptions)
 
     class Meta:

--- a/quipucords/utils/__init__.py
+++ b/quipucords/utils/__init__.py
@@ -4,9 +4,8 @@ Common utils for quipucords.
 All utils should be imported here so the internal api for importing is just
 "from utils import some_util_func".
 """
-import json
 
 from .deepget import deepget
 from .default_getter import default_getter
 from .get_from_object_or_dict import get_from_object_or_dict
-from .misc import get_choice_ids, load_json_from_tarball
+from .misc import load_json_from_tarball

--- a/quipucords/utils/misc.py
+++ b/quipucords/utils/misc.py
@@ -2,11 +2,6 @@
 import json
 
 
-def get_choice_ids(choices):
-    """Retrieve choice ids."""
-    return [choice[0] for choice in choices]
-
-
 def load_json_from_tarball(json_filename, tarball):
     """Extract a json as dict from given TarFile interface."""
     return json.loads(tarball.extractfile(json_filename).read())


### PR DESCRIPTION
- Use the same constant for Credential type choices and Source type choices
- Add sanity check for scanner modules based on DataSource constants

These refactorings will help us maintain and add new scanners more easily.