### PR TITLE
refact: remove unneded too-few-public-methods directives.

### DIFF
--- a/quipucords/api/common/middleware.py
+++ b/quipucords/api/common/middleware.py
@@ -6,7 +6,6 @@ from quipucords.environment import server_version
 class ServerVersionMiddle:
     """Middleware class to flow server version to clients."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, get_response):
         """Initialize middleware class."""
         self.get_response = get_response

--- a/quipucords/api/common/report_json_gzip_renderer.py
+++ b/quipucords/api/common/report_json_gzip_renderer.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class ReportJsonGzipRenderer(renderers.BaseRenderer):
     """Class to render reports as tar.gz containing a json file."""
 
-    # pylint: disable=too-few-public-methods
     media_type = "application/json+gzip"
     format = "tar.gz"
     render_style = "binary"

--- a/quipucords/api/deployments_report/csv_renderer.py
+++ b/quipucords/api/deployments_report/csv_renderer.py
@@ -8,7 +8,6 @@ from api.deployments_report.util import create_deployments_csv
 class DeploymentCSVRenderer(renderers.BaseRenderer):
     """Class to render report as CSV."""
 
-    # pylint: disable=too-few-public-methods
     media_type = "text/csv"
     format = "csv"
 

--- a/quipucords/api/details_report/csv_renderer.py
+++ b/quipucords/api/details_report/csv_renderer.py
@@ -8,7 +8,6 @@ from api.details_report.util import create_details_csv
 class DetailsCSVRenderer(renderers.BaseRenderer):
     """Class to render report as CSV."""
 
-    # pylint: disable=too-few-public-methods
     media_type = "text/csv"
     format = "csv"
 

--- a/quipucords/api/details_report/tests_details_report.py
+++ b/quipucords/api/details_report/tests_details_report.py
@@ -19,7 +19,6 @@ from constants import DataSources
 class MockRequest:
     """Mock a request object for the renderer."""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, mask_rep=False):
         """Initialize a fake request object."""
         self.query_params = {"mask": mask_rep}

--- a/quipucords/api/insights_report/insights_gzip_renderer.py
+++ b/quipucords/api/insights_report/insights_gzip_renderer.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class InsightsGzipRenderer(renderers.BaseRenderer):
     """Class to render insights reports as tar.gz."""
 
-    # pylint: disable=too-few-public-methods
     media_type = "application/gzip"
     format = "tar.gz"
     render_style = "binary"

--- a/quipucords/api/reports/reports_gzip_renderer.py
+++ b/quipucords/api/reports/reports_gzip_renderer.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class ReportsGzipRenderer(renderers.BaseRenderer):
     """Class to render all reports as tar.gz."""
 
-    # pylint: disable=too-few-public-methods
     media_type = "application/gzip"
     format = "tar.gz"
     render_style = "binary"

--- a/quipucords/api/vault.py
+++ b/quipucords/api/vault.py
@@ -63,7 +63,6 @@ def write_to_yaml(data):
     return vault.dump_as_yaml_to_tempfile(data)
 
 
-# pylint: disable=too-few-public-methods
 class Vault:
     """Read and write data using the Ansible vault."""
 

--- a/quipucords/fingerprinter/task.py
+++ b/quipucords/fingerprinter/task.py
@@ -98,7 +98,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
     """
 
     # pylint: disable=too-many-locals
-    # pylint: disable=too-many-arguments,too-few-public-methods
+    # pylint: disable=too-many-arguments
 
     @staticmethod
     def format_certs(redhat_certs):

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -37,7 +37,6 @@ class InspectTaskRunner(ScanTaskRunner):
     failures (host/ip).
     """
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, scan_job, scan_task):
         """Set context for task execution.
 

--- a/quipucords/scanner/network/processing/brms.py
+++ b/quipucords/scanner/network/processing/brms.py
@@ -9,8 +9,6 @@ from scanner.network.processing import process
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 # All of the processors in this file (except for

--- a/quipucords/scanner/network/processing/cloud_provider.py
+++ b/quipucords/scanner/network/processing/cloud_provider.py
@@ -7,8 +7,6 @@ GOOGLE = "google"
 AZURE = "azure"
 ALIBABA = "alibaba"
 
-# pylint: disable=too-few-public-methods
-
 
 class ProcessDmiChassisAssetTag(process.Processor):
     """Process the dmi chassis asset tag."""

