### PR TITLE
chore: remove unneeded json.loads for search_directories

### DIFF
--- a/quipucords/api/scan/model.py
+++ b/quipucords/api/scan/model.py
@@ -2,7 +2,6 @@
 
 These models are used in the REST definitions.
 """
-import json
 import logging
 
 from django.db import models
@@ -45,9 +44,7 @@ class ExtendedProductSearchOptions(models.Model):
 
     def get_search_directories(self):
         """Load JSON search directory."""
-        if self.search_directories is not None:
-            return json.loads(self.search_directories)
-        return []
+        return self.search_directories or []
 
 
 class DisabledOptionalProductsOptions(models.Model):
@@ -179,7 +176,7 @@ class ScanOptions(models.Model):
 
             # Add search directories if it is not None, not empty
             if extended_search.search_directories is not None:
-                search_directories = json.loads(extended_search.search_directories)
+                search_directories = extended_search.search_directories
                 if search_directories and isinstance(search_directories, list):
                     search_directories = " ".join(search_directories)
                     extra_vars[self.EXT_PRODUCT_SEARCH_DIRS] = search_directories

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -1614,7 +1614,7 @@ class ScanJobTest(TestCase):
             jboss_fuse=True,
             jboss_brms=True,
             jboss_ws=True,
-            search_directories='["a", "b"]',
+            search_directories=["a", "b"],
         )
         extended.save()
         disabled = DisabledOptionalProductsOptions()


### PR DESCRIPTION
This was missed in earlier PR converting to JSONField, No need to do json.loads on search_directories.