--- a/quipucords/scanner/network/processing/cpu.py
+++ b/quipucords/scanner/network/processing/cpu.py
@@ -8,8 +8,6 @@ from scanner.network.processing.util import get_line
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 

--- a/quipucords/scanner/network/processing/date.py
+++ b/quipucords/scanner/network/processing/date.py
@@ -7,8 +7,6 @@ from scanner.network.processing.util import get_line
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 

--- a/quipucords/scanner/network/processing/dmi.py
+++ b/quipucords/scanner/network/processing/dmi.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class ProcessDmiSystemUuid(process.Processor):
     """Process the dmi system uuid."""
 
-    # pylint: disable=too-few-public-methods
     KEY = "dmi_system_uuid"
 
     DEPS = ["internal_dmi_system_uuid"]

--- a/quipucords/scanner/network/processing/eap.py
+++ b/quipucords/scanner/network/processing/eap.py
@@ -7,8 +7,6 @@ from scanner.network.processing import process, util
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 FIND_WARNING = (

--- a/quipucords/scanner/network/processing/eap5.py
+++ b/quipucords/scanner/network/processing/eap5.py
@@ -7,8 +7,6 @@ from scanner.network.processing import util
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 
 class ProcessVersionTxt(util.StdoutSearchProcessor):
     """Process the output of 'cat .../version.txt'."""

--- a/quipucords/scanner/network/processing/fuse.py
+++ b/quipucords/scanner/network/processing/fuse.py
@@ -6,8 +6,6 @@ from scanner.network.processing import util
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 

--- a/quipucords/scanner/network/processing/ifconfig.py
+++ b/quipucords/scanner/network/processing/ifconfig.py
@@ -4,8 +4,6 @@ from scanner.network.processing import process
 
 INET_PREFIXES = ["inet addr:", "inet "]
 
-# pylint: disable=too-few-public-methods
-
 
 class ProcessIPAddresses(process.Processor):
     """Process the ip addresses from ifconfig."""

--- a/quipucords/scanner/network/processing/jws.py
+++ b/quipucords/scanner/network/processing/jws.py
@@ -3,7 +3,6 @@
 from scanner.network.processing import process
 
 
-# pylint: disable=too-few-public-methods
 class ProcessJWSInstalledWithRpm(process.Processor):
     """Process the results of 'yum grouplist jws3 jws3plus jws5...'."""
 
@@ -19,7 +18,6 @@ class ProcessJWSInstalledWithRpm(process.Processor):
         return False
 
 
-# pylint: disable=too-few-public-methods
 class ProcessHasJBossEULA(process.Processor):
     """Process result of $(ls $JWS_HOME/JBossEULA.txt)."""
 
@@ -32,7 +30,6 @@ class ProcessHasJBossEULA(process.Processor):
         return stdout == "true"
 
 
-# pylint: disable=too-few-public-methods
 class ProcessTomcatPartOfRedhatProduct(process.Processor):
     """Process output of search for redhat string in tomcat files."""
 
@@ -47,7 +44,6 @@ class ProcessTomcatPartOfRedhatProduct(process.Processor):
         return False
 
 
-# pylint: disable=too-few-public-methods
 class ProcessJWSHasCert(process.Processor):
     """Process output of 'ls /etc/pki/product/185.pem 2>/dev/null'."""
 

--- a/quipucords/scanner/network/processing/karaf.py
+++ b/quipucords/scanner/network/processing/karaf.py
@@ -6,8 +6,6 @@ from scanner.network.processing import process, util
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 FIND_WARNING = (

--- a/quipucords/scanner/network/processing/process.py
+++ b/quipucords/scanner/network/processing/process.py
@@ -172,7 +172,6 @@ class ProcessorMeta(abc.ABCMeta):
         super().__init__(name, bases, dct)
 
 
-# pylint: disable=too-few-public-methods
 class Processor(metaclass=ProcessorMeta):
     """A class to process the output of an Ansible task."""
 

--- a/quipucords/scanner/network/processing/redhat_packages.py
+++ b/quipucords/scanner/network/processing/redhat_packages.py
@@ -6,8 +6,6 @@ from scanner.network.processing import process
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 

--- a/quipucords/scanner/network/processing/subman.py
+++ b/quipucords/scanner/network/processing/subman.py
@@ -6,8 +6,6 @@ from scanner.network.processing import process
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 

--- a/quipucords/scanner/network/processing/system_purpose.py
+++ b/quipucords/scanner/network/processing/system_purpose.py
@@ -7,8 +7,6 @@ from scanner.network.processing import process
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 
 class ProcessSystemPurpose(process.Processor):
     """Process the system_purpose_json fact."""

--- a/quipucords/scanner/network/processing/test_process.py
+++ b/quipucords/scanner/network/processing/test_process.py
@@ -73,7 +73,6 @@ class TestIsAnsibleTaskResult(TestCase):
         )
 
 
-# pylint: disable=too-few-public-methods
 class MyProcessor(process.Processor):
     """Basic test processor."""
 
@@ -85,7 +84,6 @@ class MyProcessor(process.Processor):
         return 1
 
 
-# pylint: disable=too-few-public-methods
 class MyDependentProcessor(process.Processor):
     """Processor that depends on another key."""
 
@@ -98,7 +96,6 @@ class MyDependentProcessor(process.Processor):
         return 2
 
 
-# pylint: disable=too-few-public-methods
 class MyErroringProcessor(process.Processor):
     """Processor that has an internal error."""
 

--- a/quipucords/scanner/network/processing/user_data.py
+++ b/quipucords/scanner/network/processing/user_data.py
@@ -3,7 +3,6 @@
 from scanner.network.processing import process
 
 
-# pylint: disable=too-few-public-methods
 class ProcessSystemUserCount(process.Processor):
     """Process the system_user_count fact."""
 

--- a/quipucords/scanner/network/processing/util.py
+++ b/quipucords/scanner/network/processing/util.py
@@ -20,7 +20,6 @@ def get_line(lines, line_index=0):
     return process.NO_DATA
 
 
-# pylint: disable=too-few-public-methods
 class InitLineFinder(process.Processor):
     """Process the output of an init system.
 

--- a/quipucords/scanner/network/processing/virt.py
+++ b/quipucords/scanner/network/processing/virt.py
@@ -3,8 +3,6 @@
 from api.common.util import convert_to_int, is_int
 from scanner.network.processing import process
 
-# pylint: disable=too-few-public-methods
-
 VIRT_TYPE_VMWARE = "vmware"
 VIRT_TYPE_VIRTUALBOX = "virtualbox"
 VIRT_TYPE_VIRTUALPC = "virtualpc"

--- a/quipucords/scanner/network/processing/yum.py
+++ b/quipucords/scanner/network/processing/yum.py
@@ -6,8 +6,6 @@ from scanner.network.processing import process
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-# pylint: disable=too-few-public-methods
-
 # #### Processors ####
 
 

--- a/quipucords/scanner/vcenter/utils.py
+++ b/quipucords/scanner/vcenter/utils.py
@@ -84,7 +84,7 @@ def retrieve_properties(content, filter_spec_set, max_objects=None):
     return objects
 
 
-class HostRawFacts:  # pylint: disable=too-few-public-methods
+class HostRawFacts:
     """Constants of vcenter hosts raw facts."""
 
     CLUSTER = "host.cluster"
@@ -96,7 +96,7 @@ class HostRawFacts:  # pylint: disable=too-few-public-methods
     UUID = "host.uuid"
 
 
-class VcenterRawFacts:  # pylint: disable=too-few-public-methods
+class VcenterRawFacts:
     """Constants of vcenter raw facts."""
 
     CLUSTER = "vm.cluster"
@@ -119,7 +119,7 @@ class VcenterRawFacts:  # pylint: disable=too-few-public-methods
     UUID = "vm.uuid"
 
 
-class ClusterRawFacts:  # pylint: disable=too-few-public-methods
+class ClusterRawFacts:
     """Constants of vcenter cluster raw facts."""
 
     DATACENTER = "cluster.datacenter"


### PR DESCRIPTION
Remove the unneded pylint too-few-public-methods disable directives.

Slowly chipping away at the 460+ pylint disable directives. The too-few-public-methods pylint
disable directives are apparently no longer needed since we have the global exception 
here: https://github.com/quipucords/linting/blob/2c04ee8aa048d406990fd929bdf4d7d7d42ffc6b/base-flakeheaven.toml#L33