### PR TITLE
test: rewrite unittest-style asserts as pytest

### DIFF
--- a/quipucords/api/common/tests_common_util.py
+++ b/quipucords/api/common/tests_common_util.py
@@ -29,22 +29,22 @@ class CommonUtilTest(TestCase):
         """Test csv helper with empty values."""
         # Test Empty case
         value = self.csv_helper.serialize_value("header", {})
-        self.assertEqual("", value)
+        assert "" == value
         value = self.csv_helper.serialize_value("header", [])
-        self.assertEqual("", value)
+        assert "" == value
 
     def test_csv_serialize_dict_1_key(self):
         """Test csv helper with 1 key dict."""
         # Test flat 1 entry
         test_python = {"key": "value"}
         value = self.csv_helper.serialize_value("header", test_python)
-        self.assertEqual(value, "{key:value}")
+        assert value == "{key:value}"
 
     def test_csv_serialize_list_1_value(self):
         """Test csv helper with 1 item list."""
         test_python = ["value"]
         value = self.csv_helper.serialize_value("header", test_python)
-        self.assertEqual(value, "[value]")
+        assert value == "[value]"
 
     def test_csv_serialize_dict_2_keys(self):
         """Test csv helper with 2 key dict."""
@@ -53,13 +53,13 @@ class CommonUtilTest(TestCase):
         test_python["key1"] = "value1"
         test_python["key2"] = "value2"
         value = self.csv_helper.serialize_value("header", test_python)
-        self.assertEqual(value, "{key1:value1;key2:value2}")
+        assert value == "{key1:value1;key2:value2}"
 
     def test_csv_serialize_list_2_values(self):
         """Test csv helper with 2 item list."""
         test_python = ["value1", "value2"]
         value = self.csv_helper.serialize_value("header", test_python)
-        self.assertEqual(value, "[value1;value2]")
+        assert value == "[value1;value2]"
 
     def test_csv_serialize_dict_nested(self):
         """Test csv helper with dict containing nested list/dict."""
@@ -69,20 +69,20 @@ class CommonUtilTest(TestCase):
         test_python["dict"] = {"nkey": "nvalue"}
         test_python["list"] = ["a"]
         value = self.csv_helper.serialize_value("header", test_python)
-        self.assertEqual(value, "{key:value;dict:{nkey:nvalue};list:[a]}")
+        assert value == "{key:value;dict:{nkey:nvalue};list:[a]}"
 
     def test_csv_serialize_list_nested(self):
         """Test csv helper with list containing nested list/dict."""
         test_python = ["value", {"nkey": "nvalue"}, ["a"]]
         value = self.csv_helper.serialize_value("header", test_python)
-        self.assertEqual(value, "[value;{nkey:nvalue};[a]]")
+        assert value == "[value;{nkey:nvalue};[a]]"
 
     def test_csv_serialize_ansible_value(self):
         """Test csv helper with ansible dict."""
         # Test ansible error
         test_python = {"rc": 0}
         value = self.csv_helper.serialize_value("header", test_python)
-        self.assertEqual(value, CSVHelper.ANSIBLE_ERROR_MESSAGE)
+        assert value == CSVHelper.ANSIBLE_ERROR_MESSAGE
 
     def test_csv_generate_headers(self):
         """Test csv_generate_headers method."""
@@ -92,9 +92,9 @@ class CommonUtilTest(TestCase):
             {"header1": "value2", "header3": "value3"},
         ]
         headers = CSVHelper.generate_headers(fact_list)
-        self.assertEqual(3, len(headers))
+        assert 3 == len(headers)
         expected = set(["header1", "header2", "header3"])
-        self.assertSetEqual(expected, set(headers))
+        assert expected == set(headers)
 
     def test_create_tar_buffer(self):
         """Test create_tar_buffer method."""
@@ -108,16 +108,16 @@ class CommonUtilTest(TestCase):
             for file_name, data in files_data.items()
         }
         tar_buffer = create_tar_buffer(files_data_encoded)
-        self.assertIsInstance(tar_buffer, (io.BytesIO))
-        self.assertIn("getvalue", dir(tar_buffer))
+        assert isinstance(tar_buffer, io.BytesIO)
+        assert "getvalue" in dir(tar_buffer)
         with tarfile.open(fileobj=tar_buffer) as tar:
             files = tar.getmembers()
-            self.assertNotEqual(files, [])
-            self.assertEqual(2, len(files))
+            assert files != []
+            assert 2 == len(files)
             for file_obj in files:
                 file = tar.extractfile(file_obj)
                 extracted_content = json.loads(file.read().decode())
-                self.assertIn(extracted_content, files_data.values())
+                assert extracted_content in files_data.values()
 
     def test_bad_param_type_create_tar_buffer(self):
         """Test passing in a non-list into create_tar_buffer."""
@@ -126,13 +126,13 @@ class CommonUtilTest(TestCase):
             "{'id': 2, 'report': [{'key': 'value'}]}",
         ]
         tar_result = create_tar_buffer(json_list)
-        self.assertEqual(tar_result, None)
+        assert tar_result is None
 
     def test_bad_dict_contents_type_create_tar_buffer(self):
         """Test passing in a list of json into create_tar_buffer."""
         json0 = {"id.csv": 1, "report": [{"key.csv": "value"}]}
         tar_result = create_tar_buffer(json0)
-        self.assertEqual(tar_result, None)
+        assert tar_result is None
 
     def test_extract_tar_gz_content_good(self):
         """Test extracting files by passing a BytesIO object."""
@@ -146,24 +146,24 @@ class CommonUtilTest(TestCase):
             for file_name, data in files_data.items()
         }
         tar_buffer = create_tar_buffer(files_data_encoded)
-        self.assertIsInstance(tar_buffer, (io.BytesIO))
+        assert isinstance(tar_buffer, io.BytesIO)
         # bytesIO
         file_contents = extract_tar_gz(tar_buffer)
         for data in file_contents:
-            self.assertIn(data, files_data.values())
-        self.assertEqual(len(file_contents), len(files_data.values()))
+            assert data in files_data.values()
+        assert len(file_contents) == len(files_data.values())
         # hexstring
         file_contents = extract_tar_gz(tar_buffer.getvalue())
         for data in file_contents:
-            self.assertIn(data, files_data.values())
-        self.assertEqual(len(file_contents), len(files_data.values()))
+            assert data in files_data.values()
+        assert len(file_contents) == len(files_data.values())
 
     def test_extract_tar_gz_content_bad_param_type(self):
         """Test passing bad types as parameters."""
         bad_types = ["", 7, ["test"], {"key": "value"}]
         for bad_type in bad_types:
             file_contents = extract_tar_gz(bad_type)
-            self.assertEqual(file_contents, None)
+            assert file_contents is None
 
     def test_extract_tar_gz_empty_tar_gz(self):
         """Test trying to extract and empty tar.gz file."""
@@ -176,7 +176,7 @@ class CommonUtilTest(TestCase):
         tar_buffer.seek(0)
         # bytesIO
         file_contents = extract_tar_gz(tar_buffer)
-        self.assertEqual(file_contents, None)
+        assert file_contents is None
         # hexstring
         file_contents = extract_tar_gz(tar_buffer.getvalue())
-        self.assertEqual(file_contents, None)
+        assert file_contents is None

--- a/quipucords/api/credential/tests_credential.py
+++ b/quipucords/api/credential/tests_credential.py
@@ -84,8 +84,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
 
     def test_hostcred_create_double(self):
         """Create with duplicate name should fail."""
@@ -96,8 +96,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
 
         self.create_expect_400(data)
 
@@ -295,14 +295,14 @@ class CredentialTest(TestCase):
         json_resp = resp.json()
         assert json_resp.get("results") is not None
         results = json_resp.get("results")
-        self.assertEqual(len(results), 2)
+        assert len(results) == 2
 
         resp = self.client.get(url, {"cred_type": DataSources.VCENTER})
         assert resp.status_code == status.HTTP_200_OK
         json_resp = resp.json()
         assert json_resp.get("results") is not None
         results = json_resp.get("results")
-        self.assertEqual(len(results), 1)
+        assert len(results) == 1
 
     def test_hostcred_update_view(self):
         """Tests the update view set of the Credential API."""
@@ -387,10 +387,8 @@ class CredentialTest(TestCase):
         resp = self.client.delete(url, format="json")
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
         response_json = resp.json()
-        self.assertEqual(
-            response_json["detail"], messages.CRED_DELETE_NOT_VALID_W_SOURCES
-        )
-        self.assertEqual(response_json["sources"][0]["name"], "cred_source")
+        assert response_json["detail"] == messages.CRED_DELETE_NOT_VALID_W_SOURCES
+        assert response_json["sources"][0]["name"] == "cred_source"
 
     def test_vcentercred_create(self):
         """Ensure we can create a new vcenter credential."""
@@ -401,8 +399,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
 
     def test_vc_cred_create_double(self):
         """Vcenter cred with duplicate name should fail."""
@@ -413,8 +411,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
 
         self.create_expect_400(data)
 
@@ -469,10 +467,10 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
         self.update_credential(name="cred1", username="root")
-        self.assertEqual(Credential.objects.get().username, "root")
+        assert Credential.objects.get().username == "root"
 
     def test_hostcred_default_become_method(self):
         """Ensure we can set the default become_method via API."""
@@ -483,8 +481,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().become_method, "sudo")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().become_method == "sudo"
 
     def test_hostcred_set_become_method(self):
         """Ensure we can set the credentials become method."""
@@ -496,8 +494,8 @@ class CredentialTest(TestCase):
             "become_method": "doas",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().become_method, "doas")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().become_method == "doas"
 
     def test_hostcred_default_become_user(self):
         """Ensure we can set the default become_user via API."""
@@ -508,8 +506,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().become_user, "root")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().become_user == "root"
 
     def test_hostcred_set_become_user(self):
         """Ensure we can set the become user."""
@@ -522,8 +520,8 @@ class CredentialTest(TestCase):
             "become_user": "newuser",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().become_user, "newuser")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().become_user == "newuser"
 
     def test_hostcred_set_become_pass(self):
         """Ensure we can set the become password."""
@@ -536,9 +534,9 @@ class CredentialTest(TestCase):
             "become_password": "pass",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(
-            decrypt_data_as_unicode(Credential.objects.get().become_password), "pass"
+        assert Credential.objects.count() == 1
+        assert (
+            decrypt_data_as_unicode(Credential.objects.get().become_password) == "pass"
         )
 
     def test_vc_create_extra_keyfile_pass(self):
@@ -564,8 +562,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
 
     def test_sat_cred_create_double(self):
         """Satellite cred with duplicate name should fail."""
@@ -576,8 +574,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
 
         self.create_expect_400(data)
 
@@ -604,8 +602,8 @@ class CredentialTest(TestCase):
             "password": "pass1",
         }
         initial = self.create_expect_201(data)
-        self.assertEqual(Credential.objects.count(), 1)
-        self.assertEqual(Credential.objects.get().name, "cred1")
+        assert Credential.objects.count() == 1
+        assert Credential.objects.get().name == "cred1"
 
         update_data = {"name": "newName", "ssh_keyfile": "random_path"}
         url = reverse("cred-detail", args=(initial["id"],))

--- a/quipucords/api/deployments_report/tests_deployments_report.py
+++ b/quipucords/api/deployments_report/tests_deployments_report.py
@@ -59,7 +59,7 @@ class DeploymentReportTest(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     def create_details_report_expect_400(self, data):
@@ -68,7 +68,7 @@ class DeploymentReportTest(TestCase):
         if response.status_code != status.HTTP_400_BAD_REQUEST:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         return response.json()
 
     def generate_fingerprints(self, os_name="RHEL", os_versions=None):
@@ -127,12 +127,12 @@ class DeploymentReportTest(TestCase):
 
         # Query API
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         report = response.json()
-        self.assertIsInstance(report, dict)
-        self.assertEqual(
-            len(report["system_fingerprints"][0].keys()),
-            EXPECTED_NUMBER_OF_FINGERPRINTS,
+        assert isinstance(report, dict)
+        assert (
+            len(report["system_fingerprints"][0].keys())
+            == EXPECTED_NUMBER_OF_FINGERPRINTS
         )
 
     def test_get_deployments_report_masked(self):
@@ -141,18 +141,18 @@ class DeploymentReportTest(TestCase):
         # Query API
         self.generate_fingerprints()
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         report = response.json()
-        self.assertIsInstance(report, dict)
-        self.assertEqual(
-            len(report["system_fingerprints"][0].keys()),
-            EXPECTED_NUMBER_OF_FINGERPRINTS,
+        assert isinstance(report, dict)
+        assert (
+            len(report["system_fingerprints"][0].keys())
+            == EXPECTED_NUMBER_OF_FINGERPRINTS
         )
 
         # Check the masked values
         fingerprints = report.get("system_fingerprints")
         for source in fingerprints:
-            self.assertEqual(source.get("name"), str(hash("1.2.3.4")))
+            assert source.get("name") == str(hash("1.2.3.4"))
 
     def test_get_deployments_report_bad_param(self):
         """Test a bad query param returns a 400."""
@@ -160,7 +160,7 @@ class DeploymentReportTest(TestCase):
         # Query API
         self.generate_fingerprints()
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_get_deployments_report_404(self):
         """Fail to get a report for missing collection."""
@@ -171,7 +171,7 @@ class DeploymentReportTest(TestCase):
 
         # Query API
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_get_bad_deployment_report(self):
         """Test case where DetailsReport exists but no fingerprint."""
@@ -200,7 +200,7 @@ class DeploymentReportTest(TestCase):
 
         # Query API
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_424_FAILED_DEPENDENCY)
+        assert response.status_code == status.HTTP_424_FAILED_DEPENDENCY
 
     def test_get_details_report_bad_id(self):
         """Fail to get a report for missing collection."""
@@ -208,7 +208,7 @@ class DeploymentReportTest(TestCase):
 
         # Query API
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     ##############################################################
     # Test CSV Renderer
@@ -216,9 +216,7 @@ class DeploymentReportTest(TestCase):
 
     def test_sanitize_row(self):
         """Test sanitize_row function."""
-        self.assertEqual(
-            sanitize_row(["data", None, "data,data"]), ["data", None, "data;data"]
-        )
+        assert sanitize_row(["data", None, "data,data"]) == ["data", None, "data;data"]
 
     def test_csv_renderer(self):
         """Test DeploymentCSVRenderer."""
@@ -226,18 +224,18 @@ class DeploymentReportTest(TestCase):
         # Test no FC id
         test_json = {}
         value = renderer.render(test_json, renderer_context=self.mock_renderer_context)
-        self.assertIsNone(value)
+        assert value is None
 
         # Test doesn't exist
         test_json = {"id": 42}
         value = renderer.render(test_json, renderer_context=self.mock_renderer_context)
-        self.assertIsNone(value)
+        assert value is None
 
         # Create a system fingerprint via collection receiver
         self.generate_fingerprints(os_versions=["7.4", "7.4", "7.5"])
         url = "/api/v1/reports/1/deployments/"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         report = response.json()
 
         csv_result = renderer.render(
@@ -258,7 +256,7 @@ class DeploymentReportTest(TestCase):
         # test the masked deployments report
         url = "/api/v1/reports/1/deployments/?mask=True"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         report = response.json()
 
         new_mock_req = MockRequest(mask_rep=True)
@@ -287,18 +285,18 @@ class DeploymentReportTest(TestCase):
         # Test no FC id
         test_json = {}
         value = renderer.render(test_json)
-        self.assertIsNone(value)
+        assert value is None
 
         # Test doesn't exist
         test_json = {"id": 42}
         value = renderer.render(test_json)
-        self.assertIsNone(value)
+        assert value is None
 
         # Create a system fingerprint via collection receiver
         self.generate_fingerprints(os_versions=["7.4", "7.4", "7.5"])
         url = "/api/v1/reports/1/deployments/"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         report_dict = response.json()
 
         # Test that the data in the subfile equals the report_dict
@@ -307,4 +305,4 @@ class DeploymentReportTest(TestCase):
             json_file = tar.getmembers()[0]
             tar_info = tar.extractfile(json_file)
             tar_dict_data = json.loads(tar_info.read().decode())
-            self.assertEqual(tar_dict_data, report_dict)
+            assert tar_dict_data == report_dict

--- a/quipucords/api/deployments_report/tests_fingerprint_model.py
+++ b/quipucords/api/deployments_report/tests_fingerprint_model.py
@@ -31,7 +31,7 @@ class FingerprintModelTest(TestCase):
         is_valid = serializer.is_valid()
         if not is_valid:
             print(serializer.errors)
-        self.assertTrue(is_valid)
+        assert is_valid
         serializer.save()
 
     # pylint: disable=invalid-name
@@ -54,7 +54,7 @@ class FingerprintModelTest(TestCase):
         is_valid = serializer.is_valid()
         if not is_valid:
             print(serializer.errors)
-        self.assertTrue(is_valid)
+        assert is_valid
         serializer.save()
 
     def test_product_fingerprint(self):
@@ -71,7 +71,7 @@ class FingerprintModelTest(TestCase):
         is_valid = serializer.is_valid()
         if not is_valid:
             print(serializer.errors)
-        self.assertTrue(is_valid)
+        assert is_valid
         serializer.save()
 
     def test_entitlement_fingerprint(self):
@@ -92,5 +92,5 @@ class FingerprintModelTest(TestCase):
         is_valid = serializer.is_valid()
         if not is_valid:
             print(serializer.errors)
-        self.assertTrue(is_valid)
+        assert is_valid
         serializer.save()

--- a/quipucords/api/details_report/tests_details_report.py
+++ b/quipucords/api/details_report/tests_details_report.py
@@ -65,7 +65,7 @@ class DetailReportTest(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     def retrieve_expect_200(self, identifier, query_param=""):
@@ -76,7 +76,7 @@ class DetailReportTest(TestCase):
         if response.status_code != status.HTTP_200_OK:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         return response.json()
 
     def test_get_details_report_404(self):
@@ -85,7 +85,7 @@ class DetailReportTest(TestCase):
 
         # Query API
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     ##############################################################
     # Test details endpoint
@@ -108,7 +108,7 @@ class DetailReportTest(TestCase):
         response_json = self.create_expect_201(request_json)
         identifier = response_json["report_id"]
         response_json = self.retrieve_expect_200(identifier)
-        self.assertEqual(response_json["report_id"], identifier)
+        assert response_json["report_id"] == identifier
 
     def test_details_masked(self):
         """Get details report with masked values for a report via API."""
@@ -135,7 +135,7 @@ class DetailReportTest(TestCase):
         response_json = self.create_expect_201(request_json)
         identifier = response_json["report_id"]
         response_json = self.retrieve_expect_200(identifier, query_param="?mask=True")
-        self.assertEqual(response_json["report_id"], identifier)
+        assert response_json["report_id"] == identifier
         # assert the ips/macs/hostname is masked
         source_to_check = response_json.get("sources")[0]
         facts = source_to_check.get("facts")
@@ -147,12 +147,12 @@ class DetailReportTest(TestCase):
                 "vm.name": "-2457967226571033580",
             }
         ]
-        self.assertEqual(facts, expected_facts)
+        assert facts == expected_facts
         # test bad query param
         url = "/api/v1/reports/" + str(identifier) + "/details/?mask=foo"
         # Query API
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     ##############################################################
     # Test CSV Renderer
@@ -164,12 +164,12 @@ class DetailReportTest(TestCase):
         # Test no FC id
         test_json = {}
         value = renderer.render(test_json, renderer_context=self.mock_renderer_context)
-        self.assertIsNone(value)
+        assert value is None
 
         # Test doesn't exist
         test_json = {"id": 42}
         value = renderer.render(test_json, renderer_context=self.mock_renderer_context)
-        self.assertIsNone(value)
+        assert value is None
 
         request_json = {
             "report_type": "details",
@@ -207,7 +207,7 @@ class DetailReportTest(TestCase):
             "ip_addresses,mac_addresses,uname_hostname,vm.name\r\n"
             "[1.2.3.4],[1.2.3.5;2.4.5.6],foo,foo\r\n\r\n\r\n"
         )
-        self.assertEqual(csv_result, expected)
+        assert csv_result == expected
 
         # Test cached works too
         test_json = copy.deepcopy(response_json)
@@ -216,7 +216,7 @@ class DetailReportTest(TestCase):
             test_json, renderer_context=self.mock_renderer_context
         )
         # These would be different if not cached
-        self.assertEqual(csv_result, expected)
+        assert csv_result == expected
 
         # Clear cache
         details_report = DetailsReport.objects.get(report_id=response_json["report_id"])
@@ -247,14 +247,14 @@ class DetailReportTest(TestCase):
             "[-7334718598697473719],[-7048634151319043688;-3493454847440916718],"
             "-2457967226571033580,-2457967226571033580\r\n\r\n\r\n"
         )
-        self.assertEqual(csv_result, expected)
+        assert csv_result == expected
 
         # Test cached works too for hashed
         test_json = copy.deepcopy(response_json)
         test_json["sources"][0]["facts"] = []
         csv_result = renderer.render(test_json, renderer_context=new_renderer)
         # These would be different if not cached
-        self.assertEqual(csv_result, expected)
+        assert csv_result == expected
 
         # Clear cache
         details_report = DetailsReport.objects.get(report_id=response_json["report_id"])
@@ -277,7 +277,7 @@ class DetailReportTest(TestCase):
             f"1,details,{self.report_version},{test_json.get('report_platform_id')},"
             "0\r\n"
         )
-        self.assertEqual(csv_result, expected)
+        assert csv_result == expected
 
         # Clear cache
         details_report = DetailsReport.objects.get(id=response_json["report_id"])
@@ -295,7 +295,7 @@ class DetailReportTest(TestCase):
             f"1,details,{self.report_version},{test_json.get('report_platform_id')},"
             "0\r\n\r\n\r\n"
         )
-        self.assertEqual(csv_result, expected)
+        assert csv_result == expected
 
         # Clear cache
         details_report = DetailsReport.objects.get(report_id=response_json["report_id"])
@@ -317,7 +317,7 @@ class DetailReportTest(TestCase):
             f"{self.server_id},test_source,network\r\n"
             "Facts\r\n\r\n"
         )
-        self.assertEqual(csv_result, expected)
+        assert csv_result == expected
 
     ##############################################################
     # Test Json Gzip Render
@@ -328,7 +328,7 @@ class DetailReportTest(TestCase):
         # Test no FC id
         test_json = {}
         value = renderer.render(test_json)
-        self.assertIsNone(value)
+        assert value is None
 
         request_json = {
             "report_type": "details",
@@ -351,4 +351,4 @@ class DetailReportTest(TestCase):
             json_file = tar.getmembers()[0]
             tar_info = tar.extractfile(json_file)
             tar_dict_data = json.loads(tar_info.read().decode())
-            self.assertEqual(tar_dict_data, report_dict)
+            assert tar_dict_data == report_dict

--- a/quipucords/api/details_report/tests_sync_report_creation.py
+++ b/quipucords/api/details_report/tests_sync_report_creation.py
@@ -47,10 +47,10 @@ class DetailsReportTest(TestCase):
     def create_expect_400(self, data, expected_response=None):
         """We will do a lot of create tests that expect HTTP 400s."""
         response = self.create(data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_json = response.json()
         if expected_response:
-            self.assertEqual(response_json, expected_response)
+            assert response_json == expected_response
         return response_json
 
     def create_expect_201(self, data):
@@ -59,7 +59,7 @@ class DetailsReportTest(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     ################################################################
@@ -81,26 +81,26 @@ class DetailsReportTest(TestCase):
         }
 
         response_json = self.create_expect_201(request_json)
-        self.assertEqual(response_json["sources"], request_json["sources"])
-        self.assertEqual(DetailsReport.objects.count(), 1)
+        assert response_json["sources"] == request_json["sources"]
+        assert DetailsReport.objects.count() == 1
 
     def test_empty_request_body(self):
         """Test empty request body."""
         request_json = {}
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(response_json["report_type"], messages.FC_REQUIRED_ATTRIBUTE)
+        assert response_json["report_type"] == messages.FC_REQUIRED_ATTRIBUTE
 
     def test_missing_sources(self):
         """Test missing sources attribute."""
         request_json = {"report_type": "details"}
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(response_json["sources"], messages.FC_REQUIRED_ATTRIBUTE)
+        assert response_json["sources"] == messages.FC_REQUIRED_ATTRIBUTE
 
     def test_empty_sources(self):
         """Test empty sources attribute."""
         request_json = {"report_type": "details", "sources": []}
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(response_json["sources"], messages.FC_REQUIRED_ATTRIBUTE)
+        assert response_json["sources"] == messages.FC_REQUIRED_ATTRIBUTE
 
     def test_source_missing_report_version(self):
         """Test source missing report version."""
@@ -116,33 +116,33 @@ class DetailsReportTest(TestCase):
             ],
         }
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["report_version"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["report_version"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_missing_name(self):
         """Test source is missing source_name."""
         request_json = {"report_type": "details", "sources": [{"foo": "abc"}]}
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_name"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_name"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_empty_name(self):
         """Test source has empty source_name."""
         request_json = {"report_type": "details", "sources": [{"source_name": ""}]}
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_name"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_name"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_name_not_string(self):
@@ -159,11 +159,11 @@ class DetailsReportTest(TestCase):
             ],
         }
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_name"],
-            messages.FC_SOURCE_NAME_NOT_STR,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_name"]
+            == messages.FC_SOURCE_NAME_NOT_STR
         )
 
     def test_missing_source_type(self):
@@ -179,11 +179,11 @@ class DetailsReportTest(TestCase):
             ],
         }
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_type"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_type"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_empty_source_type(self):
@@ -200,11 +200,11 @@ class DetailsReportTest(TestCase):
             ],
         }
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_type"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_type"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_invalid_source_type(self):
@@ -221,14 +221,14 @@ class DetailsReportTest(TestCase):
             ],
         }
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
 
         valid_choices = ", ".join(DataSources.values)
 
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_type"],
-            messages.FC_MUST_BE_ONE_OF % valid_choices,
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_type"]
+            == messages.FC_MUST_BE_ONE_OF % valid_choices
         )
 
     def test_source_missing_facts(self):
@@ -245,11 +245,11 @@ class DetailsReportTest(TestCase):
             ],
         }
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["facts"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["facts"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_empty_facts(self):
@@ -266,9 +266,9 @@ class DetailsReportTest(TestCase):
             ],
         }
         response_json = self.create_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["facts"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["facts"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )

--- a/quipucords/api/merge_report/tests_async_merge_report.py
+++ b/quipucords/api/merge_report/tests_async_merge_report.py
@@ -55,7 +55,7 @@ class AsyncMergeReports(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     def merge_details_from_source_expect_400(self, data):
@@ -64,7 +64,7 @@ class AsyncMergeReports(TestCase):
         if response.status_code != status.HTTP_400_BAD_REQUEST:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         return response.json()
 
     ##############################################################
@@ -95,13 +95,13 @@ class AsyncMergeReports(TestCase):
             "status": "created",
             "status_message": "Job is created.",
         }
-        self.assertIn("id", response_json)
+        assert "id" in response_json
         job_id = response_json.pop("id")
-        self.assertEqual(response_json, expected)
+        assert response_json == expected
 
         url = f"/api/v1/reports/merge/jobs/{job_id}/"
         get_response = self.client.get(url)
-        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
+        assert get_response.status_code == status.HTTP_200_OK
 
     def test_404_if_not_fingerprint_job(self):
         """Test report job status only returns merge jobs."""
@@ -116,37 +116,37 @@ class AsyncMergeReports(TestCase):
 
         url = f"/api/v1/reports/merge/jobs/{scan_job.id}/"
         get_response = self.client.get(url)
-        self.assertEqual(get_response.status_code, status.HTTP_404_NOT_FOUND)
+        assert get_response.status_code == status.HTTP_404_NOT_FOUND
 
         scan_job.scan_type = ScanTask.SCAN_TYPE_FINGERPRINT
         scan_job.save()
         url = f"/api/v1/reports/merge/jobs/{scan_job.id}/"
         get_response = self.client.get(url)
-        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
+        assert get_response.status_code == status.HTTP_200_OK
 
     def test_create_report_merge_bad_url(self):
         """Create merge report job bad url."""
         url = "/api/v1/reports/merge/jobs/1/"
         get_response = self.client.post(url)
-        self.assertEqual(get_response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        assert get_response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     def test_empty_request_body(self):
         """Test empty request body."""
         request_json = {}
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(response_json["report_type"], messages.FC_REQUIRED_ATTRIBUTE)
+        assert response_json["report_type"] == messages.FC_REQUIRED_ATTRIBUTE
 
     def test_missing_sources(self):
         """Test missing sources attribute."""
         request_json = {"report_type": "details"}
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(response_json["sources"], messages.FC_REQUIRED_ATTRIBUTE)
+        assert response_json["sources"] == messages.FC_REQUIRED_ATTRIBUTE
 
     def test_empty_sources(self):
         """Test empty sources attribute."""
         request_json = {"report_type": "details", "sources": []}
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(response_json["sources"], messages.FC_REQUIRED_ATTRIBUTE)
+        assert response_json["sources"] == messages.FC_REQUIRED_ATTRIBUTE
 
     def test_source_missing_report_version(self):
         """Test source missing report version."""
@@ -163,33 +163,33 @@ class AsyncMergeReports(TestCase):
             ],
         }
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["report_version"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["report_version"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_missing_name(self):
         """Test source is missing source_name."""
         request_json = {"report_type": "details", "sources": [{"foo": "abc"}]}
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_name"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_name"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_empty_name(self):
         """Test source has empty source_name."""
         request_json = {"report_type": "details", "sources": [{"source_name": ""}]}
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_name"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_name"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_name_not_string(self):
@@ -206,11 +206,11 @@ class AsyncMergeReports(TestCase):
             ],
         }
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_name"],
-            messages.FC_SOURCE_NAME_NOT_STR,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_name"]
+            == messages.FC_SOURCE_NAME_NOT_STR
         )
 
     def test_missing_source_type(self):
@@ -226,11 +226,11 @@ class AsyncMergeReports(TestCase):
             ],
         }
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_type"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_type"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_empty_source_type(self):
@@ -247,11 +247,11 @@ class AsyncMergeReports(TestCase):
             ],
         }
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_type"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_type"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_invalid_source_type(self):
@@ -268,14 +268,14 @@ class AsyncMergeReports(TestCase):
             ],
         }
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
 
         valid_choices = ", ".join(DataSources.values)
 
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["source_type"],
-            messages.FC_MUST_BE_ONE_OF % valid_choices,
+        assert (
+            response_json["invalid_sources"][0]["errors"]["source_type"]
+            == messages.FC_MUST_BE_ONE_OF % valid_choices
         )
 
     def test_source_missing_facts(self):
@@ -292,11 +292,11 @@ class AsyncMergeReports(TestCase):
             ],
         }
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["facts"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["facts"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     def test_source_empty_facts(self):
@@ -314,11 +314,11 @@ class AsyncMergeReports(TestCase):
             ],
         }
         response_json = self.merge_details_from_source_expect_400(request_json)
-        self.assertEqual(len(response_json["valid_sources"]), 0)
-        self.assertEqual(len(response_json["invalid_sources"]), 1)
-        self.assertEqual(
-            response_json["invalid_sources"][0]["errors"]["facts"],
-            messages.FC_REQUIRED_ATTRIBUTE,
+        assert len(response_json["valid_sources"]) == 0
+        assert len(response_json["invalid_sources"]) == 1
+        assert (
+            response_json["invalid_sources"][0]["errors"]["facts"]
+            == messages.FC_REQUIRED_ATTRIBUTE
         )
 
     ##############################################################
@@ -335,7 +335,7 @@ class AsyncMergeReports(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     def merge_details_by_ids_expect_400(self, data):
@@ -344,7 +344,7 @@ class AsyncMergeReports(TestCase):
         if response.status_code != status.HTTP_400_BAD_REQUEST:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         return response.json()
 
     def test_sync_merge_empty_body(self):
@@ -352,51 +352,49 @@ class AsyncMergeReports(TestCase):
         # pylint: disable=no-member
         data = None
         json_response = self.merge_details_by_ids_expect_400(data)
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_REQUIRED]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_REQUIRED]}
 
     def test_by_id_merge_empty_dict(self):
         """Test report merge by id with empty dict."""
         # pylint: disable=no-member
         data = {}
         json_response = self.merge_details_by_ids_expect_400(data)
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_REQUIRED]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_REQUIRED]}
 
     def test_by_id_merge_jobs_not_list(self):
         """Test report merge by id with not list."""
         # pylint: disable=no-member
         data = {"reports": 5}
         json_response = self.merge_details_by_ids_expect_400(data)
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_NOT_LIST]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_LIST]}
 
     def test_by_id_merge_jobs_list_too_short(self):
         """Test report merge by id with list too short."""
         # pylint: disable=no-member
         data = {"reports": [5]}
         json_response = self.merge_details_by_ids_expect_400(data)
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_TOO_SHORT]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_TOO_SHORT]}
 
     def test_by_id_merge_jobs_list_contains_string(self):
         """Test report merge by id with containing str."""
         # pylint: disable=no-member
         data = {"reports": [5, "hello"]}
         json_response = self.merge_details_by_ids_expect_400(data)
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_NOT_INT]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_INT]}
 
     def test_by_id_merge_jobs_list_contains_duplicates(self):
         """Test report merge by id with containing duplicates."""
         # pylint: disable=no-member
         data = {"reports": [5, 5]}
         json_response = self.merge_details_by_ids_expect_400(data)
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_NOT_UNIQUE]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_UNIQUE]}
 
     def test_by_id_merge_jobs_list_contains_invalid_job_ids(self):
         """Test report merge by id with containing duplicates."""
         # pylint: disable=no-member
         data = {"reports": [5, 6]}
         json_response = self.merge_details_by_ids_expect_400(data)
-        self.assertEqual(
-            json_response, {"reports": [messages.REPORT_MERGE_NOT_FOUND % "5, 6"]}
-        )
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_FOUND % "5, 6"]}
 
     @patch("api.merge_report.view.start_scan", side_effect=dummy_start)
     def test_by_id_merge_jobs_success(self, mock_dummy_start):
@@ -426,7 +424,7 @@ class AsyncMergeReports(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print(response.json())
         response_json = response.json()
-        self.assertEqual(response_json["sources"], sources1)
+        assert response_json["sources"] == sources1
         report1_id = response_json["report_id"]
 
         request_json = {"report_type": "details", "sources": sources2}
@@ -434,7 +432,7 @@ class AsyncMergeReports(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print(response.json())
         response_json = response.json()
-        self.assertEqual(response_json["sources"], sources2)
+        assert response_json["sources"] == sources2
         report2_id = response_json["report_id"]
 
         data = {"reports": [report1_id, report2_id]}
@@ -446,4 +444,4 @@ class AsyncMergeReports(TestCase):
             "status_message": "Job is created.",
         }
 
-        self.assertEqual(json_response, expected)
+        assert json_response == expected

--- a/quipucords/api/merge_report/tests_sync_merge_report.py
+++ b/quipucords/api/merge_report/tests_sync_merge_report.py
@@ -49,7 +49,7 @@ class SyncMergeReports(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     ##############################################################
@@ -60,9 +60,9 @@ class SyncMergeReports(TestCase):
         # pylint: disable=no-member
         url = "/api/v1/reports/merge/"
         response = self.client.put(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_response = response.json()
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_REQUIRED]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_REQUIRED]}
 
     def test_sync_merge_empty_dict(self):
         """Test sync merge with empty dict."""
@@ -72,9 +72,9 @@ class SyncMergeReports(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_response = response.json()
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_REQUIRED]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_REQUIRED]}
 
     def test_sync_merge_jobs_not_list(self):
         """Test sync merge with not list."""
@@ -84,9 +84,9 @@ class SyncMergeReports(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_response = response.json()
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_NOT_LIST]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_LIST]}
 
     def test_sync_merge_jobs_list_too_short(self):
         """Test sync merge with list too short."""
@@ -96,9 +96,9 @@ class SyncMergeReports(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_response = response.json()
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_TOO_SHORT]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_TOO_SHORT]}
 
     def test_sync_merge_jobs_list_contains_string(self):
         """Test sync merge with containing str."""
@@ -108,9 +108,9 @@ class SyncMergeReports(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_response = response.json()
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_NOT_INT]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_INT]}
 
     def test_sync_merge_jobs_list_contains_duplicates(self):
         """Test sync merge with containing duplicates."""
@@ -120,9 +120,9 @@ class SyncMergeReports(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_response = response.json()
-        self.assertEqual(json_response, {"reports": [messages.REPORT_MERGE_NOT_UNIQUE]})
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_UNIQUE]}
 
     def test_sync_merge_jobs_list_contains_invalid_job_ids(self):
         """Test sync merge with containing duplicates."""
@@ -132,11 +132,9 @@ class SyncMergeReports(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_response = response.json()
-        self.assertEqual(
-            json_response, {"reports": [messages.REPORT_MERGE_NOT_FOUND % "5, 6"]}
-        )
+        assert json_response == {"reports": [messages.REPORT_MERGE_NOT_FOUND % "5, 6"]}
 
     def test_sync_merge_jobs_success(self):
         """Test sync merge jobs success."""
@@ -164,7 +162,7 @@ class SyncMergeReports(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print(response.json())
         response_json = response.json()
-        self.assertEqual(response_json["sources"], sources1)
+        assert response_json["sources"] == sources1
         report1_id = response_json["report_id"]
 
         request_json = {"report_type": "details", "sources": sources2}
@@ -172,7 +170,7 @@ class SyncMergeReports(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print(response.json())
         response_json = response.json()
-        self.assertEqual(response_json["sources"], sources2)
+        assert response_json["sources"] == sources2
         report2_id = response_json["report_id"]
 
         url = "/api/v1/reports/merge/"
@@ -182,7 +180,7 @@ class SyncMergeReports(TestCase):
         )
         if response.status_code != status.HTTP_201_CREATED:
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         json_response = response.json()
         expected = {
             "report_id": 3,
@@ -207,4 +205,4 @@ class SyncMergeReports(TestCase):
             ],
         }
 
-        self.assertEqual(json_response, expected)
+        assert json_response == expected

--- a/quipucords/api/reports/tests_reports.py
+++ b/quipucords/api/reports/tests_reports.py
@@ -62,7 +62,7 @@ class ReportsTest(TestCase):
         if response.status_code != status.HTTP_201_CREATED:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         details_json = response.json()
         self.details_json = details_json
         return details_json
@@ -123,7 +123,7 @@ class ReportsTest(TestCase):
         if response.status_code != status.HTTP_200_OK:
             print("Failure cause: ")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         return response.json()
 
     def create_reports_dict(self, query_params=""):
@@ -131,7 +131,7 @@ class ReportsTest(TestCase):
         url = "/api/v1/reports/1/deployments/" + query_params
         self.generate_fingerprints(os_versions=["7.4", "7.4", "7.5"])
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         report = response.json()
         self.deployments_json = report
         self.details_json = self.retrieve_expect_200_details(1, query_params)
@@ -174,11 +174,11 @@ class ReportsTest(TestCase):
         tar_gz_result = renderer.render(
             reports_dict, renderer_context=self.mock_renderer_context
         )
-        self.assertNotEqual(tar_gz_result, None)
+        assert tar_gz_result is not None
         tar = tarfile.open(fileobj=tar_gz_result)  # pylint: disable=consider-using-with
         files = tar.getmembers()
         filenames = tar.getnames()
-        self.assertEqual(len(files), 5)
+        assert len(files) == 5
         # tar.getnames() always returns same order as tar.getmembers()
         for idx, file in enumerate(files):
             file_contents = tar.extractfile(file).read().decode()
@@ -193,9 +193,9 @@ class ReportsTest(TestCase):
                 tar_json = json.loads(file_contents)
                 tar_json_type = tar_json.get("report_type")
                 if tar_json_type == "details":
-                    self.assertEqual(tar_json, self.details_json)
+                    assert tar_json == self.details_json
                 elif tar_json_type == "deployments":
-                    self.assertEqual(tar_json, self.deployments_json)
+                    assert tar_json == self.deployments_json
                 else:
                     sys.exit("Could not identify .json return")
 
@@ -231,11 +231,11 @@ class ReportsTest(TestCase):
         tar_gz_result = renderer.render(
             reports_dict, renderer_context=mock_renderer_context
         )
-        self.assertNotEqual(tar_gz_result, None)
+        assert tar_gz_result is not None
         tar = tarfile.open(fileobj=tar_gz_result)  # pylint: disable=consider-using-with
         files = tar.getmembers()
         filenames = tar.getnames()
-        self.assertEqual(len(files), 5)
+        assert len(files) == 5
         # tar.getnames() always returns same order as tar.getmembers()
         for idx, file in enumerate(files):
             file_contents = tar.extractfile(file).read().decode()
@@ -250,9 +250,9 @@ class ReportsTest(TestCase):
                 tar_json = json.loads(file_contents)
                 tar_json_type = tar_json.get("report_type")
                 if tar_json_type == "details":
-                    self.assertEqual(tar_json, self.details_json)
+                    assert tar_json == self.details_json
                 elif tar_json_type == "deployments":
-                    self.assertEqual(tar_json, self.deployments_json)
+                    assert tar_json == self.deployments_json
                 else:
                     sys.exit("Could not identify .json return")
 
@@ -266,7 +266,7 @@ class ReportsTest(TestCase):
             tar_gz_result = renderer.render(
                 reports_dict, renderer_context=mock_renderer_context
             )
-            self.assertEqual(tar_gz_result, None)
+            assert tar_gz_result is None
 
     def test_sha256sum(self):
         """Ensure SHA256SUM hashes are correct."""
@@ -277,7 +277,7 @@ class ReportsTest(TestCase):
         tar_gz_result = renderer.render(
             reports_dict, renderer_context=mock_renderer_context
         )
-        self.assertNotEqual(tar_gz_result, None)
+        assert tar_gz_result is not None
         tar = tarfile.open(fileobj=tar_gz_result)  # pylint: disable=consider-using-with
         files = tar.getmembers()
         # ignore folder name

--- a/quipucords/api/scan/tests_scan.py
+++ b/quipucords/api/scan/tests_scan.py
@@ -46,14 +46,14 @@ class ScanTest(TestCase):
     def create_expect_400(self, data, expected_response):
         """We will do a lot of create tests that expect HTTP 400s."""
         response = self.create(data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_json = response.json()
         if response.status_code != status.HTTP_400_BAD_REQUEST:
             print("Cause of failure: ")
             print(f"expected: {expected_response}")
             print(f"actual: {response_json}")
 
-        self.assertEqual(response_json, expected_response)
+        assert response_json == expected_response
 
     def create_expect_201(self, data):
         """Create a scan, return the response as a dict."""
@@ -63,7 +63,7 @@ class ScanTest(TestCase):
             print("Cause of failure: ")
             print(response_json)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response_json
 
     def test_successful_create(self):
@@ -74,7 +74,7 @@ class ScanTest(TestCase):
             "scan_type": ScanTask.SCAN_TYPE_CONNECT,
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
+        assert "id" in response
 
     def test_create_no_name(self):
         """A create request must have a name."""
@@ -162,9 +162,9 @@ class ScanTest(TestCase):
             },
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
-        self.assertIn("scan_type", response)
-        self.assertEqual(response["scan_type"], ScanTask.SCAN_TYPE_INSPECT)
+        assert "id" in response
+        assert "scan_type" in response
+        assert response["scan_type"] == ScanTask.SCAN_TYPE_INSPECT
 
     def test_create_invalid_source(self):
         """The Source name must valid."""
@@ -227,7 +227,7 @@ class ScanTest(TestCase):
 
         url = reverse("scan-list")
         response = self.client.get(url, {"scan_type": ScanTask.SCAN_TYPE_CONNECT})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         content = response.json()
         results1 = [
@@ -239,7 +239,7 @@ class ScanTest(TestCase):
             }
         ]
         expected = {"count": 1, "next": None, "previous": None, "results": results1}
-        self.assertEqual(content, expected)
+        assert content == expected
 
     def test_retrieve(self):
         """Get Scan details by primary key."""
@@ -252,19 +252,17 @@ class ScanTest(TestCase):
 
         url = reverse("scan-detail", args=(initial["id"],))
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("sources", response.json())
+        assert response.status_code == status.HTTP_200_OK
+        assert "sources" in response.json()
         sources = response.json()["sources"]
 
-        self.assertEqual(
-            sources, [{"id": 1, "name": "source1", "source_type": "network"}]
-        )
+        assert sources == [{"id": 1, "name": "source1", "source_type": "network"}]
 
     def test_retrieve_bad_id(self):
         """Get Scan details by bad primary key."""
         url = reverse("scan-detail", args=("string",))
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update(self):
         """Completely update a scan."""
@@ -301,11 +299,11 @@ class ScanTest(TestCase):
             url, json.dumps(data), content_type="application/json", format="json"
         )
         response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("scan_type"), ScanTask.SCAN_TYPE_INSPECT)
-        self.assertEqual(response_json.get("name"), "test2")
-        self.assertFalse(response_json.get("options").get("jboss_eap"))
-        self.assertEqual(response_json.get("sources"), [self.source2.id])
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("scan_type") == ScanTask.SCAN_TYPE_INSPECT
+        assert response_json.get("name") == "test2"
+        assert not response_json.get("options").get("jboss_eap")
+        assert response_json.get("sources") == [self.source2.id]
 
     def test_partial_update(self):
         """Test partial update a scan."""
@@ -330,8 +328,8 @@ class ScanTest(TestCase):
             url, json.dumps(data), content_type="application/json", format="json"
         )
         response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("scan_type"), ScanTask.SCAN_TYPE_INSPECT)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("scan_type") == ScanTask.SCAN_TYPE_INSPECT
         data = {
             "name": "test2",
             "options": {
@@ -347,9 +345,9 @@ class ScanTest(TestCase):
             url, json.dumps(data), content_type="application/json", format="json"
         )
         response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("name"), "test2")
-        self.assertFalse(response_json.get("options").get("jboss_eap"))
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("name") == "test2"
+        assert not response_json.get("options").get("jboss_eap")
 
     def test_partial_update_retains(self):
         """Test partial update retains unprovided info."""
@@ -374,8 +372,8 @@ class ScanTest(TestCase):
             url, json.dumps(data), content_type="application/json", format="json"
         )
         response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("scan_type"), ScanTask.SCAN_TYPE_INSPECT)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("scan_type") == ScanTask.SCAN_TYPE_INSPECT
         data = {
             "name": "test2",
             "options": {
@@ -409,9 +407,9 @@ class ScanTest(TestCase):
                 "search_directories": ["/foo/bar/"],
             },
         }
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("name"), "test2")
-        self.assertEqual(response_json.get("options"), options)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("name") == "test2"
+        assert response_json.get("options") == options
 
     def test_partial_update_sources(self):
         """Test partial update on sources."""
@@ -428,16 +426,16 @@ class ScanTest(TestCase):
             url, json.dumps(data), content_type="application/json", format="json"
         )
         response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("scan_type"), ScanTask.SCAN_TYPE_INSPECT)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("scan_type") == ScanTask.SCAN_TYPE_INSPECT
         data = {"name": "test2", "sources": [self.source2.id]}
         response = self.client.patch(
             url, json.dumps(data), content_type="application/json", format="json"
         )
         response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("name"), "test2")
-        self.assertEqual(response_json.get("sources"), [self.source2.id])
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("name") == "test2"
+        assert response_json.get("sources") == [self.source2.id]
 
     def test_partial_update_enabled(self):
         """Test partial update retains unprovided info."""
@@ -462,8 +460,8 @@ class ScanTest(TestCase):
             url, json.dumps(data), content_type="application/json", format="json"
         )
         response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("scan_type"), ScanTask.SCAN_TYPE_INSPECT)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("scan_type") == ScanTask.SCAN_TYPE_INSPECT
         data = {
             "name": "test2",
             "options": {
@@ -487,9 +485,9 @@ class ScanTest(TestCase):
                 "search_directories": ["/foo/bar/"],
             },
         }
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("name"), "test2")
-        self.assertEqual(response_json.get("options"), options)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("name") == "test2"
+        assert response_json.get("options") == options
 
     def test_partial_update_scan_type(self):
         """Test partial update retains unprovided info."""
@@ -533,10 +531,10 @@ class ScanTest(TestCase):
                 "search_directories": ["/foo/bar/"],
             },
         }
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("name"), "test2")
-        self.assertEqual(response_json.get("options"), options)
-        self.assertEqual(response_json.get("scan_type"), ScanTask.SCAN_TYPE_INSPECT)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("name") == "test2"
+        assert response_json.get("options") == options
+        assert response_json.get("scan_type") == ScanTask.SCAN_TYPE_INSPECT
         # test with max concurrency & scan type
         data = {
             "name": "test2",
@@ -557,10 +555,10 @@ class ScanTest(TestCase):
                 "search_directories": ["/foo/bar/"],
             },
         }
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json.get("name"), "test2")
-        self.assertEqual(response_json.get("options"), options)
-        self.assertEqual(response_json.get("scan_type"), ScanTask.SCAN_TYPE_CONNECT)
+        assert response.status_code == status.HTTP_200_OK
+        assert response_json.get("name") == "test2"
+        assert response_json.get("options") == options
+        assert response_json.get("scan_type") == ScanTask.SCAN_TYPE_CONNECT
 
     def test_expand_scan(self):
         """Test view expand_scan."""
@@ -576,16 +574,13 @@ class ScanTest(TestCase):
         json_scan = serializer.data
         json_scan = expand_scan(json_scan)
 
-        self.assertEqual(json_scan.get("sources").first().get("name"), "source1")
-        self.assertEqual(
-            json_scan.get("most_recent"),
-            {
-                "id": 1,
-                "scan_type": "inspect",
-                "status": "pending",
-                "status_details": {"job_status_message": "Job is pending."},
-            },
-        )
+        assert json_scan.get("sources").first().get("name") == "source1"
+        assert json_scan.get("most_recent") == {
+            "id": 1,
+            "scan_type": "inspect",
+            "status": "pending",
+            "status_details": {"job_status_message": "Job is pending."},
+        }
 
     def test_delete(self):
         """Delete a scan."""
@@ -606,7 +601,7 @@ class ScanTest(TestCase):
 
         url = reverse("scan-detail", args=(response["id"],))
         response = self.client.delete(url, format="json")
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
 
     def test_get_extra_vars_missing_options(self):
         """Tests the get_default_extra_vars."""
@@ -622,7 +617,7 @@ class ScanTest(TestCase):
             "jboss_brms_ext": False,
             "jboss_ws_ext": False,
         }
-        self.assertEqual(extra_vars, expected_vars)
+        assert extra_vars == expected_vars
 
 
 class TestScanList(TestCase):
@@ -704,12 +699,12 @@ class TestScanList(TestCase):
         """List all scan objects."""
         url = reverse("scan-list")
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), self.expected)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == self.expected
 
     def test_list_by_scanjob_end_time(self):
         """List all scan objects, ordered by ScanJob start time."""
         url = reverse("scan-list")
         response = self.client.get(url, {"ordering": "most_recent_scanjob__start_time"})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), self.expected)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == self.expected

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -55,16 +55,13 @@ class ScanTaskTest(TestCase):
         )
         serializer = ScanTaskSerializer(task)
         json_task = serializer.data
-        self.assertEqual(
-            {
-                "sequence_number": 0,
-                "source": 1,
-                "scan_type": ScanTask.SCAN_TYPE_CONNECT,
-                "status": "pending",
-                "status_message": messages.ST_STATUS_MSG_PENDING,
-            },
-            json_task,
-        )
+        assert {
+            "sequence_number": 0,
+            "source": 1,
+            "scan_type": ScanTask.SCAN_TYPE_CONNECT,
+            "status": "pending",
+            "status_message": messages.ST_STATUS_MSG_PENDING,
+        } == json_task
 
     def test_successful_start(self):
         """Create a scan task and start it."""
@@ -77,10 +74,10 @@ class ScanTaskTest(TestCase):
         start_time = datetime.utcnow()
         task.start()
         task.save()
-        self.assertEqual(messages.ST_STATUS_MSG_RUNNING, task.status_message)
-        self.assertEqual(task.status, ScanTask.RUNNING)
-        self.assertEqual(
-            start_time.replace(microsecond=0), task.start_time.replace(microsecond=0)
+        assert messages.ST_STATUS_MSG_RUNNING == task.status_message
+        assert task.status == ScanTask.RUNNING
+        assert start_time.replace(microsecond=0) == task.start_time.replace(
+            microsecond=0
         )
 
     def test_successful_restart(self):
@@ -93,8 +90,8 @@ class ScanTaskTest(TestCase):
         )
         task.restart()
         task.save()
-        self.assertEqual(messages.ST_STATUS_MSG_RESTARTED, task.status_message)
-        self.assertEqual(task.status, ScanTask.PENDING)
+        assert messages.ST_STATUS_MSG_RESTARTED == task.status_message
+        assert task.status == ScanTask.PENDING
 
     def test_successful_pause(self):
         """Create a scan task and pause it."""
@@ -106,8 +103,8 @@ class ScanTaskTest(TestCase):
         )
         task.pause()
         task.save()
-        self.assertEqual(messages.ST_STATUS_MSG_PAUSED, task.status_message)
-        self.assertEqual(task.status, ScanTask.PAUSED)
+        assert messages.ST_STATUS_MSG_PAUSED == task.status_message
+        assert task.status == ScanTask.PAUSED
 
     def test_successful_cancel(self):
         """Create a scan task and cancel it."""
@@ -120,11 +117,9 @@ class ScanTaskTest(TestCase):
         end_time = datetime.utcnow()
         task.cancel()
         task.save()
-        self.assertEqual(messages.ST_STATUS_MSG_CANCELED, task.status_message)
-        self.assertEqual(task.status, ScanTask.CANCELED)
-        self.assertEqual(
-            end_time.replace(microsecond=0), task.end_time.replace(microsecond=0)
-        )
+        assert messages.ST_STATUS_MSG_CANCELED == task.status_message
+        assert task.status == ScanTask.CANCELED
+        assert end_time.replace(microsecond=0) == task.end_time.replace(microsecond=0)
 
     def test_successful_complete(self):
         """Create a scan task and complete it."""
@@ -137,11 +132,9 @@ class ScanTaskTest(TestCase):
         end_time = datetime.utcnow()
         task.complete("great")
         task.save()
-        self.assertEqual("great", task.status_message)
-        self.assertEqual(task.status, ScanTask.COMPLETED)
-        self.assertEqual(
-            end_time.replace(microsecond=0), task.end_time.replace(microsecond=0)
-        )
+        assert "great" == task.status_message
+        assert task.status == ScanTask.COMPLETED
+        assert end_time.replace(microsecond=0) == task.end_time.replace(microsecond=0)
 
     def test_scantask_fail(self):
         """Create a scan task and fail it."""
@@ -156,11 +149,9 @@ class ScanTaskTest(TestCase):
         end_time = datetime.utcnow()
         task.fail(MSG)
         task.save()
-        self.assertEqual(MSG, task.status_message)
-        self.assertEqual(task.status, ScanTask.FAILED)
-        self.assertEqual(
-            end_time.replace(microsecond=0), task.end_time.replace(microsecond=0)
-        )
+        assert MSG == task.status_message
+        assert task.status == ScanTask.FAILED
+        assert end_time.replace(microsecond=0) == task.end_time.replace(microsecond=0)
 
     def test_scantask_increment(self):
         """Test scan task increment feature."""
@@ -179,10 +170,10 @@ class ScanTaskTest(TestCase):
             increment_sys_failed=True,
             increment_sys_unreachable=True,
         )
-        self.assertEqual(1, task.systems_count)
-        self.assertEqual(1, task.systems_scanned)
-        self.assertEqual(1, task.systems_failed)
-        self.assertEqual(1, task.systems_unreachable)
+        assert 1 == task.systems_count
+        assert 1 == task.systems_scanned
+        assert 1 == task.systems_failed
+        assert 1 == task.systems_unreachable
         task.increment_stats(
             "foo",
             increment_sys_count=True,
@@ -190,10 +181,10 @@ class ScanTaskTest(TestCase):
             increment_sys_failed=True,
             increment_sys_unreachable=True,
         )
-        self.assertEqual(2, task.systems_count)
-        self.assertEqual(2, task.systems_scanned)
-        self.assertEqual(2, task.systems_failed)
-        self.assertEqual(2, task.systems_unreachable)
+        assert 2 == task.systems_count
+        assert 2 == task.systems_scanned
+        assert 2 == task.systems_failed
+        assert 2 == task.systems_unreachable
 
     def test_scantask_reset_stats(self):
         """Test scan task reset stat feature."""
@@ -212,15 +203,15 @@ class ScanTaskTest(TestCase):
             increment_sys_failed=True,
             increment_sys_unreachable=True,
         )
-        self.assertEqual(1, task.systems_count)
-        self.assertEqual(1, task.systems_scanned)
-        self.assertEqual(1, task.systems_failed)
-        self.assertEqual(1, task.systems_unreachable)
+        assert 1 == task.systems_count
+        assert 1 == task.systems_scanned
+        assert 1 == task.systems_failed
+        assert 1 == task.systems_unreachable
         task.reset_stats()
-        self.assertEqual(None, task.systems_count)
-        self.assertEqual(None, task.systems_scanned)
-        self.assertEqual(None, task.systems_failed)
-        self.assertEqual(None, task.systems_unreachable)
+        assert None is task.systems_count
+        assert None is task.systems_scanned
+        assert None is task.systems_failed
+        assert None is task.systems_unreachable
 
         (
             systems_count,
@@ -229,10 +220,10 @@ class ScanTaskTest(TestCase):
             systems_unreachable,
         ) = task.calculate_counts()
 
-        self.assertEqual(systems_count, 0)
-        self.assertEqual(systems_scanned, 0)
-        self.assertEqual(systems_failed, 0)
-        self.assertEqual(systems_unreachable, 0)
+        assert systems_count == 0
+        assert systems_scanned == 0
+        assert systems_failed == 0
+        assert systems_unreachable == 0
 
     def test_calculate_counts(self):
         """Test calculate counts."""
@@ -257,7 +248,7 @@ class ScanTaskTest(TestCase):
             systems_failed,
             systems_unreachable,
         ) = task.calculate_counts()
-        self.assertEqual(systems_count, 1)
-        self.assertEqual(systems_scanned, 1)
-        self.assertEqual(systems_failed, 1)
-        self.assertEqual(systems_unreachable, 1)
+        assert systems_count == 1
+        assert systems_scanned == 1
+        assert systems_failed == 1
+        assert systems_unreachable == 1

--- a/quipucords/api/source/tests_source.py
+++ b/quipucords/api/source/tests_source.py
@@ -83,10 +83,10 @@ class SourceTest(TestCase):
     def create_expect_400(self, data, expected_response=None):
         """We will do a lot of create tests that expect HTTP 400s."""
         response = self.create(data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         if expected_response:
             response_json = response.json()
-            self.assertEqual(response_json, expected_response)
+            assert response_json == expected_response
 
     def create_expect_201(self, data):
         """Create a source, return the response as a dict."""
@@ -95,7 +95,7 @@ class SourceTest(TestCase):
             print("#" * 1200)
             print("Status code not 201.  See JSON response.")
             print(response.json())
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     # pylint: disable=unused-argument
@@ -115,17 +115,17 @@ class SourceTest(TestCase):
     def create_expect_201_with_query(self, query, data):
         """Create a valid source with a scan parameter."""
         response = self.create_with_query(query, data)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert response.status_code == status.HTTP_201_CREATED
         return response.json()
 
     # pylint: disable=no-value-for-parameter
     def create_expect_400_with_query(self, query, data, expected_response=None):
         """Create an expect HTTP 400."""
         response = self.create_with_query(query, data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         if expected_response:
             response_json = response.json()
-            self.assertEqual(response_json, expected_response)
+            assert response_json == expected_response
 
     #################################################
     # Function Tests
@@ -139,7 +139,7 @@ class SourceTest(TestCase):
 
         options = {}
         SourceSerializer.validate_opts(options, source_type)
-        self.assertEqual(options["ssl_cert_verify"], True)
+        assert options["ssl_cert_verify"] is True
 
         source_type = DataSources.VCENTER
         options = {"use_paramiko": True}
@@ -148,7 +148,7 @@ class SourceTest(TestCase):
 
         options = {}
         SourceSerializer.validate_opts(options, source_type)
-        self.assertEqual(options["ssl_cert_verify"], True)
+        assert options["ssl_cert_verify"] is True
 
         source_type = DataSources.NETWORK
         options = {"disable_ssl": True}
@@ -205,7 +205,7 @@ class SourceTest(TestCase):
                 "source_systems_unreachable": 0,
             },
         }
-        self.assertEqual(out, expected)
+        assert out == expected
 
     #################################################
     # Network Tests
@@ -225,7 +225,7 @@ class SourceTest(TestCase):
             "credentials": [self.net_cred_for_upload],
         }
         response = self.create_expect_201_with_query(query, data)
-        self.assertIn("id", response)
+        assert "id" in response
 
     def test_source_create_with_true_scan(self):
         """Test creating source with valid scan query param of True."""
@@ -261,7 +261,7 @@ class SourceTest(TestCase):
             "credentials": [self.net_cred_for_upload],
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
+        assert "id" in response
 
     def test_successful_net_create_no_port(self):
         """A valid create request should succeed without port."""
@@ -272,7 +272,7 @@ class SourceTest(TestCase):
             "credentials": [self.net_cred_for_upload],
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
+        assert "id" in response
 
     def test_double_create(self):
         """A duplicate create should fail."""
@@ -284,7 +284,7 @@ class SourceTest(TestCase):
             "credentials": [self.net_cred_for_upload],
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
+        assert "id" in response
         self.create_expect_400(data)
 
     def test_create_multiple_hosts(self):
@@ -496,8 +496,8 @@ class SourceTest(TestCase):
                 "credentials": [self.net_cred_for_upload],
             }
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(len(response.data["hosts"]), len(hosts))
+        assert response.status_code == 400
+        assert len(response.data["hosts"]) == len(hosts)
 
     def test_create_bad_host_pattern(self):
         """Test a invalid host pattern."""
@@ -512,8 +512,8 @@ class SourceTest(TestCase):
                 "credentials": [self.net_cred_for_upload],
             }
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(len(response.data["hosts"]), len(hosts))
+        assert response.status_code == 400
+        assert len(response.data["hosts"]) == len(hosts)
 
     def test_create_bad_port(self):
         """-1 is not a valid ssh port."""
@@ -614,7 +614,7 @@ class SourceTest(TestCase):
 
         url = reverse("source-list")
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         content = response.json()
         results1 = [
@@ -644,7 +644,7 @@ class SourceTest(TestCase):
             },
         ]
         expected = {"count": 3, "next": None, "previous": None, "results": results1}
-        self.assertEqual(content, expected)
+        assert content == expected
 
     def test_filter_by_type_list(self):
         """List all Source objects filtered by type."""
@@ -674,7 +674,7 @@ class SourceTest(TestCase):
 
         url = reverse("source-list")
         response = self.client.get(url, {"source_type": DataSources.VCENTER})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         content = response.json()
         results1 = [
@@ -702,7 +702,7 @@ class SourceTest(TestCase):
             },
         ]
         expected = {"count": 2, "next": None, "previous": None, "results": results1}
-        self.assertEqual(content, expected)
+        assert content == expected
 
     def test_retrieve(self):
         """Get details on a specific Source by primary key."""
@@ -719,21 +719,21 @@ class SourceTest(TestCase):
 
         url = reverse("source-detail", args=(initial["id"],))
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
-        self.assertIn("credentials", response_json)
+        assert "credentials" in response_json
         creds = response_json["credentials"]
 
-        self.assertEqual(creds, [self.net_cred_for_response])
-        self.assertIn("hosts", response_json)
-        self.assertEqual(response_json["hosts"][0], "1.2.3.4")
-        self.assertEqual(response_json["exclude_hosts"][0], "1.2.3.4")
+        assert creds == [self.net_cred_for_response]
+        assert "hosts" in response_json
+        assert response_json["hosts"][0] == "1.2.3.4"
+        assert response_json["exclude_hosts"][0] == "1.2.3.4"
 
     def test_retrieve_bad_id(self):
         """Get details on a specific Source by bad primary key."""
         url = reverse("source-detail", args=("string",))
         response = self.client.get(url, format="json")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # We don't have to test that update validates fields correctly
     # because the validation code is shared between create and update.
@@ -759,7 +759,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
         expected = {
             "name": "source2",
@@ -771,7 +771,7 @@ class SourceTest(TestCase):
         # data should be a strict subset of the response, because the
         # response adds an id field.
         for key, value in expected.items():
-            self.assertEqual(value, response.json()[key])
+            assert value == response.json()[key]
 
     def test_update_collide(self):
         """Fail update due to name conflict."""
@@ -805,7 +805,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_partial_update_missing_hosts(self):
         """Partial update should succeed with missing hosts."""
@@ -824,7 +824,7 @@ class SourceTest(TestCase):
         response = self.client.patch(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
     def test_partial_update_network_ssl_options_not_allowed(self):
         """Partial update should succeed with missing hosts."""
@@ -848,7 +848,7 @@ class SourceTest(TestCase):
         response = self.client.patch(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_partial_update_no_hosts_retains_initial_host(self):
         """Partial update should keep initial host if no host provided."""
@@ -868,7 +868,7 @@ class SourceTest(TestCase):
             url, json.dumps(data), content_type="application/json", format="json"
         )
         expected = ["1.2.3.4"]
-        self.assertEqual(response.data["hosts"], expected)
+        assert response.data["hosts"] == expected
 
     def test_partial_update_empty_hosts(self):
         """Partial update should succeed with missing hosts."""
@@ -892,7 +892,7 @@ class SourceTest(TestCase):
         response = self.client.patch(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_missing_hosts(self):
         """Fail update due to missing host array."""
@@ -911,7 +911,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_empty_hosts(self):
         """Fail update due to empty host array."""
@@ -935,9 +935,9 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_rsp = response.json()
-        self.assertEqual(json_rsp["hosts"][0], messages.SOURCE_HOSTS_CANNOT_BE_EMPTY)
+        assert json_rsp["hosts"][0] == messages.SOURCE_HOSTS_CANNOT_BE_EMPTY
 
     def test_update_type_passed(self):
         """Fail update due to type passed."""
@@ -962,7 +962,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_bad_cred_type(self):
         """Fail update due to bad cred type."""
@@ -987,7 +987,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_partial_update(self):
         """Partially update a Source."""
@@ -1006,9 +1006,9 @@ class SourceTest(TestCase):
         response = self.client.patch(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["name"], "source3-new")
-        self.assertEqual(response.json()["hosts"], ["1.2.3.5"])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["name"] == "source3-new"
+        assert response.json()["hosts"] == ["1.2.3.5"]
 
     def test_delete(self):
         """Delete a Source."""
@@ -1023,7 +1023,7 @@ class SourceTest(TestCase):
 
         url = reverse("source-detail", args=(response["id"],))
         response = self.client.delete(url, format="json")
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
 
     def test_delete_with_scans(self):
         """Delete a Source used by a scan."""
@@ -1044,12 +1044,10 @@ class SourceTest(TestCase):
 
         url = reverse("source-detail", args=(source.id,))
         response = self.client.delete(url, format="json")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_json = response.json()
-        self.assertEqual(
-            response_json["detail"], messages.SOURCE_DELETE_NOT_VALID_W_SCANS
-        )
-        self.assertEqual(response_json["scans"][0]["name"], "test_scan")
+        assert response_json["detail"] == messages.SOURCE_DELETE_NOT_VALID_W_SCANS
+        assert response_json["scans"][0]["name"] == "test_scan"
 
     #################################################
     # VCenter Tests
@@ -1063,7 +1061,7 @@ class SourceTest(TestCase):
             "credentials": [self.vc_cred_for_upload],
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
+        assert "id" in response
 
     def test_create_too_many_creds(self):
         """A vcenter source and have one credential."""
@@ -1153,7 +1151,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
     def test_update_vc_more_than_one_host(self):
         """VC - Fail more than one host."""
@@ -1177,7 +1175,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_vc_with_exclude_host(self):
         """VC - Fail when excluded hosts are provided."""
@@ -1202,7 +1200,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_vc_more_than_one_cred(self):
         """VC - Fail more than one cred."""
@@ -1226,7 +1224,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_vc_range_hosts(self):
         """Fail update due to empty host array."""
@@ -1250,9 +1248,9 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_rsp = response.json()
-        self.assertEqual(json_rsp["hosts"][0], messages.SOURCE_ONE_HOST)
+        assert json_rsp["hosts"][0] == messages.SOURCE_ONE_HOST
 
     def test_create_req_type(self):
         """A vcenter source must have an type."""
@@ -1276,7 +1274,7 @@ class SourceTest(TestCase):
             "credentials": [self.sat_cred_for_upload],
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
+        assert "id" in response
 
     def test_successful_sat_create_with_options(self):
         """A valid create request should succeed."""
@@ -1288,7 +1286,7 @@ class SourceTest(TestCase):
             "options": {"ssl_cert_verify": False},
         }
         response = self.create_expect_201(data)
-        self.assertIn("id", response)
+        assert "id" in response
 
     def test_sat_too_many_creds(self):
         """A sat source and have one credential."""
@@ -1378,7 +1376,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
 
     def test_update_sat_with_options(self):
         """Sat - Valid full update with options."""
@@ -1403,7 +1401,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK
         expected = {
             "id": 1,
             "name": "source",
@@ -1413,7 +1411,7 @@ class SourceTest(TestCase):
             "options": {"ssl_cert_verify": False},
             "credentials": [{"id": 3, "name": "sat_cred1"}],
         }
-        self.assertEqual(response.json(), expected)
+        assert response.json() == expected
 
     def test_update_sat_more_than_one_hosts(self):
         """Sat- Fail update due to multiple hosts."""
@@ -1437,7 +1435,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_sat_more_exclude_hosts(self):
         """Sat- Fail update due to including excluded hosts."""
@@ -1462,7 +1460,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_sat_more_than_one_cred(self):
         """Sat- Fail update due to multiple hosts."""
@@ -1486,7 +1484,7 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_sat_range_hosts(self):
         """Fail update due to invalid host array."""
@@ -1510,9 +1508,9 @@ class SourceTest(TestCase):
         response = self.client.put(
             url, json.dumps(data), content_type="application/json", format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         json_rsp = response.json()
-        self.assertEqual(json_rsp["hosts"][0], messages.SOURCE_ONE_HOST)
+        assert json_rsp["hosts"][0] == messages.SOURCE_ONE_HOST
 
     def test_openshift_source_create(self):
         """Ensure we can create a new openshift source."""

--- a/quipucords/api/status/tests_status.py
+++ b/quipucords/api/status/tests_status.py
@@ -13,7 +13,7 @@ class StatusTest(TestCase):
         """Test the status endpoint."""
         url = reverse("server-status")
         response = self.client.get(url)
-        self.assertTrue(response.has_header("X-Server-Version"))
-        self.assertEqual(response["X-Server-Version"], server_version())
+        assert response.has_header("X-Server-Version")
+        assert response["X-Server-Version"] == server_version()
         json_result = response.json()
-        self.assertEqual(json_result["api_version"], 1)
+        assert json_result["api_version"] == 1

--- a/quipucords/api/tests_vault.py
+++ b/quipucords/api/tests_vault.py
@@ -12,14 +12,14 @@ class VaultTest(TestCase):
     def test_encrypt_data_as_unicode(self):
         """Tests the encryption of sensitive data using SECRET_KEY."""
         value = vault.encrypt_data_as_unicode("encrypted data")
-        self.assertTrue(isinstance(value, str))
+        assert isinstance(value, str)
 
     def test_decrypt_data(self):
         """Test the decryption of data using SECRET_KEY."""
         raw = "encrypted data"
         encrypted = vault.encrypt_data_as_unicode(raw)
         decrypted = vault.decrypt_data_as_unicode(encrypted)
-        self.assertEqual(raw, decrypted)
+        assert raw == decrypted
 
     def test_dump_yaml(self):
         """Test the writing of dictionary data to a yaml file encrypted."""
@@ -34,10 +34,10 @@ class VaultTest(TestCase):
             }
         }
         temp_yaml = vault.write_to_yaml(data)
-        self.assertTrue("yaml" in temp_yaml)
+        assert "yaml" in temp_yaml
 
         with open(temp_yaml, "r", encoding="utf-8") as temp_file:
             encrypted = temp_file.read()
             decrypted = vault.decrypt_data_as_unicode(encrypted)
             obj = yaml.load(decrypted, Loader=yaml.SafeLoader)
-            self.assertEqual(obj, data)
+            assert obj == data

--- a/quipucords/api/user/tests_user.py
+++ b/quipucords/api/user/tests_user.py
@@ -25,4 +25,4 @@ class UserTest(TestCase):
         force_authenticate(request, user=self.user)
         user_current = UserViewSet.as_view({"get": "current"})
         response = user_current(request)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.status_code == status.HTTP_200_OK

--- a/quipucords/fingerprinter/tests_fingerprint_task.py
+++ b/quipucords/fingerprinter/tests_fingerprint_task.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import patch
 
+import pytest
 from django.db import DataError
 from django.test import TestCase
 
@@ -395,140 +396,112 @@ class EngineTest(TestCase):
 
     def _validate_network_result(self, fingerprint, fact):
         """Help to validate fields."""
-        self.assertEqual(fact.get("connection_host"), fingerprint.get("name"))
+        assert fact.get("connection_host") == fingerprint.get("name")
 
-        self.assertEqual(fact.get("etc_release_name"), fingerprint.get("os_name"))
-        self.assertEqual(fact.get("etc_release_release"), fingerprint.get("os_release"))
-        self.assertEqual(fact.get("etc_release_version"), fingerprint.get("os_version"))
+        assert fact.get("etc_release_name") == fingerprint.get("os_name")
+        assert fact.get("etc_release_release") == fingerprint.get("os_release")
+        assert fact.get("etc_release_version") == fingerprint.get("os_version")
 
-        self.assertListEqual(
-            fact.get("ifconfig_ip_addresses"), fingerprint.get("ip_addresses")
-        )
-        self.assertListEqual(
-            fact.get("ifconfig_mac_addresses"), fingerprint.get("mac_addresses")
-        )
+        assert fact.get("ifconfig_ip_addresses") == fingerprint.get("ip_addresses")
+        assert fact.get("ifconfig_mac_addresses") == fingerprint.get("mac_addresses")
 
-        self.assertEqual(fact.get("cpu_count"), fingerprint.get("cpu_count"))
+        assert fact.get("cpu_count") == fingerprint.get("cpu_count")
 
-        self.assertEqual(fact.get("dmi_system_uuid"), fingerprint.get("bios_uuid"))
-        self.assertEqual(
-            fact.get("subscription_manager_id"),
-            fingerprint.get("subscription_manager_id"),
+        assert fact.get("dmi_system_uuid") == fingerprint.get("bios_uuid")
+        assert fact.get("subscription_manager_id") == fingerprint.get(
+            "subscription_manager_id"
         )
 
-        self.assertEqual(
-            fact.get("cpu_socket_count"), fingerprint.get("cpu_socket_count")
-        )
-        self.assertEqual(fact.get("cpu_core_count"), fingerprint.get("cpu_core_count"))
+        assert fact.get("cpu_socket_count") == fingerprint.get("cpu_socket_count")
+        assert fact.get("cpu_core_count") == fingerprint.get("cpu_core_count")
 
-        self.assertEqual(
-            fact.get("date_anaconda_log"), fingerprint.get("date_anaconda_log")
+        assert fact.get("date_anaconda_log") == fingerprint.get("date_anaconda_log")
+        assert fact.get("date_yum_history") == fingerprint.get("date_yum_history")
+        assert fact.get("date_machine_id") == fingerprint.get("date_machine_id")
+        assert fact.get("date_filesystem_create") == fingerprint.get(
+            "date_filesystem_create"
         )
-        self.assertEqual(
-            fact.get("date_yum_history"), fingerprint.get("date_yum_history")
-        )
-        self.assertEqual(
-            fact.get("date_machine_id"), fingerprint.get("date_machine_id")
-        )
-        self.assertEqual(
-            fact.get("date_filesystem_create"),
-            fingerprint.get("date_filesystem_create"),
-        )
-        self.assertEqual("virtualized", fingerprint.get("infrastructure_type"))
+        assert "virtualized" == fingerprint.get("infrastructure_type")
 
-        self.assertEqual(fact.get("virt_type"), fingerprint.get("virtualized_type"))
-        self.assertEqual(fact.get("uname_processor"), fingerprint.get("architecture"))
-        self.assertEqual(
-            fact.get("redhat_packages_certs"), fingerprint.get("redhat_certs")
-        )
-        self.assertEqual(
-            fact.get("redhat_packages_gpg_is_redhat"), fingerprint.get("is_redhat")
-        )
-        self.assertEqual(
-            fact.get("redhat_packages_gpg_num_rh_packages"),
-            fingerprint.get("redhat_package_count"),
+        assert fact.get("virt_type") == fingerprint.get("virtualized_type")
+        assert fact.get("uname_processor") == fingerprint.get("architecture")
+        assert fact.get("redhat_packages_certs") == fingerprint.get("redhat_certs")
+        assert fact.get("redhat_packages_gpg_is_redhat") == fingerprint.get("is_redhat")
+        assert fact.get("redhat_packages_gpg_num_rh_packages") == fingerprint.get(
+            "redhat_package_count"
         )
         system_purpose_json = fact.get("system_purpose_json", None)
         if system_purpose_json:
-            self.assertEqual(system_purpose_json, fingerprint.get("system_purpose"))
-            self.assertEqual(
-                system_purpose_json.get("role", None), fingerprint.get("system_role")
+            assert system_purpose_json == fingerprint.get("system_purpose")
+            assert system_purpose_json.get("role", None) == fingerprint.get(
+                "system_role"
             )
-            self.assertEqual(
-                system_purpose_json.get("addons", None),
-                fingerprint.get("system_addons"),
+            assert system_purpose_json.get("addons", None) == fingerprint.get(
+                "system_addons"
             )
-            self.assertEqual(
-                system_purpose_json.get("service_level_agreement", None),
-                fingerprint.get("system_service_level_agreement"),
-            )
-            self.assertEqual(
-                system_purpose_json.get("usage", None),
-                fingerprint.get("system_usage_type"),
+            assert system_purpose_json.get(
+                "service_level_agreement", None
+            ) == fingerprint.get("system_service_level_agreement")
+            assert system_purpose_json.get("usage", None) == fingerprint.get(
+                "system_usage_type"
             )
         else:
-            self.assertIsNone(fingerprint.get("system_role"))
-            self.assertIsNone(fingerprint.get("system_addons"))
-            self.assertIsNone(fingerprint.get("system_service_level_agreement"))
-            self.assertIsNone(fingerprint.get("system_usage_type"))
+            assert fingerprint.get("system_role") is None
+            assert fingerprint.get("system_addons") is None
+            assert fingerprint.get("system_service_level_agreement") is None
+            assert fingerprint.get("system_usage_type") is None
 
     def _validate_vcenter_result(self, fingerprint, fact):
         """Help to validate fields."""
         if fact.get("vm.dns_name"):
-            self.assertEqual(fact.get("vm.dns_name"), fingerprint.get("name"))
+            assert fact.get("vm.dns_name") == fingerprint.get("name")
         else:
-            self.assertEqual(fact.get("vm.name"), fingerprint.get("name"))
+            assert fact.get("vm.name") == fingerprint.get("name")
 
-        self.assertEqual(fact.get("vm.os"), fingerprint.get("os_release"))
+        assert fact.get("vm.os") == fingerprint.get("os_release")
 
-        self.assertEqual(fact.get("vm.ip_addresses"), fingerprint.get("ip_addresses"))
-        self.assertEqual(fact.get("vm.mac_addresses"), fingerprint.get("mac_addresses"))
-        self.assertEqual(fact.get("vm.cpu_count"), fingerprint.get("cpu_count"))
+        assert fact.get("vm.ip_addresses") == fingerprint.get("ip_addresses")
+        assert fact.get("vm.mac_addresses") == fingerprint.get("mac_addresses")
+        assert fact.get("vm.cpu_count") == fingerprint.get("cpu_count")
 
-        self.assertEqual(fact.get("vm.state"), fingerprint.get("vm_state"))
+        assert fact.get("vm.state") == fingerprint.get("vm_state")
 
-        self.assertEqual(fact.get("vm.uuid"), fingerprint.get("vm_uuid"))
+        assert fact.get("vm.uuid") == fingerprint.get("vm_uuid")
 
-        self.assertEqual(fact.get("vm.dns_name"), fingerprint.get("vm_dns_name"))
-        self.assertEqual(fact.get("vm.host.name"), fingerprint.get("virtual_host_name"))
+        assert fact.get("vm.dns_name") == fingerprint.get("vm_dns_name")
+        assert fact.get("vm.host.name") == fingerprint.get("virtual_host_name")
 
-        self.assertEqual(
-            fact.get("vm.host.cpu_count"), fingerprint.get("vm_host_socket_count")
-        )
-        self.assertEqual(
-            fact.get("vm.host.cpu_cores"), fingerprint.get("vm_host_core_count")
-        )
-        self.assertEqual(fact.get("vm.datacenter"), fingerprint.get("vm_datacenter"))
-        self.assertEqual(fact.get("vm.cluster"), fingerprint.get("vm_cluster"))
-        self.assertEqual(fact.get("uname_processor"), fingerprint.get("architecture"))
-        self.assertEqual(fact.get("is_redhat"), fingerprint.get("is_redhat"))
+        assert fact.get("vm.host.cpu_count") == fingerprint.get("vm_host_socket_count")
+        assert fact.get("vm.host.cpu_cores") == fingerprint.get("vm_host_core_count")
+        assert fact.get("vm.datacenter") == fingerprint.get("vm_datacenter")
+        assert fact.get("vm.cluster") == fingerprint.get("vm_cluster")
+        assert fact.get("uname_processor") == fingerprint.get("architecture")
+        assert fact.get("is_redhat") == fingerprint.get("is_redhat")
 
     def _validate_satellite_result(self, fingerprint, fact):
         """Help to validate fields."""
-        self.assertEqual(fact.get("hostname"), fingerprint.get("name"))
+        assert fact.get("hostname") == fingerprint.get("name")
 
-        self.assertEqual(fact.get("os_name"), fingerprint.get("os_name"))
-        self.assertEqual(fact.get("os_release"), fingerprint.get("os_release"))
-        self.assertEqual(fact.get("os_version"), fingerprint.get("os_version"))
+        assert fact.get("os_name") == fingerprint.get("os_name")
+        assert fact.get("os_release") == fingerprint.get("os_release")
+        assert fact.get("os_version") == fingerprint.get("os_version")
 
-        self.assertEqual(fact.get("cores"), fingerprint.get("cpu_count"))
-        self.assertEqual(fact.get("ip_addresses"), fingerprint.get("ip_addresses"))
-        self.assertEqual(fact.get("mac_addresses"), fingerprint.get("mac_addresses"))
-        self.assertEqual(
-            fact.get("registration_time"), fingerprint.get("registration_time")
-        )
-        self.assertEqual(fact.get("uuid"), fingerprint.get("subscription_manager_id"))
+        assert fact.get("cores") == fingerprint.get("cpu_count")
+        assert fact.get("ip_addresses") == fingerprint.get("ip_addresses")
+        assert fact.get("mac_addresses") == fingerprint.get("mac_addresses")
+        assert fact.get("registration_time") == fingerprint.get("registration_time")
+        assert fact.get("uuid") == fingerprint.get("subscription_manager_id")
         if fact.get("hostname", "").endswith(
             tuple("-" + str(num) for num in range(1, 10))
         ) and fact.get("hostname").startswith("virt-who-"):
-            self.assertEqual("hypervisor", fingerprint.get("infrastructure_type"))
+            assert "hypervisor" == fingerprint.get("infrastructure_type")
         else:
-            self.assertEqual("virtualized", fingerprint.get("infrastructure_type"))
+            assert "virtualized" == fingerprint.get("infrastructure_type")
 
-        self.assertEqual(fact.get("cores"), fingerprint.get("cpu_core_count"))
-        self.assertEqual(fact.get("num_sockets"), fingerprint.get("cpu_socket_count"))
-        self.assertEqual(fact.get("architecture"), fingerprint.get("architecture"))
-        self.assertEqual(fact.get("is_redhat"), fingerprint.get("is_redhat"))
+        assert fact.get("cores") == fingerprint.get("cpu_core_count")
+        assert fact.get("num_sockets") == fingerprint.get("cpu_socket_count")
+        assert fact.get("architecture") == fingerprint.get("architecture")
+        assert fact.get("is_redhat") == fingerprint.get("is_redhat")
 
     def _create_network_fingerprint(self, *args, **kwargs):
         """Create test network fingerprint."""
@@ -746,7 +719,7 @@ class EngineTest(TestCase):
         n_cpu_count = nfingerprints[0]["cpu_count"]
         v_cpu_count = vfingerprints[0]["cpu_count"]
         v_name = vfingerprints[0]["name"]
-        self.assertNotEqual(n_cpu_count, v_cpu_count)
+        assert n_cpu_count != v_cpu_count
 
         reverse_priority_keys = {"cpu_count"}
         (
@@ -758,13 +731,13 @@ class EngineTest(TestCase):
             vfingerprints,
             reverse_priority_keys=reverse_priority_keys,
         )
-        self.assertEqual(len(result_fingerprints), 3)
+        assert len(result_fingerprints) == 3
 
         for result_fingerprint in result_fingerprints:
             if result_fingerprint.get("vm_uuid") == "match":
-                self.assertEqual(result_fingerprint.get("cpu_count"), v_cpu_count)
-                self.assertNotEqual(result_fingerprint.get("cpu_count"), n_cpu_count)
-                self.assertNotEqual(result_fingerprint.get("name"), v_name)
+                assert result_fingerprint.get("cpu_count") == v_cpu_count
+                assert result_fingerprint.get("cpu_count") != n_cpu_count
+                assert result_fingerprint.get("name") != v_name
 
     def test_merge_network_and_vcenter_infrastructure_type(self):
         """Test if VCenter infrastructure_type is prefered over network."""
@@ -777,9 +750,9 @@ class EngineTest(TestCase):
         # change infrastructure_type to bypass the validation
         nfingerprints[0]["infrastructure_type"] = "unknown"
         vfingerprints[0]["infrastructure_type"] = "virtualized"
-        self.assertNotEqual(
-            nfingerprints[0]["infrastructure_type"],
-            vfingerprints[0]["infrastructure_type"],
+        assert (
+            nfingerprints[0]["infrastructure_type"]
+            != vfingerprints[0]["infrastructure_type"]
         )
 
         reverse_priority_keys = {"cpu_count", "infrastructure_type"}
@@ -794,32 +767,30 @@ class EngineTest(TestCase):
         )
         for result_fingerprint in result_fingerprints:
             if result_fingerprint.get("vm_uuid") == "match":
-                self.assertEqual(
-                    result_fingerprint.get("infrastructure_type"), "virtualized"
-                )
+                assert result_fingerprint.get("infrastructure_type") == "virtualized"
 
     def test_merge_mac_address_case_insensitive(self):
         """Test if fingerprints will be merged with mixed mac addr."""
         n_mac = ["00:50:56:A3:A2:E8", "00:50:56:c3:d2:m8"]
         v_mac = ["00:50:56:a3:a2:e8", "00:50:56:C3:D2:m8"]
         s_mac = ["00:50:56:A3:a2:E8", "00:50:56:C3:D2:M8"]
-        self.assertNotEqual(v_mac, n_mac)
-        self.assertNotEqual(v_mac, s_mac)
+        assert v_mac != n_mac
+        assert v_mac != s_mac
         nfingerprints = [self._create_network_fingerprint(ifconfig_mac_addresses=n_mac)]
         vfingerprints = [self._create_vcenter_fingerprint(vm_mac_addresses=v_mac)]
         sfingerprints = [self._create_satellite_fingerprint(mac_addresses=s_mac)]
         v_mac_addresses = vfingerprints[0]["mac_addresses"]
         n_mac_addresses = nfingerprints[0]["mac_addresses"]
         s_mac_addresses = sfingerprints[0]["mac_addresses"]
-        self.assertEqual(v_mac_addresses, n_mac_addresses)
-        self.assertEqual(v_mac_addresses, s_mac_addresses)
+        assert v_mac_addresses == n_mac_addresses
+        assert v_mac_addresses == s_mac_addresses
         (
             _,
             result_fingerprints,
         ) = self.fp_task_runner._merge_fingerprints_from_source_types(
             NETWORK_SATELLITE_MERGE_KEYS, nfingerprints, sfingerprints
         )
-        self.assertEqual(len(result_fingerprints), 1)
+        assert len(result_fingerprints) == 1
         reverse_priority_keys = {"cpu_count", "infrastructure_type"}
         (
             _,
@@ -830,7 +801,7 @@ class EngineTest(TestCase):
             vfingerprints,
             reverse_priority_keys=reverse_priority_keys,
         )
-        self.assertEqual(len(result_fingerprints), 1)
+        assert len(result_fingerprints) == 1
 
     def test_merge_net_sate_vcenter_infrastructure_type(self):
         """Test if VCenter infrastructure_type is prefered over the others."""
@@ -853,7 +824,7 @@ class EngineTest(TestCase):
         )
         for result_fingerprint in result_fingerprints:
             if result_fingerprint.get("vm_uuid") == "match":
-                self.assertEqual(result_fingerprint.get("infrastructure_type"), "test")
+                assert result_fingerprint.get("infrastructure_type") == "test"
         reverse_priority_keys = {"cpu_count", "infrastructure_type"}
         (
             _,
@@ -866,9 +837,7 @@ class EngineTest(TestCase):
         )
         for result_fingerprint in result_fingerprints:
             if result_fingerprint.get("vm_uuid") == "match":
-                self.assertEqual(
-                    result_fingerprint.get("infrastructure_type"), "virtualized"
-                )
+                assert result_fingerprint.get("infrastructure_type") == "virtualized"
 
     def test_merge_matching_fingerprints(self):
         """Test merge of two lists of fingerprints."""
@@ -979,27 +948,27 @@ class EngineTest(TestCase):
         }
 
         # merge list should always contain all nfingerprints (base_list)
-        self.assertEqual(len(merge_list), 3)
-        self.assertTrue(expected_merge_fingerprint in merge_list)
-        self.assertTrue(nfingerprint_no_match in merge_list)
-        self.assertTrue(nfingerprint_no_key in merge_list)
+        assert len(merge_list) == 3
+        assert expected_merge_fingerprint in merge_list
+        assert nfingerprint_no_match in merge_list
+        assert nfingerprint_no_key in merge_list
 
         # assert VM property merged
-        self.assertIsNotNone(expected_merge_fingerprint.get("vm_uuid"))
+        assert expected_merge_fingerprint.get("vm_uuid") is not None
 
         # assert network os_release had priority
-        self.assertEqual(expected_merge_fingerprint.get("os_release"), "RHEL 7")
-        self.assertEqual(expected_merge_fingerprint.get("sources"), merged_sources)
+        assert expected_merge_fingerprint.get("os_release") == "RHEL 7"
+        assert expected_merge_fingerprint.get("sources") == merged_sources
 
         # assert those that didn't match, don't have VM properties
-        self.assertIsNone(nfingerprint_no_match.get("vm_uuid"))
-        self.assertIsNone(nfingerprint_no_key.get("vm_uuid"))
+        assert nfingerprint_no_match.get("vm_uuid") is None
+        assert nfingerprint_no_key.get("vm_uuid") is None
 
         # no_match_found list should only contain vfingerprints
         #  with no match
-        self.assertEqual(len(no_match_found_list), 2)
-        self.assertTrue(vfingerprint_no_match in no_match_found_list)
-        self.assertTrue(vfingerprint_no_key in no_match_found_list)
+        assert len(no_match_found_list) == 2
+        assert vfingerprint_no_match in no_match_found_list
+        assert vfingerprint_no_key in no_match_found_list
 
     def test_remove_duplicate_fingerprints(self):
         """Test remove duplicate fingerprints created by index."""
@@ -1022,22 +991,22 @@ class EngineTest(TestCase):
             "mac_addresses", fingerprints
         )
 
-        self.assertEqual(len(no_key_found), 1)
-        self.assertEqual(no_key_found[0]["id"], 3)
-        self.assertIsNotNone(no_key_found[0].get(FINGERPRINT_GLOBAL_ID_KEY))
-        self.assertEqual(len(index.keys()), 4)
-        self.assertIsNotNone(index.get("1234"))
-        self.assertIsNotNone(index.get("2345"))
-        self.assertIsNotNone(index.get("9876"))
-        self.assertIsNotNone(index.get("8765"))
+        assert len(no_key_found) == 1
+        assert no_key_found[0]["id"] == 3
+        assert no_key_found[0].get(FINGERPRINT_GLOBAL_ID_KEY) is not None
+        assert len(index.keys()) == 4
+        assert index.get("1234") is not None
+        assert index.get("2345") is not None
+        assert index.get("9876") is not None
+        assert index.get("8765") is not None
 
         # deplicate but leave unique key
         leave_key_list = list(index.values())
         unique_list = self.fp_task_runner._remove_duplicate_fingerprints(
             [FINGERPRINT_GLOBAL_ID_KEY], leave_key_list
         )
-        self.assertEqual(len(unique_list), 2)
-        self.assertIsNotNone(unique_list[0].get(FINGERPRINT_GLOBAL_ID_KEY))
+        assert len(unique_list) == 2
+        assert unique_list[0].get(FINGERPRINT_GLOBAL_ID_KEY) is not None
 
         # same test, but add value that doesn't have key
         leave_key_list = list(index.values())
@@ -1045,15 +1014,15 @@ class EngineTest(TestCase):
         unique_list = self.fp_task_runner._remove_duplicate_fingerprints(
             [FINGERPRINT_GLOBAL_ID_KEY], leave_key_list
         )
-        self.assertEqual(len(unique_list), 3)
+        assert len(unique_list) == 3
 
         # now pass flag to strip id key
         remove_key_list = list(index.values())
         unique_list = self.fp_task_runner._remove_duplicate_fingerprints(
             [FINGERPRINT_GLOBAL_ID_KEY], remove_key_list, True
         )
-        self.assertEqual(len(unique_list), 2)
-        self.assertIsNone(unique_list[0].get(FINGERPRINT_GLOBAL_ID_KEY))
+        assert len(unique_list) == 2
+        assert unique_list[0].get(FINGERPRINT_GLOBAL_ID_KEY) is None
 
     def test_create_index_for_fingerprints(self):
         """Test create index for fingerprints."""
@@ -1067,57 +1036,57 @@ class EngineTest(TestCase):
         index, no_key_found = self.fp_task_runner._create_index_for_fingerprints(
             "bios_uuid", fingerprints, False
         )
-        self.assertIsNone(no_key_found[0].get(FINGERPRINT_GLOBAL_ID_KEY))
+        assert no_key_found[0].get(FINGERPRINT_GLOBAL_ID_KEY) is None
 
         # Tests with unique id in objects
         index, no_key_found = self.fp_task_runner._create_index_for_fingerprints(
             "bios_uuid", fingerprints
         )
 
-        self.assertEqual(len(no_key_found), 1)
-        self.assertEqual(no_key_found[0]["id"], 3)
-        self.assertIsNotNone(no_key_found[0].get(FINGERPRINT_GLOBAL_ID_KEY))
-        self.assertEqual(len(index.keys()), 2)
-        self.assertIsNotNone(index.get("1234"))
-        self.assertIsNotNone(index.get("2345"))
+        assert len(no_key_found) == 1
+        assert no_key_found[0]["id"] == 3
+        assert no_key_found[0].get(FINGERPRINT_GLOBAL_ID_KEY) is not None
+        assert len(index.keys()) == 2
+        assert index.get("1234") is not None
+        assert index.get("2345") is not None
 
     def test_merge_fingerprint(self):
         """Test merging a vcenter and network fingerprint."""
         nfingerprint = self._create_network_fingerprint()
         vfingerprint = self._create_vcenter_fingerprint()
 
-        self.assertIsNone(nfingerprint.get("vm_state"))
-        self.assertIsNone(nfingerprint.get("vm_uuid"))
-        self.assertIsNone(nfingerprint.get("vm_dns_name"))
-        self.assertIsNone(nfingerprint.get("vm_host_socket_count"))
-        self.assertIsNone(nfingerprint.get("vm_datacenter"))
-        self.assertIsNone(nfingerprint.get("vm_cluster"))
+        assert nfingerprint.get("vm_state") is None
+        assert nfingerprint.get("vm_uuid") is None
+        assert nfingerprint.get("vm_dns_name") is None
+        assert nfingerprint.get("vm_host_socket_count") is None
+        assert nfingerprint.get("vm_datacenter") is None
+        assert nfingerprint.get("vm_cluster") is None
 
-        self.assertIsNone(vfingerprint.get("os_name"))
-        self.assertIsNone(vfingerprint.get("os_version"))
-        self.assertIsNone(vfingerprint.get("bios_uuid"))
-        self.assertIsNone(vfingerprint.get("subscription_manager_id"))
-        self.assertIsNone(vfingerprint.get("cpu_socket_count"))
-        self.assertIsNone(vfingerprint.get("cpu_core_count"))
+        assert vfingerprint.get("os_name") is None
+        assert vfingerprint.get("os_version") is None
+        assert vfingerprint.get("bios_uuid") is None
+        assert vfingerprint.get("subscription_manager_id") is None
+        assert vfingerprint.get("cpu_socket_count") is None
+        assert vfingerprint.get("cpu_core_count") is None
 
         new_fingerprint = self.fp_task_runner._merge_fingerprint(
             nfingerprint, vfingerprint
         )
 
-        self.assertIsNotNone(new_fingerprint.get("vm_state"))
-        self.assertIsNotNone(new_fingerprint.get("vm_uuid"))
-        self.assertIsNotNone(new_fingerprint.get("vm_dns_name"))
-        self.assertIsNotNone(new_fingerprint.get("vm_host_socket_count"))
-        self.assertIsNotNone(new_fingerprint.get("vm_datacenter"))
-        self.assertIsNotNone(new_fingerprint.get("vm_cluster"))
+        assert new_fingerprint.get("vm_state") is not None
+        assert new_fingerprint.get("vm_uuid") is not None
+        assert new_fingerprint.get("vm_dns_name") is not None
+        assert new_fingerprint.get("vm_host_socket_count") is not None
+        assert new_fingerprint.get("vm_datacenter") is not None
+        assert new_fingerprint.get("vm_cluster") is not None
 
-        self.assertIsNotNone(new_fingerprint.get("name"))
-        self.assertIsNotNone(new_fingerprint.get("os_name"))
-        self.assertIsNotNone(new_fingerprint.get("os_version"))
-        self.assertIsNotNone(new_fingerprint.get("bios_uuid"))
-        self.assertIsNotNone(new_fingerprint.get("subscription_manager_id"))
-        self.assertIsNotNone(new_fingerprint.get("cpu_socket_count"))
-        self.assertIsNotNone(new_fingerprint.get("cpu_core_count"))
+        assert new_fingerprint.get("name") is not None
+        assert new_fingerprint.get("os_name") is not None
+        assert new_fingerprint.get("os_version") is not None
+        assert new_fingerprint.get("bios_uuid") is not None
+        assert new_fingerprint.get("subscription_manager_id") is not None
+        assert new_fingerprint.get("cpu_socket_count") is not None
+        assert new_fingerprint.get("cpu_core_count") is not None
 
     def assert_all_fingerprints_have_sudo(self, metadata_dict):
         """
@@ -1126,14 +1095,11 @@ class EngineTest(TestCase):
         If its not True, all offending fingerprints will appear on the error log.
         """
         # fp <<< abbreviation for fingerprint
-        self.assertTrue(
-            all(fp_meta["has_sudo"] for fp_meta in metadata_dict.values()),
-            [
-                fp_name
-                for fp_name, fp_meta in metadata_dict.items()
-                if not fp_meta["has_sudo"]
-            ],
-        )
+        assert all(fp_meta["has_sudo"] for fp_meta in metadata_dict.values()), [
+            fp_name
+            for fp_name, fp_meta in metadata_dict.items()
+            if not fp_meta["has_sudo"]
+        ]
         return True
 
     def test_assert_all_fingerprints_have_sudo(self):
@@ -1141,7 +1107,7 @@ class EngineTest(TestCase):
         fake_fingerprints = {"foo": {"has_sudo": True}, "bar": {"has_sudo": True}}
         self.assert_all_fingerprints_have_sudo(fake_fingerprints)
         fake_fingerprints["foo"]["has_sudo"] = False
-        with self.assertRaisesMessage(AssertionError, "False is not true : ['foo']"):
+        with pytest.raises(AssertionError, match="['foo']"):
             self.assert_all_fingerprints_have_sudo(fake_fingerprints)
 
     def test_merge_fingerprint_sudo(self):
@@ -1158,7 +1124,7 @@ class EngineTest(TestCase):
         result = self.fp_task_runner._merge_fingerprint(
             sudo_fingerprint, regular_fingerprint
         )
-        self.assertEqual(result, sudo_fingerprint)
+        assert result == sudo_fingerprint
         self.assert_all_fingerprints_have_sudo(result["metadata"])
 
         # Test that sudo is preferred when part of to merge fingerprint
@@ -1181,13 +1147,13 @@ class EngineTest(TestCase):
         vfingerprint = self._create_vcenter_fingerprint()
 
         nfingerprint["os_release"] = "Fedora"
-        self.assertNotEqual(vfingerprint.get("os_release"), nfingerprint["os_release"])
+        assert vfingerprint.get("os_release") != nfingerprint["os_release"]
 
         new_fingerprint = self.fp_task_runner._merge_fingerprint(
             nfingerprint, vfingerprint
         )
 
-        self.assertEqual(new_fingerprint.get("os_release"), nfingerprint["os_release"])
+        assert new_fingerprint.get("os_release") == nfingerprint["os_release"]
 
     def test_source_name_in_metadata(self):
         """Test that adding facts includes source_name in metadata."""
@@ -1198,9 +1164,7 @@ class EngineTest(TestCase):
         }
         fingerprint = {"metadata": {}}
         result = self.fp_task_runner._process_network_fact(sourcetopass, fingerprint)
-        self.assertEqual(
-            result["metadata"]["infrastructure_type"]["source_name"], "source1"
-        )
+        assert result["metadata"]["infrastructure_type"]["source_name"] == "source1"
 
     def test_all_facts_with_null_value_in_process_network_scan(self):
         """Test fingerprinting method with all facts set to null value."""
@@ -1212,9 +1176,7 @@ class EngineTest(TestCase):
         facts_dict = network_template()
         result = self.fp_task_runner._process_network_fact(source_dict, facts_dict)
         metadata_dict = result.pop(META_DATA_KEY)
-        self.assertEqual(
-            set(metadata_dict.keys()), set(EXPECTED_FINGERPRINT_MAP_NETWORK.keys())
-        )
+        assert set(metadata_dict.keys()) == set(EXPECTED_FINGERPRINT_MAP_NETWORK.keys())
         assert {
             fingerprint_name: {
                 "server_id": self.server_id,
@@ -1233,7 +1195,7 @@ class EngineTest(TestCase):
         expected_fingerprints[PRODUCTS_KEY] = mock.ANY
         expected_fingerprints[ENTITLEMENTS_KEY] = []
         expected_fingerprints["infrastructure_type"] = SystemFingerprint.UNKNOWN
-        self.assertDictEqual(result, expected_fingerprints)
+        assert result == expected_fingerprints
 
     def test_scan_all_facts_with_null_value_in_process_vcenter_scan(self):
         """Test fingerprinting method with all facts set to null value."""
@@ -1245,9 +1207,7 @@ class EngineTest(TestCase):
         facts_dict = vcenter_template()
         result = self.fp_task_runner._process_vcenter_fact(source_dict, facts_dict)
         metadata_dict = result.pop(META_DATA_KEY)
-        self.assertEqual(
-            set(metadata_dict.keys()), set(EXPECTED_FINGERPRINT_MAP_VCENTER.keys())
-        )
+        assert set(metadata_dict.keys()) == set(EXPECTED_FINGERPRINT_MAP_VCENTER.keys())
         assert {
             fingerprint_name: {
                 "server_id": self.server_id,
@@ -1267,7 +1227,7 @@ class EngineTest(TestCase):
         expected_fingerprints["infrastructure_type"] = SystemFingerprint.VIRTUALIZED
         expected_fingerprints[PRODUCTS_KEY] = []
         expected_fingerprints[ENTITLEMENTS_KEY] = []
-        self.assertDictEqual(result, expected_fingerprints)
+        assert result == expected_fingerprints
 
     def test_scan_all_facts_with_null_value_in_process_satellite_scan(self):
         """Test fingerprinting method with all facts set to null value."""
@@ -1280,23 +1240,21 @@ class EngineTest(TestCase):
         result = self.fp_task_runner._process_satellite_fact(source_dict, facts_dict)
         metadata_dict = result.pop(META_DATA_KEY)
 
-        self.assertEqual(
-            set(metadata_dict.keys()), set(EXPECTED_FINGERPRINT_MAP_SATELLITE.keys())
+        assert set(metadata_dict.keys()) == set(
+            EXPECTED_FINGERPRINT_MAP_SATELLITE.keys()
         )
 
-        self.assertDictEqual(
-            {
-                fingerprint_name: {
-                    "server_id": self.server_id,
-                    "source_name": "source3",
-                    "source_type": DataSources.SATELLITE,
-                    "has_sudo": False,
-                    "raw_fact_key": fact_name,
-                }
-                for fingerprint_name, fact_name in EXPECTED_FINGERPRINT_MAP_SATELLITE.items()  # noqa E501
-            },
-            metadata_dict,
-        )
+        assert {
+            fingerprint_name: {
+                "server_id": self.server_id,
+                "source_name": "source3",
+                "source_type": DataSources.SATELLITE,
+                "has_sudo": False,
+                "raw_fact_key": fact_name,
+            }
+            for fingerprint_name, fact_name in EXPECTED_FINGERPRINT_MAP_SATELLITE.items()  # noqa E501
+        } == metadata_dict
+
         expected_fingerprints = {
             fingerprint_name: None
             for fingerprint_name in EXPECTED_FINGERPRINT_MAP_SATELLITE
@@ -1335,7 +1293,7 @@ class EngineTest(TestCase):
         ) = self.fp_task_runner._merge_fingerprints_from_source_types(
             NETWORK_SATELLITE_MERGE_KEYS, nfingerprints, sfingerprints
         )
-        self.assertEqual(len(result_fingerprints), 1)
+        assert len(result_fingerprints) == 1
         fp = result_fingerprints[0]
         fp["date_yum_history"] = "2018-1-7"
         fp["date_filesystem_create"] = None
@@ -1345,9 +1303,9 @@ class EngineTest(TestCase):
         self.fp_task_runner._compute_system_creation_time(fp)
         test_date = datetime.strptime("2018-4-7", "%Y-%m-%d").date()
 
-        self.assertEqual(fp["system_creation_date"], test_date)
+        assert fp["system_creation_date"] == test_date
         metadata = fp["metadata"]["system_creation_date"]["raw_fact_key"]
-        self.assertEqual("registration_time", metadata)
+        assert "registration_time" == metadata
 
     ################################################################
     # Test multi_format_dateparse
@@ -1362,7 +1320,7 @@ class EngineTest(TestCase):
             "2018-4-7 12:45:02",
             ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S %z"],
         )
-        self.assertEqual(date_value, test_date)
+        assert date_value == test_date
 
         date_value = self.fp_task_runner._multi_format_dateparse(
             source,
@@ -1370,12 +1328,12 @@ class EngineTest(TestCase):
             "2018-4-7 12:45:02 -0400",
             ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S %z"],
         )
-        self.assertEqual(date_value, test_date)
+        assert date_value == test_date
 
         date_value = self.fp_task_runner._multi_format_dateparse(
             source, "fake_key", "2018-4-7 12:45:02 -0400", ["%Y-%m-%d %H:%M:%S"]
         )
-        self.assertIsNone(date_value)
+        assert date_value is None
 
     def test_process_details_report_failed(self):
         """Test processing a details report no valid fps."""
@@ -1390,8 +1348,8 @@ class EngineTest(TestCase):
                 "", details_report
             )
 
-            self.assertIn("failed", status_message.lower())
-            self.assertEqual(status, "failed")
+            assert "failed" in status_message.lower()
+            assert status == "failed"
 
     def test_process_details_report_success(self):
         """Test processing a details report success."""
@@ -1413,8 +1371,8 @@ class EngineTest(TestCase):
             status_message, status = self.fp_task_runner._process_details_report(
                 "", details_report
             )
-        self.assertIn("success", status_message.lower())
-        self.assertEqual(status, "completed")
+        assert "success" in status_message.lower()
+        assert status == "completed"
 
     def test_process_details_report_exception(self):
         """Test processing a details report with an exception."""
@@ -1438,19 +1396,19 @@ class EngineTest(TestCase):
                     "", details_report
                 )
 
-                self.assertIn("failed", status_message.lower())
-                self.assertEqual(status, "failed")
+                assert "failed" in status_message.lower()
+                assert status == "failed"
 
     def test_format_certs(self):
         """Testing the format_certs function."""
         certs = ["69.pem", "67.pem", ""]
         formatted_certs = FingerprintTaskRunner.format_certs(certs)
-        self.assertEqual([69, 67], formatted_certs)
+        assert [69, 67] == formatted_certs
         # assert empty list stays empty
         certs = []
         formatted_certs = FingerprintTaskRunner.format_certs(certs)
-        self.assertEqual([], formatted_certs)
+        assert [] == formatted_certs
         # assert exception returns empty
         certs = ["notint.pem"]
         formatted_certs = FingerprintTaskRunner.format_certs(certs)
-        self.assertEqual([], formatted_certs)
+        assert [] == formatted_certs

--- a/quipucords/fingerprinter/tests_fp_utils.py
+++ b/quipucords/fingerprinter/tests_fp_utils.py
@@ -11,4 +11,4 @@ class FingerprinterUtilTest(TestCase):
     def test_product_entitlement_no_name(self):
         """Test product entitlement without name is false."""
         result = product_entitlement_found([{}], "Foo")
-        self.assertFalse(result)
+        assert not result

--- a/quipucords/fingerprinter/tests_product_brms.py
+++ b/quipucords/fingerprinter/tests_product_brms.py
@@ -36,7 +36,7 @@ class ProductBRMSTest(TestCase):
                 "raw_fact_key": "jboss_brms_kie_api_ver/" "jboss_brms_manifest_mf",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     # pylint: disable=C0103
     def test_detect_jboss_brms_potential_sub(self):
@@ -58,7 +58,7 @@ class ProductBRMSTest(TestCase):
                 "raw_fact_key": "subman_consumed",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_brms_potential_ent(self):
         """Test the detect_jboss_brms method."""
@@ -79,7 +79,7 @@ class ProductBRMSTest(TestCase):
                 "raw_fact_key": "entitlements",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_brms_absent(self):
         """Test the detect_jboss_brms method."""
@@ -100,4 +100,4 @@ class ProductBRMSTest(TestCase):
                 "raw_fact_key": None,
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected

--- a/quipucords/fingerprinter/tests_product_eap.py
+++ b/quipucords/fingerprinter/tests_product_eap.py
@@ -17,11 +17,11 @@ class TestVersionAwareDedup(unittest.TestCase):
 
     def test_dedup(self):
         """Dedup redundant version numbers."""
-        self.assertEqual(version_aware_dedup(["1", "1.0", "1.0.1"]), {"1.0.1"})
+        assert version_aware_dedup(["1", "1.0", "1.0.1"]) == {"1.0.1"}
 
     def test_empty_input(self):
         """Return an empty set for an empty input."""
-        self.assertEqual(version_aware_dedup([]), set())
+        assert version_aware_dedup([]) == set()
 
 
 class ProductEAPTest(TestCase):
@@ -56,7 +56,7 @@ class ProductEAPTest(TestCase):
                 "raw_fact_key": "eap_home_ls/jboss_eap_jar_ver",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     # pylint: disable=C0103
     def test_detect_jboss_eap_potential_common(self):
@@ -78,7 +78,7 @@ class ProductEAPTest(TestCase):
                 "raw_fact_key": "jboss_eap_common_files",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_eap_potential_sub(self):
         """Test the detect_jboss_eap method."""
@@ -99,7 +99,7 @@ class ProductEAPTest(TestCase):
                 "raw_fact_key": "subman_consumed",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_eap_potential_ent(self):
         """Test the detect_jboss_eap method."""
@@ -120,7 +120,7 @@ class ProductEAPTest(TestCase):
                 "raw_fact_key": "entitlements",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_eap_absent(self):
         """Test the detect_jboss_eap method."""
@@ -141,7 +141,7 @@ class ProductEAPTest(TestCase):
                 "raw_fact_key": None,
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
 
 class TestVerifyClassification(unittest.TestCase):
@@ -149,12 +149,12 @@ class TestVerifyClassification(unittest.TestCase):
 
     def test_wildfly(self):
         """Test that a wildfly version returns False."""
-        self.assertEqual(verify_classification("WildFly-10"), False)
+        assert verify_classification("WildFly-10") is False
 
     def test_jbossas(self):
         """Test that a jbossas version returns False."""
-        self.assertEqual(verify_classification("JBossAS-7"), False)
+        assert verify_classification("JBossAS-7") is False
 
     def test_eap(self):
         """Test that an eap version returns True."""
-        self.assertEqual(verify_classification("6.0.1"), True)
+        assert verify_classification("6.0.1") is True

--- a/quipucords/fingerprinter/tests_product_fuse.py
+++ b/quipucords/fingerprinter/tests_product_fuse.py
@@ -37,7 +37,7 @@ class ProductFuseTest(TestCase):
                 "raw_fact_key": "eap_home_bin/jboss_activemq_ver",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     # pylint: disable=C0103
     def test_detect_jboss_fuse_potential_init(self):
@@ -59,7 +59,7 @@ class ProductFuseTest(TestCase):
                 "raw_fact_key": "jboss_fuse_systemctl_unit_files",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_fuse_potential_sub(self):
         """Test the detect_jboss_fuse method."""
@@ -80,7 +80,7 @@ class ProductFuseTest(TestCase):
                 "raw_fact_key": "subman_consumed",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_fuse_potential_ent(self):
         """Test the detect_jboss_fuse method."""
@@ -101,7 +101,7 @@ class ProductFuseTest(TestCase):
                 "raw_fact_key": "entitlements",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_jboss_fuse_absent(self):
         """Test the detect_jboss_fuse method."""
@@ -122,7 +122,7 @@ class ProductFuseTest(TestCase):
                 "raw_fact_key": None,
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_fuse_present(self):
         """Test the detect_jboss_fuse method."""
@@ -153,7 +153,7 @@ class ProductFuseTest(TestCase):
                 "jboss_fuse_on_eap_activemq_ver",
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_detect_activemq_fuse_absent(self):
         """Test the detect_jboss_fuse method with activemq version found."""
@@ -178,11 +178,11 @@ class ProductFuseTest(TestCase):
                 "raw_fact_key": None,
             },
         }
-        self.assertEqual(product, expected)
+        assert product == expected
 
     def test_get_version(self):
         """Test the get_version method."""
         eap_camel = [{"homedir": "/foo/bin", "version": ["redhat-620133"]}]
         versions = get_version(eap_camel)
         expected = ["redhat-620133"]
-        self.assertEqual(versions, expected)
+        assert versions == expected

--- a/quipucords/fingerprinter/tests_product_jws.py
+++ b/quipucords/fingerprinter/tests_product_jws.py
@@ -21,7 +21,7 @@ class ProductJWSTest(TestCase):
         versions = get_version(raw_versions)
         expected = ["JWS 3.0.3"]
 
-        self.assertEqual(versions, expected)
+        assert versions == expected
 
     # pylint: disable=unused-argument
     def test_detect_ws_present(self):
@@ -46,7 +46,7 @@ class ProductJWSTest(TestCase):
         }
         facts = {"jws_installed_with_rpm": True}
         product = detect_jboss_ws(source, facts)
-        self.assertEqual(product, expected)
+        assert product == expected
 
         # Test where jws certificate was found
         source = {
@@ -57,7 +57,7 @@ class ProductJWSTest(TestCase):
         facts = {"jws_installed_with_rpm": False, "jws_has_cert": True}
         expected["metadata"]["raw_fact_key"] = "jws_has_cert"
         product = detect_jboss_ws(source, facts)
-        self.assertEqual(product, expected)
+        assert product == expected
 
         # Test where valid version string is found
         facts = {
@@ -71,7 +71,7 @@ class ProductJWSTest(TestCase):
             "fingerprinter.jboss_web_server.get_version", return_value=["JWS 3.0.1"]
         ):
             product = detect_jboss_ws(source, facts)
-            self.assertEqual(product, expected)
+            assert product == expected
 
     # pylint: disable=unused-argument
     def test_detect_ws_potential(self):
@@ -100,14 +100,14 @@ class ProductJWSTest(TestCase):
             "tomcat_is_part_of_redhat_product": True,
         }
         product = detect_jboss_ws(source, facts)
-        self.assertEqual(product, expected)
+        assert product == expected
 
         # Test where JWS_HOME contains jboss eula file
         facts["tomcat_is_part_of_redhat_product"] = False
         facts["jws_has_eula_txt_file"] = True
         product = detect_jboss_ws(source, facts)
         expected["metadata"]["raw_fact_key"] = "jws_has_eula_txt_file"
-        self.assertEqual(product, expected)
+        assert product == expected
 
         # Test where server only has JWS entitlement
         facts["jws_has_eula_txt_file"] = False
@@ -117,7 +117,7 @@ class ProductJWSTest(TestCase):
             return_value=True,
         ):
             product = detect_jboss_ws(source, facts)
-            self.assertEqual(product, expected)
+            assert product == expected
 
         # Test where only valid EWS version is found
         expected["version"] = ["EWS 1.0.0"]
@@ -125,7 +125,7 @@ class ProductJWSTest(TestCase):
             "fingerprinter.jboss_web_server.get_version", return_value=["EWS 1.0.0"]
         ):
             product = detect_jboss_ws(source, facts)
-            self.assertEqual(product, expected)
+            assert product == expected
 
     # pylint: disable=unused-argument
     def test_detect_ws_absent(self):
@@ -153,4 +153,4 @@ class ProductJWSTest(TestCase):
             },
         }
         product = detect_jboss_ws(source, facts)
-        self.assertEqual(product, expected)
+        assert product == expected

--- a/quipucords/fingerprinter/tests_product_utils.py
+++ b/quipucords/fingerprinter/tests_product_utils.py
@@ -13,25 +13,25 @@ class ProductUtilsTest(TestCase):
         string = "/opt/eap/modules.jar"
         prefix = "/opt/eap/"
         stripped = strip_prefix(string, prefix)
-        self.assertEqual(stripped, "modules.jar")
+        assert stripped == "modules.jar"
 
     def test_strip_prefix_no_prefix(self):
         """Test the strip_prefix method."""
         string = "/opt/eap/modules.jar"
         prefix = "/opt/fuse/"
         stripped = strip_prefix(string, prefix)
-        self.assertEqual(stripped, string)
+        assert stripped == string
 
     def test_strip_suffix_no_suffix(self):
         """Test the strip_suffix method."""
         string = "modules.jar"
         suffix = ".csv"
         stripped = strip_suffix(string, suffix)
-        self.assertEqual(stripped, string)
+        assert stripped == string
 
     def test_strip_suffix(self):
         """Test the strip_suffix method."""
         string = "modules.jar"
         suffix = ".jar"
         stripped = strip_suffix(string, suffix)
-        self.assertEqual(stripped, "modules")
+        assert stripped == "modules"

--- a/quipucords/quipucords/tests_environment.py
+++ b/quipucords/quipucords/tests_environment.py
@@ -25,7 +25,7 @@ class EnvironmentTest(TestCase):
         expected = "buildnum"
         mock_os.get.return_value = expected
         result = environment.commit()
-        self.assertEqual(result, expected)
+        assert result == expected
 
     @patch("subprocess.check_output")
     def test_commit_with_subprocess(self, mock_subprocess):
@@ -33,7 +33,7 @@ class EnvironmentTest(TestCase):
         expected = "buildnum"
         mock_subprocess.return_value = expected
         result = environment.commit()
-        self.assertEqual(result, expected)
+        assert result == expected
 
     @patch("platform.uname")
     def test_platform_info(self, mock_platform):
@@ -42,8 +42,8 @@ class EnvironmentTest(TestCase):
         a_plat = platform_record("Red Hat", "7.4")
         mock_platform.return_value = a_plat
         result = environment.platform_info()
-        self.assertEqual(result["os"], "Red Hat")
-        self.assertEqual(result["version"], "7.4")
+        assert result["os"] == "Red Hat"
+        assert result["version"] == "7.4"
 
     @patch("sys.version")
     def test_python_version(self, mock_sys_ver):
@@ -51,7 +51,7 @@ class EnvironmentTest(TestCase):
         expected = "Python 3.6"
         mock_sys_ver.replace.return_value = expected
         result = environment.python_version()
-        self.assertEqual(result, expected)
+        assert result == expected
 
     @patch("sys.modules")
     def test_modules(self, mock_modules):
@@ -61,7 +61,7 @@ class EnvironmentTest(TestCase):
         mod2 = Mock(__version__="version2")
         mock_modules.items.return_value = (("module1", mod1), ("module2", mod2))
         result = environment.modules()
-        self.assertEqual(result, expected)
+        assert result == expected
 
     @patch("quipucords.environment.logger.info")
     def test_startup(self, mock_logger):

--- a/quipucords/scanner/network/processing/test_brms.py
+++ b/quipucords/scanner/network/processing/test_brms.py
@@ -23,19 +23,17 @@ Implementation-Version: 6.5.0.Final-redhat-2
 
     def test_success(self):
         """Extract the Implementation_Version from a manifest."""
-        self.assertEqual(
-            brms.ProcessJbossBRMSManifestMF.process_item(
-                ansible_item("/opt/brms/", self.MANIFEST)
-            ),
-            ("/opt/brms", "6.5.0.Final-redhat-2"),
-        )
+        assert brms.ProcessJbossBRMSManifestMF.process_item(
+            ansible_item("/opt/brms/", self.MANIFEST)
+        ) == ("/opt/brms", "6.5.0.Final-redhat-2")
 
     def test_no_version(self):
         """Don't crash if the manifest is missing a version."""
-        self.assertIsNone(
+        assert (
             brms.ProcessJbossBRMSManifestMF.process_item(
                 ansible_item("manifest", "not\na\nmanifest")
             )
+            is None
         )
 
 
@@ -44,20 +42,20 @@ class TestEnclosingWarArchive(unittest.TestCase):
 
     def test_enclosing(self):
         """Return the enclosing war archive."""
-        self.assertEqual(
-            brms.enclosing_war_archive("/foo/kie-server.war/bar/baz"),
-            "/foo/kie-server.war",
+        assert (
+            brms.enclosing_war_archive("/foo/kie-server.war/bar/baz")
+            == "/foo/kie-server.war"
         )
 
     def test_war_root(self):
         """Return the war archive when applied to just the archive."""
-        self.assertEqual(
-            brms.enclosing_war_archive("/foo/kie-server.war"), "/foo/kie-server.war"
+        assert (
+            brms.enclosing_war_archive("/foo/kie-server.war") == "/foo/kie-server.war"
         )
 
     def test_no_war_archive(self):
         """Return None when there is no war archive."""
-        self.assertIsNone(brms.enclosing_war_archive("/foo/bar/baz"))
+        assert brms.enclosing_war_archive("/foo/bar/baz") is None
 
 
 class TestProcessJbossBRMSKieBusinessCentral(unittest.TestCase):
@@ -73,10 +71,9 @@ class TestProcessJbossBRMSKieBusinessCentral(unittest.TestCase):
 
     def test_success_case(self):
         """Return stdout_lines in case of success."""
-        self.assertEqual(
-            set(brms.ProcessJbossBRMSKieBusinessCentral.process(self.ls_results)),
-            {("/tmp/good", "version-string")},
-        )
+        assert set(
+            brms.ProcessJbossBRMSKieBusinessCentral.process(self.ls_results)
+        ) == {("/tmp/good", "version-string")}
 
 
 class TestFindBRMSKieApiVer(unittest.TestCase):
@@ -102,13 +99,13 @@ class TestFindBRMSKieApiVer(unittest.TestCase):
 
     def test_success_case(self):
         """Return the correct (directory, version string) pairs."""
-        self.assertEqual(
+        assert (
             set(
                 brms.ProcessFindBRMSKieApiVer.process(
                     ansible_result(self.ansible_stdout)
                 )
-            ),
-            self.expected,
+            )
+            == self.expected
         )
 
 
@@ -117,10 +114,11 @@ class TestProcessFindBRMSKieWarVer(unittest.TestCase):
 
     def test_success_case(self):
         """Return stdout_lines in case of success."""
-        self.assertEqual(
-            brms.ProcessFindBRMSKieWarVer.process(ansible_result("a\nb\nc")),
-            ["a", "b", "c"],
-        )
+        assert brms.ProcessFindBRMSKieWarVer.process(ansible_result("a\nb\nc")) == [
+            "a",
+            "b",
+            "c",
+        ]
 
 
 class TestProcessJbossBRMSBusinessCentralCandidates(unittest.TestCase):
@@ -128,26 +126,23 @@ class TestProcessJbossBRMSBusinessCentralCandidates(unittest.TestCase):
 
     def test_success(self):
         """Found jboss-modules.jar."""
-        self.assertEqual(
-            brms.ProcessJbossBRMSBusinessCentralCandidates.process(
-                "QPC_FORCE_POST_PROCESS",
-                {
-                    "internal_jboss_brms_business_central_candidates": ansible_result(
-                        "a\nb\nc"
-                    )
-                },
-            ),
-            ["a", "b", "c"],
-        )
+        assert brms.ProcessJbossBRMSBusinessCentralCandidates.process(
+            "QPC_FORCE_POST_PROCESS",
+            {
+                "internal_jboss_brms_business_central_candidates": ansible_result(
+                    "a\nb\nc"
+                )
+            },
+        ) == ["a", "b", "c"]
 
     def test_not_found(self):
         """Did not find jboss-modules.jar."""
-        self.assertEqual(
+        assert (
             brms.ProcessJbossBRMSBusinessCentralCandidates.process(
                 "QPC_FORCE_POST_PROCESS",
                 {"internal_jboss_brms_business_central_candidates": ansible_result("")},
-            ),
-            [],
+            )
+            == []
         )
 
 
@@ -156,26 +151,23 @@ class TestProcessJbossBRMSDecisionCentralCandidates(unittest.TestCase):
 
     def test_success(self):
         """Found candidates."""
-        self.assertEqual(
-            brms.ProcessJbossBRMSDecisionCentralCandidates.process(
-                "QPC_FORCE_POST_PROCESS",
-                {
-                    "internal_jboss_brms_decision_central_candidates": ansible_result(
-                        "a\nb\nc"
-                    )
-                },
-            ),
-            ["a", "b", "c"],
-        )
+        assert brms.ProcessJbossBRMSDecisionCentralCandidates.process(
+            "QPC_FORCE_POST_PROCESS",
+            {
+                "internal_jboss_brms_decision_central_candidates": ansible_result(
+                    "a\nb\nc"
+                )
+            },
+        ) == ["a", "b", "c"]
 
     def test_not_found(self):
         """Did not find candidates."""
-        self.assertEqual(
+        assert (
             brms.ProcessJbossBRMSDecisionCentralCandidates.process(
                 "QPC_FORCE_POST_PROCESS",
                 {"internal_jboss_brms_decision_central_candidates": ansible_result("")},
-            ),
-            [],
+            )
+            == []
         )
 
 
@@ -184,26 +176,19 @@ class TestProcessJbossBRMSKieCentralCandidates(unittest.TestCase):
 
     def test_success(self):
         """Found candidates."""
-        self.assertEqual(
-            brms.ProcessJbossBRMSKieCentralCandidates.process(
-                "QPC_FORCE_POST_PROCESS",
-                {
-                    "internal_jboss_brms_kie_server_candidates": ansible_result(
-                        "a\nb\nc"
-                    )
-                },
-            ),
-            ["a", "b", "c"],
-        )
+        assert brms.ProcessJbossBRMSKieCentralCandidates.process(
+            "QPC_FORCE_POST_PROCESS",
+            {"internal_jboss_brms_kie_server_candidates": ansible_result("a\nb\nc")},
+        ) == ["a", "b", "c"]
 
     def test_not_found(self):
         """Did not find candidates."""
-        self.assertEqual(
+        assert (
             brms.ProcessJbossBRMSKieCentralCandidates.process(
                 "QPC_FORCE_POST_PROCESS",
                 {"internal_jboss_brms_kie_server_candidates": ansible_result("")},
-            ),
-            [],
+            )
+            == []
         )
 
 
@@ -212,24 +197,17 @@ class TestProcessKieSearchCandidates(unittest.TestCase):
 
     def test_success(self):
         """Found candidates."""
-        self.assertEqual(
-            brms.ProcessKieSearchCandidates.process(
-                "QPC_FORCE_POST_PROCESS",
-                {
-                    "internal_jboss_brms_kie_server_candidates": ansible_result(
-                        "a\nb\nc"
-                    )
-                },
-            ),
-            ["a", "b", "c"],
-        )
+        assert brms.ProcessKieSearchCandidates.process(
+            "QPC_FORCE_POST_PROCESS",
+            {"internal_jboss_brms_kie_server_candidates": ansible_result("a\nb\nc")},
+        ) == ["a", "b", "c"]
 
     def test_not_found(self):
         """Did not find candidates."""
-        self.assertEqual(
+        assert (
             brms.ProcessKieSearchCandidates.process(
                 "QPC_FORCE_POST_PROCESS",
                 {"internal_jboss_brms_kie_server_candidates": ansible_result("")},
-            ),
-            [],
+            )
+            == []
         )

--- a/quipucords/scanner/network/processing/test_cloud_provider.py
+++ b/quipucords/scanner/network/processing/test_cloud_provider.py
@@ -13,36 +13,36 @@ class TestProcessDmiChassisAssetTag(unittest.TestCase):
     def test_success_case(self):
         """Found dmi chassis asset tag."""
         dependencies = {"internal_dmi_chassis_asset_tag": ansible_result("a\nb\nc")}
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiChassisAssetTag.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "a",
+            )
+            == "a"
         )
         # stdout_lines looks like ['', 'b']
         dependencies["internal_dmi_chassis_asset_tag"] = ansible_result("\nb\n")
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiChassisAssetTag.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "b",
+            )
+            == "b"
         )
         dependencies["internal_dmi_chassis_asset_tag"] = ansible_result("Failed", 1)
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiChassisAssetTag.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
 
     def test_not_found(self):
         """Did not find dmi chassis asset tag."""
         dependencies = {}
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiChassisAssetTag.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
 
 
@@ -52,36 +52,36 @@ class TestProcessDmiSystemProductName(unittest.TestCase):
     def test_success_case(self):
         """Found dmi system product name."""
         dependencies = {"internal_dmi_system_product_name": ansible_result("a\nb\nc")}
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiSystemProductName.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "a",
+            )
+            == "a"
         )
         # stdout_lines looks like ['', 'b']
         dependencies["internal_dmi_system_product_name"] = ansible_result("\nb\n")
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiSystemProductName.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "b",
+            )
+            == "b"
         )
         dependencies["internal_dmi_system_product_name"] = ansible_result("Failed", 1)
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiSystemProductName.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
 
     def test_not_found(self):
         """Did not find dmi system product name."""
         dependencies = {}
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessDmiSystemProductName.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
 
 
@@ -91,56 +91,56 @@ class TestProcessCloudProvider(unittest.TestCase):
     def test_success_case(self):
         """Found cpu model ver."""
         dependencies = {"dmi_bios_version": "3.4.3.amazon"}
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            cloud_provider.AMAZON,
+            )
+            == cloud_provider.AMAZON
         )
         dependencies["dmi_bios_version"] = "6.0"
         dependencies[
             "dmi_chassis_asset_tag"
         ] = "Asset Tag: 7783-7084-3265-9085-8269-3286-77"
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            cloud_provider.AZURE,
+            )
+            == cloud_provider.AZURE
         )
         dependencies["dmi_bios_version"] = "Google, 1.2.6"
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            cloud_provider.GOOGLE,
+            )
+            == cloud_provider.GOOGLE
         )
         dependencies["dmi_bios_version"] = "6.0"
         dependencies["dmi_system_manufacturer"] = "Alibaba Cloud"
         dependencies["dmi_chassis_asset_tag"] = "Asset Tag: No Asset Tag"
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            cloud_provider.ALIBABA,
+            )
+            == cloud_provider.ALIBABA
         )
         dependencies["dmi_system_manufacturer"] = "empty"
         dependencies["dmi_system_product_name"] = "	Alibaba Cloud ECS"
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            cloud_provider.ALIBABA,
+            )
+            == cloud_provider.ALIBABA
         )
 
     def test_not_found(self):
         """Did not find any dmi facts to compute the cloud provider."""
         # no deps
         dependencies = {}
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
         # deps indicate no cloud provider
         dependencies["dmi_bios_version"] = "6.0"
@@ -149,9 +149,9 @@ class TestProcessCloudProvider(unittest.TestCase):
             "dmi_system_product_name"
         ] = "Product Name: VMware Virtual Platform"
         dependencies["dmi_system_manufacturer"] = "VMWare, Inc."
-        self.assertEqual(
+        assert (
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )

--- a/quipucords/scanner/network/processing/test_cpu.py
+++ b/quipucords/scanner/network/processing/test_cpu.py
@@ -12,13 +12,11 @@ class TestProcessCpuModelVer(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu model ver."""
-        self.assertEqual(cpu.ProcessCpuModelVer.process(ansible_result("a\nb\nc")), "a")
+        assert cpu.ProcessCpuModelVer.process(ansible_result("a\nb\nc")) == "a"
 
     def test_not_found(self):
         """Did not find cpu model ver."""
-        self.assertEqual(
-            cpu.ProcessCpuModelVer.process(ansible_result("")), process.NO_DATA
-        )
+        assert cpu.ProcessCpuModelVer.process(ansible_result("")) == process.NO_DATA
 
 
 class TestProcessCpuCpuFamily(unittest.TestCase):
@@ -26,15 +24,11 @@ class TestProcessCpuCpuFamily(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu family."""
-        self.assertEqual(
-            cpu.ProcessCpuCpuFamily.process(ansible_result("a\nb\nc")), "a"
-        )
+        assert cpu.ProcessCpuCpuFamily.process(ansible_result("a\nb\nc")) == "a"
 
     def test__not_found(self):
         """Did not find cpu family."""
-        self.assertEqual(
-            cpu.ProcessCpuCpuFamily.process(ansible_result("")), process.NO_DATA
-        )
+        assert cpu.ProcessCpuCpuFamily.process(ansible_result("")) == process.NO_DATA
 
 
 class TestProcessCpuVendorId(unittest.TestCase):
@@ -42,13 +36,11 @@ class TestProcessCpuVendorId(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu vendor id."""
-        self.assertEqual(cpu.ProcessCpuVendorId.process(ansible_result("a\nb\nc")), "a")
+        assert cpu.ProcessCpuVendorId.process(ansible_result("a\nb\nc")) == "a"
 
     def test__not_found(self):
         """Did not find cpu vendor id."""
-        self.assertEqual(
-            cpu.ProcessCpuVendorId.process(ansible_result("")), process.NO_DATA
-        )
+        assert cpu.ProcessCpuVendorId.process(ansible_result("")) == process.NO_DATA
 
 
 class TestProcessCpuModelName(unittest.TestCase):
@@ -56,15 +48,11 @@ class TestProcessCpuModelName(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu model name."""
-        self.assertEqual(
-            cpu.ProcessCpuModelName.process(ansible_result("a\nb\nc")), "a"
-        )
+        assert cpu.ProcessCpuModelName.process(ansible_result("a\nb\nc")) == "a"
 
     def test__not_found(self):
         """Did not find cpu model name."""
-        self.assertEqual(
-            cpu.ProcessCpuModelName.process(ansible_result("")), process.NO_DATA
-        )
+        assert cpu.ProcessCpuModelName.process(ansible_result("")) == process.NO_DATA
 
 
 class TestProcessCpuBogomips(unittest.TestCase):
@@ -72,13 +60,11 @@ class TestProcessCpuBogomips(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu bogomips."""
-        self.assertEqual(cpu.ProcessCpuBogomips.process(ansible_result("a\nb\nc")), "a")
+        assert cpu.ProcessCpuBogomips.process(ansible_result("a\nb\nc")) == "a"
 
     def test__not_found(self):
         """Did not find cpu bogomips."""
-        self.assertEqual(
-            cpu.ProcessCpuBogomips.process(ansible_result("")), process.NO_DATA
-        )
+        assert cpu.ProcessCpuBogomips.process(ansible_result("")) == process.NO_DATA
 
 
 class TestProcessCpuSocketCount(unittest.TestCase):
@@ -93,8 +79,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "Status: Unpopulated\r\n"
         )
         dependencies = {"internal_cpu_socket_count_dmi": ansible_result(one_dmi_result)}
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 1
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 1
         )
 
     def test_dmiresult_contains_no_enabled_sockets(self):
@@ -109,8 +96,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_dmi": ansible_result(no_dmi_result),
             "internal_cpu_socket_count_cpuinfo": ansible_result("2"),
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 2
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 2
         )
 
     def test_dmiresult_contains_nonint_characters(self):
@@ -119,8 +107,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_dmi": ansible_result("Permission Denied."),
             "internal_cpu_socket_count_cpuinfo": ansible_result("2"),
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 2
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 2
         )
 
     def test_dmiresult_cpuinfo_fails(self):
@@ -130,15 +119,17 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_cpuinfo": ansible_result(""),
             "cpu_count": "4",
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 4
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 4
         )
 
     def test_dmiresult_cpuinfo_not_in_dependencies(self):
         """Test that we use cpu count when the dependencies are None."""
         dependencies = {"cpu_count": "4"}
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 4
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 4
         )
 
     def test_dmiresult_cpuinfo_failed_tasks(self):
@@ -148,8 +139,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_cpuinfo": ansible_result("Failed", 1),
             "cpu_count": "4",
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 4
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 4
         )
 
     def test_cpuinfo_failed_value_error(self):
@@ -159,8 +151,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_cpuinfo": ansible_result("Failure"),
             "cpu_count": "1",
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 1
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 1
         )
 
     def test_cpuinfo_failed_return_none(self):
@@ -169,9 +162,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_dmi": ansible_result("Permission Denied."),
             "internal_cpu_socket_count_cpuinfo": ansible_result("Failure"),
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies),
-            None,
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            is None
         )
 
     def test_dmiresult_greater_than_8(self):
@@ -181,8 +174,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_cpuinfo": ansible_result("9"),
             "cpu_count": "3",
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 3
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 3
         )
 
     def test_dmiresult_equal_to_8(self):
@@ -210,8 +204,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_cpuinfo": ansible_result("9"),
             "cpu_count": "3",
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 8
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 8
         )
 
     def test_cpuinfo_equal_to_8(self):
@@ -221,8 +216,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_cpuinfo": ansible_result("8"),
             "cpu_count": "3",
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies), 8
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 8
         )
 
     def test_cpu_count_greater_than_8(self):
@@ -232,9 +228,9 @@ class TestProcessCpuSocketCount(unittest.TestCase):
             "internal_cpu_socket_count_cpuinfo": ansible_result("9"),
             "cpu_count": "12",
         }
-        self.assertEqual(
-            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies),
-            12,
+        assert (
+            cpu.ProcessCpuSocketCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 12
         )
 
 
@@ -244,8 +240,8 @@ class TestProcessCpuCoreCount(unittest.TestCase):
     def test_core_count_success(self):
         """Test the cc when virt_type is None and cpu per socket is defined."""
         dependencies = {"cpu_core_per_socket": 2, "cpu_socket_count": 2}
-        self.assertEqual(
-            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies), 4
+        assert (
+            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies) == 4
         )
 
     def test_core_count_success_with_virt_type(self):
@@ -256,8 +252,8 @@ class TestProcessCpuCoreCount(unittest.TestCase):
             "cpu_count": 3,
             "virt_type": "vmware",
         }
-        self.assertEqual(
-            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies), 3
+        assert (
+            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies) == 3
         )
 
     def test_core_count_success_with_hyperthreading(self):
@@ -267,8 +263,9 @@ class TestProcessCpuCoreCount(unittest.TestCase):
             "cpu_count": 3,
             "cpu_hyperthreading": True,
         }
-        self.assertEqual(
-            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies), 1.5
+        assert (
+            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == 1.5
         )
 
     def test_core_count_success_without_hyperthreading(self):
@@ -278,14 +275,14 @@ class TestProcessCpuCoreCount(unittest.TestCase):
             "cpu_count": 3,
             "cpu_hyperthreading": False,
         }
-        self.assertEqual(
-            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies), 3
+        assert (
+            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies) == 3
         )
 
     def test_core_count_return_empty_string(self):
         """Test the core count is set to '' when deps not available."""
         dependencies = {}
-        self.assertEqual(
-            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies),
-            None,
+        assert (
+            cpu.ProcessCpuCoreCount.process("QPC_FORCE_POST_PROCESS", dependencies)
+            is None
         )

--- a/quipucords/scanner/network/processing/test_date.py
+++ b/quipucords/scanner/network/processing/test_date.py
@@ -12,13 +12,11 @@ class TestProcessDateDate(unittest.TestCase):
 
     def test_success_case(self):
         """Found date."""
-        self.assertEqual(date.ProcessDateDate.process(ansible_result("a\nb\nc")), "a")
+        assert date.ProcessDateDate.process(ansible_result("a\nb\nc")) == "a"
 
     def test_not_found(self):
         """Did not find date."""
-        self.assertEqual(
-            date.ProcessDateDate.process(ansible_result("")), process.NO_DATA
-        )
+        assert date.ProcessDateDate.process(ansible_result("")) == process.NO_DATA
 
 
 class ProcessDateFilesystemCreate(unittest.TestCase):
@@ -26,15 +24,15 @@ class ProcessDateFilesystemCreate(unittest.TestCase):
 
     def test_success_case(self):
         """Found date file system create."""
-        self.assertEqual(
-            date.ProcessDateFilesystemCreate.process(ansible_result("a\nb\nc")), "a"
+        assert (
+            date.ProcessDateFilesystemCreate.process(ansible_result("a\nb\nc")) == "a"
         )
 
     def test_not_found(self):
         """Did not find date file system create."""
-        self.assertEqual(
-            date.ProcessDateFilesystemCreate.process(ansible_result("")),
-            process.NO_DATA,
+        assert (
+            date.ProcessDateFilesystemCreate.process(ansible_result(""))
+            == process.NO_DATA
         )
 
 
@@ -43,15 +41,11 @@ class ProcessDateMachineId(unittest.TestCase):
 
     def test_success_case(self):
         """Found date machine id."""
-        self.assertEqual(
-            date.ProcessDateMachineId.process(ansible_result("a\nb\nc")), "a"
-        )
+        assert date.ProcessDateMachineId.process(ansible_result("a\nb\nc")) == "a"
 
     def test_not_found(self):
         """Did not find date file system create."""
-        self.assertEqual(
-            date.ProcessDateMachineId.process(ansible_result("")), process.NO_DATA
-        )
+        assert date.ProcessDateMachineId.process(ansible_result("")) == process.NO_DATA
 
 
 class ProcessDateYumHistory(unittest.TestCase):
@@ -59,13 +53,11 @@ class ProcessDateYumHistory(unittest.TestCase):
 
     def test_success_case(self):
         """Found date yum history."""
-        self.assertEqual(
-            date.ProcessDateYumHistory.process(ansible_result("\n2017-07-25")),
-            "2017-07-25",
+        assert (
+            date.ProcessDateYumHistory.process(ansible_result("\n2017-07-25"))
+            == "2017-07-25"
         )
 
     def test_not_found(self):
         """Did not find date yum history."""
-        self.assertEqual(
-            date.ProcessDateYumHistory.process(ansible_result("")), process.NO_DATA
-        )
+        assert date.ProcessDateYumHistory.process(ansible_result("")) == process.NO_DATA

--- a/quipucords/scanner/network/processing/test_dmi.py
+++ b/quipucords/scanner/network/processing/test_dmi.py
@@ -14,37 +14,41 @@ class TestProcessDmiSystemUuidr(unittest.TestCase):
         """Test multiple dmi_system_uuid values."""
         # stdout_lines looks like ['a', 'b', 'c']
         dependencies = {"internal_dmi_system_uuid": ansible_result("a\nb\nc")}
-        self.assertEqual(
-            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies),
-            "a",
+        assert (
+            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == "a"
         )
         # stdout_lines looks like ['', 'b']
         dependencies["internal_dmi_system_uuid"] = ansible_result("\nb\n")
-        self.assertEqual(
-            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies),
-            "b",
+        assert (
+            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == "b"
         )
         dependencies["internal_dmi_system_uuid"] = ansible_result("Failed", 1)
-        self.assertEqual(
-            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies), ""
+        assert (
+            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == ""
         )
 
     def test_invalid_uuid_case(self):
         """Test dmi_system_uuid too long."""
         # stdout_lines looks like ['a', 'b', 'c']
         dependencies = {"internal_dmi_system_uuid": ansible_result(f"{'a' * 37}\nb\nc")}
-        self.assertEqual(
-            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies), ""
+        assert (
+            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == ""
         )
         # stdout_lines looks like ['', 'b']
         dependencies["internal_dmi_system_uuid"] = ansible_result(f"\n{'b' * 37}\n")
-        self.assertEqual(
-            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies), ""
+        assert (
+            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == ""
         )
 
     def test_not_found(self):
         """Did not find dmi system uuid."""
         dependencies = {}
-        self.assertEqual(
-            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies), ""
+        assert (
+            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies)
+            == ""
         )

--- a/quipucords/scanner/network/processing/test_eap.py
+++ b/quipucords/scanner/network/processing/test_eap.py
@@ -17,15 +17,15 @@ class TestProcessJbossEapRunningPaths(unittest.TestCase):
 
     def test_success_case(self):
         """Strip spaces from good input."""
-        self.assertEqual(
-            eap.ProcessJbossEapRunningPaths.process(ansible_result(" good ")), ["good"]
-        )
+        assert eap.ProcessJbossEapRunningPaths.process(ansible_result(" good ")) == [
+            "good"
+        ]
 
     def test_find_warning(self):
         """Fail if we get the special find warning string."""
-        self.assertEqual(
-            eap.ProcessJbossEapRunningPaths.process(ansible_result(eap.FIND_WARNING)),
-            process.NO_DATA,
+        assert (
+            eap.ProcessJbossEapRunningPaths.process(ansible_result(eap.FIND_WARNING))
+            == process.NO_DATA
         )
 
 
@@ -34,9 +34,11 @@ class TestProcessFindJboss(unittest.TestCase):
 
     def test_success_case(self):
         """Return stdout_lines in case of success."""
-        self.assertEqual(
-            eap.ProcessFindJboss.process(ansible_result("a\nb\nc")), ["a", "b", "c"]
-        )
+        assert eap.ProcessFindJboss.process(ansible_result("a\nb\nc")) == [
+            "a",
+            "b",
+            "c",
+        ]
 
 
 class TestProcessIdUJboss(unittest.TestCase):
@@ -44,22 +46,20 @@ class TestProcessIdUJboss(unittest.TestCase):
 
     def test_user_found(self):
         """'id' found the user."""
-        self.assertEqual(eap.ProcessIdUJboss.process(ansible_result("11111")), True)
+        assert eap.ProcessIdUJboss.process(ansible_result("11111")) is True
 
     def test_no_such_user(self):
         """'id' did not find the user."""
-        self.assertEqual(
-            eap.ProcessIdUJboss.process(
-                ansible_result("id: jboss: no such user", rc=1)
-            ),
-            False,
+        assert (
+            eap.ProcessIdUJboss.process(ansible_result("id: jboss: no such user", rc=1))
+            is False
         )
 
     def test_unknown_error(self):
         """'id' returned an error."""
-        self.assertEqual(
-            eap.ProcessIdUJboss.process(ansible_result("something went wrong!", rc=1)),
-            process.NO_DATA,
+        assert (
+            eap.ProcessIdUJboss.process(ansible_result("something went wrong!", rc=1))
+            == process.NO_DATA
         )
 
 
@@ -68,18 +68,15 @@ class TestProcessJbossCommonFiles(unittest.TestCase):
 
     def test_three_states(self):
         """Test one file found, one not found, and one skipped."""
-        self.assertEqual(
-            eap.ProcessJbossEapCommonFiles.process(
-                {
-                    "results": [
-                        {"item": "dir1", "skipped": True},
-                        {"item": "dir2", "rc": 1},
-                        {"item": "dir3", "rc": 0},
-                    ]
-                }
-            ),
-            ["dir3"],
-        )
+        assert eap.ProcessJbossEapCommonFiles.process(
+            {
+                "results": [
+                    {"item": "dir1", "skipped": True},
+                    {"item": "dir2", "rc": 1},
+                    {"item": "dir3", "rc": 0},
+                ]
+            }
+        ) == ["dir3"]
 
 
 class TestProcessJbossProcesses(unittest.TestCase):
@@ -87,23 +84,21 @@ class TestProcessJbossProcesses(unittest.TestCase):
 
     def test_no_processes(self):
         """No processes found."""
-        self.assertEqual(eap.ProcessJbossProcesses.process(ansible_result("")), 0)
+        assert eap.ProcessJbossProcesses.process(ansible_result("")) == 0
 
     def test_found_processes(self):
         """Found one process."""
-        self.assertEqual(
-            eap.ProcessJbossProcesses.process(ansible_result("java\nbash\ngrep")), 1
+        assert (
+            eap.ProcessJbossProcesses.process(ansible_result("java\nbash\ngrep")) == 1
         )
 
     def test_no_grep(self):
         """Grep sometimes doesn't appear in the ps output."""
-        self.assertEqual(
-            eap.ProcessJbossProcesses.process(ansible_result("java\nbash")), 1
-        )
+        assert eap.ProcessJbossProcesses.process(ansible_result("java\nbash")) == 1
 
     def test_bad_rc(self):
         """Test that a bad return code returns 0 processes."""
-        self.assertEqual(eap.ProcessJbossProcesses.process({"results": [{"rc": 1}]}), 0)
+        assert eap.ProcessJbossProcesses.process({"results": [{"rc": 1}]}) == 0
 
 
 class TestProcessJbossEapPackages(unittest.TestCase):
@@ -111,13 +106,11 @@ class TestProcessJbossEapPackages(unittest.TestCase):
 
     def test_found_packages(self):
         """Found some packages."""
-        self.assertEqual(
-            eap.ProcessJbossEapPackages.process(ansible_result("a\nb\nc")), 3
-        )
+        assert eap.ProcessJbossEapPackages.process(ansible_result("a\nb\nc")) == 3
 
     def test_no_packages(self):
         """No RPMs found."""
-        self.assertEqual(eap.ProcessJbossEapPackages.process(ansible_result("")), 0)
+        assert eap.ProcessJbossEapPackages.process(ansible_result("")) == 0
 
 
 class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):
@@ -125,14 +118,15 @@ class TestProcessJbossLocateJbossModulesJar(unittest.TestCase):
 
     def test_success(self):
         """Found jboss-modules.jar."""
-        self.assertEqual(
-            eap.ProcessJbossEapLocate.process(ansible_result("a\nb\nc")),
-            ["a", "b", "c"],
-        )
+        assert eap.ProcessJbossEapLocate.process(ansible_result("a\nb\nc")) == [
+            "a",
+            "b",
+            "c",
+        ]
 
     def test_not_found(self):
         """Did not find jboss-modules.jar."""
-        self.assertEqual(eap.ProcessJbossEapLocate.process(ansible_result("")), [])
+        assert eap.ProcessJbossEapLocate.process(ansible_result("")) == []
 
 
 class TestProcessEapHomeLs(unittest.TestCase):
@@ -153,30 +147,27 @@ class TestProcessEapHomeLs(unittest.TestCase):
             "SHA256SUM",
         ]
 
-        self.assertEqual(
-            eap.ProcessEapHomeLs.process(
-                ansible_results(
-                    [
-                        # dir1: ls was successful, directory has JBoss files.
-                        {
-                            "item": "dir1",
-                            "stdout": "\n".join(
-                                extra_files + eap.ProcessEapHomeLs.INDICATOR_FILES
-                            ),
-                        },
-                        # dir2: ls was unsuccessful. Output should be ignored.
-                        {
-                            "item": "dir2",
-                            "rc": 1,
-                            "stdout": "\n".join(eap.ProcessEapHomeLs.INDICATOR_FILES),
-                        },
-                        # dir3: ls was successful, directory has no JBoss files.
-                        {"item": "dir3", "stdout": "\n".join(extra_files)},
-                    ]
-                )
-            ),
-            {"dir1": eap.ProcessEapHomeLs.INDICATOR_FILES, "dir2": [], "dir3": []},
-        )
+        assert eap.ProcessEapHomeLs.process(
+            ansible_results(
+                [
+                    # dir1: ls was successful, directory has JBoss files.
+                    {
+                        "item": "dir1",
+                        "stdout": "\n".join(
+                            extra_files + eap.ProcessEapHomeLs.INDICATOR_FILES
+                        ),
+                    },
+                    # dir2: ls was unsuccessful. Output should be ignored.
+                    {
+                        "item": "dir2",
+                        "rc": 1,
+                        "stdout": "\n".join(eap.ProcessEapHomeLs.INDICATOR_FILES),
+                    },
+                    # dir3: ls was successful, directory has no JBoss files.
+                    {"item": "dir3", "stdout": "\n".join(extra_files)},
+                ]
+            )
+        ) == {"dir1": eap.ProcessEapHomeLs.INDICATOR_FILES, "dir2": [], "dir3": []}
 
 
 class TestProcessEapHomeVersionTxt(unittest.TestCase):
@@ -186,21 +177,18 @@ class TestProcessEapHomeVersionTxt(unittest.TestCase):
 
     def test_three_dirs(self):
         """A directory can have three outcomes."""
-        self.assertEqual(
-            eap.ProcessEapHomeVersionTxt.process(
-                ansible_results(
-                    [
-                        # dir1: cat was successful, stdout has 'Red Hat' in it.
-                        {"item": "dir1", "stdout": self.cat_result},
-                        # dir2: cat was unsuccessful. Output should be ignored.
-                        {"item": "dir2", "rc": 1, "stdout": self.cat_result},
-                        # dir3: cat was successful, output does not have 'Red Hat'.
-                        {"item": "dir3", "stdout": "foo"},
-                    ]
-                )
-            ),
-            {"dir1": "6.4.0", "dir2": False, "dir3": "foo"},
-        )
+        assert eap.ProcessEapHomeVersionTxt.process(
+            ansible_results(
+                [
+                    # dir1: cat was successful, stdout has 'Red Hat' in it.
+                    {"item": "dir1", "stdout": self.cat_result},
+                    # dir2: cat was unsuccessful. Output should be ignored.
+                    {"item": "dir2", "rc": 1, "stdout": self.cat_result},
+                    # dir3: cat was successful, output does not have 'Red Hat'.
+                    {"item": "dir3", "stdout": "foo"},
+                ]
+            )
+        ) == {"dir1": "6.4.0", "dir2": False, "dir3": "foo"}
 
 
 class TestProcessJbossEapInitFiles(unittest.TestCase):
@@ -211,11 +199,8 @@ class TestProcessJbossEapInitFiles(unittest.TestCase):
     def test_no_jboss(self):
         """No 'jboss' or 'eap' found."""
         for processor in self.processors:
-            self.assertEqual(
-                # Blank line in input to check that processor will skip it.
-                processor.process(ansible_result("foo\nbar\n\nbaz")),
-                [],
-            )
+            # Blank line in input to check that processor will skip it.
+            assert processor.process(ansible_result("foo\nbar\n\nbaz")) == []
 
     def test_jboss(self):
         """'jboss' found."""
@@ -223,18 +208,16 @@ class TestProcessJbossEapInitFiles(unittest.TestCase):
         # and that it does *not* return the 'baz jboss' line, becuase
         # in that line 'jboss' is not in the first piece.
         for processor in self.processors:
-            self.assertEqual(
-                processor.process(ansible_result("  foo\n  jboss bar\n  baz jboss")),
-                ["jboss bar"],
-            )
+            assert processor.process(
+                ansible_result("  foo\n  jboss bar\n  baz jboss")
+            ) == ["jboss bar"]
 
     def test_eap(self):
         """'eap' found."""
         for processor in self.processors:
-            self.assertEqual(
-                processor.process(ansible_result("  foo\n  eap bar\n  baz eap")),
-                ["eap bar"],
-            )
+            assert processor.process(ansible_result("  foo\n  eap bar\n  baz eap")) == [
+                "eap bar"
+            ]
 
 
 class TestProcessEapHomeBinForFuse(unittest.TestCase):
@@ -249,7 +232,7 @@ class TestProcessEapHomeBinForFuse(unittest.TestCase):
         )
         expected_result = {"/some/dir": []}
         actual_result = eap.ProcessEapHomeBinForFuse.process(processor_input)
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result
 
     def test_fuse_is_found(self):
         """Test successfully finding a fuse script."""
@@ -264,7 +247,7 @@ class TestProcessEapHomeBinForFuse(unittest.TestCase):
             "/some/dir": eap.ProcessEapHomeBinForFuse.INDICATOR_FILES[:-1]
         }
         actual_result = eap.ProcessEapHomeBinForFuse.process(processor_input)
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result
 
 
 class TestItemSuccessChecker(unittest.TestCase):
@@ -272,14 +255,14 @@ class TestItemSuccessChecker(unittest.TestCase):
 
     def test_success(self):
         """Found eap home layers."""
-        self.assertEqual(
-            eap.ItemSuccessChecker.process_item(ansible_item("foo", "bin/fuse")), True
+        assert (
+            eap.ItemSuccessChecker.process_item(ansible_item("foo", "bin/fuse")) is True
         )
 
     def test_not_found(self):
         """Did not find eap home layers."""
-        self.assertEqual(
-            eap.ItemSuccessChecker.process_item(ansible_item("foo", "", rc=1)), False
+        assert (
+            eap.ItemSuccessChecker.process_item(ansible_item("foo", "", rc=1)) is False
         )
 
 
@@ -288,21 +271,15 @@ class TestProcessEapHomeLayersConf(unittest.TestCase):
 
     def test_success(self):
         """Found eap home layers conf."""
-        self.assertEqual(
-            eap.ProcessEapHomeLayersConf.process(
-                ansible_results([{"item": "foo", "stdout": "bin/fuse"}])
-            ),
-            {"foo": True},
-        )
+        assert eap.ProcessEapHomeLayersConf.process(
+            ansible_results([{"item": "foo", "stdout": "bin/fuse"}])
+        ) == {"foo": True}
 
     def test_not_found(self):
         """Did not find eap home layers conf."""
-        self.assertEqual(
-            eap.ProcessEapHomeLayersConf.process(
-                ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            {"foo": False},
-        )
+        assert eap.ProcessEapHomeLayersConf.process(
+            ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
+        ) == {"foo": False}
 
 
 class TestProcessFindJbossEAPJarVer(unittest.TestCase):
@@ -316,10 +293,11 @@ class TestProcessFindJbossEAPJarVer(unittest.TestCase):
             "1.3.6.Final-redhat-1**2018-01-18\n"
         )
         expected = {"version": "1.3.6.Final-redhat-1", "date": "2018-01-18"}
-        self.assertEqual(
-            eap.ProcessFindJbossEAPJarVer.process(ansible_result(in_line)),
-            [expected, expected, expected],
-        )
+        assert eap.ProcessFindJbossEAPJarVer.process(ansible_result(in_line)) == [
+            expected,
+            expected,
+            expected,
+        ]
 
 
 class TestProcessFindJbossEAPRunJarVer(unittest.TestCase):
@@ -333,7 +311,8 @@ class TestProcessFindJbossEAPRunJarVer(unittest.TestCase):
             "1.3.6.Final-redhat-1**2018-01-18\n"
         )
         expected = {"version": "1.3.6.Final-redhat-1", "date": "2018-01-18"}
-        self.assertEqual(
-            eap.ProcessFindJbossEAPRunJarVer.process(ansible_result(in_line)),
-            [expected, expected, expected],
-        )
+        assert eap.ProcessFindJbossEAPRunJarVer.process(ansible_result(in_line)) == [
+            expected,
+            expected,
+            expected,
+        ]

--- a/quipucords/scanner/network/processing/test_fuse.py
+++ b/quipucords/scanner/network/processing/test_fuse.py
@@ -14,10 +14,10 @@ class TestProcessFindJbossActiveMQJar(unittest.TestCase):
     def test_success_case(self):
         """Return stdout_lines in case of success."""
         in_line = "redhat-620133; redhat-630187\n"
-        self.assertEqual(
-            fuse.ProcessFindJbossActiveMQJar.process(ansible_result(in_line)),
-            ["redhat-620133", "redhat-630187"],
-        )
+        assert fuse.ProcessFindJbossActiveMQJar.process(ansible_result(in_line)) == [
+            "redhat-620133",
+            "redhat-630187",
+        ]
 
 
 class TestProcessFindJbossCamelJar(unittest.TestCase):
@@ -26,10 +26,10 @@ class TestProcessFindJbossCamelJar(unittest.TestCase):
     def test_success_case(self):
         """Return stdout_lines in case of success."""
         in_line = "redhat-620133; redhat-630187\n"
-        self.assertEqual(
-            fuse.ProcessFindJbossCamelJar.process(ansible_result(in_line)),
-            ["redhat-620133", "redhat-630187"],
-        )
+        assert fuse.ProcessFindJbossCamelJar.process(ansible_result(in_line)) == [
+            "redhat-620133",
+            "redhat-630187",
+        ]
 
 
 class TestProcessFindJbossCXFJar(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestProcessFindJbossCXFJar(unittest.TestCase):
     def test_success_case(self):
         """Return stdout_lines in case of success."""
         in_line = "redhat-620133; redhat-630187\n"
-        self.assertEqual(
-            fuse.ProcessFindJbossCXFJar.process(ansible_result(in_line)),
-            ["redhat-620133", "redhat-630187"],
-        )
+        assert fuse.ProcessFindJbossCXFJar.process(ansible_result(in_line)) == [
+            "redhat-620133",
+            "redhat-630187",
+        ]

--- a/quipucords/scanner/network/processing/test_ifconfig.py
+++ b/quipucords/scanner/network/processing/test_ifconfig.py
@@ -12,14 +12,13 @@ class TestProcessIPAddresses(unittest.TestCase):
 
     def test_success_case(self):
         """Found IP."""
-        self.assertEqual(
-            ifconfig.ProcessIPAddresses.process(ansible_result("inet addr: 1.2.3.4")),
-            ["1.2.3.4"],
-        )
+        assert ifconfig.ProcessIPAddresses.process(
+            ansible_result("inet addr: 1.2.3.4")
+        ) == ["1.2.3.4"]
 
     def test_not_found(self):
         """Did not find IP."""
-        self.assertEqual(ifconfig.ProcessIPAddresses.process(ansible_result("")), [])
+        assert ifconfig.ProcessIPAddresses.process(ansible_result("")) == []
 
 
 class TestProcessMacAddresses(unittest.TestCase):
@@ -27,11 +26,10 @@ class TestProcessMacAddresses(unittest.TestCase):
 
     def test_success_case(self):
         """Found mac address."""
-        self.assertEqual(
-            ifconfig.ProcessMacAddresses.process(ansible_result("00:10:20:3a:40:b5")),
-            ["00:10:20:3a:40:b5"],
-        )
+        assert ifconfig.ProcessMacAddresses.process(
+            ansible_result("00:10:20:3a:40:b5")
+        ) == ["00:10:20:3a:40:b5"]
 
     def test_not_found(self):
         """Did not find mac address."""
-        self.assertEqual(ifconfig.ProcessMacAddresses.process(ansible_result("")), [])
+        assert ifconfig.ProcessMacAddresses.process(ansible_result("")) == []

--- a/quipucords/scanner/network/processing/test_jws.py
+++ b/quipucords/scanner/network/processing/test_jws.py
@@ -13,18 +13,18 @@ class TestProcessJWSInstalledWithRpm(unittest.TestCase):
 
     def test_installed_with_rpm(self):
         """Return true if jws was installed with rpm."""
-        self.assertEqual(
+        assert (
             jws.ProcessJWSInstalledWithRpm.process(
                 ansible_result("Red Hat JBoss Web Server")
-            ),
-            True,
+            )
+            is True
         )
 
     def test_not_installed_with_rpm(self):
         """Return false if jws was not installed with rpm."""
-        self.assertEqual(
-            jws.ProcessJWSInstalledWithRpm.process(ansible_result("Not installed")),
-            False,
+        assert (
+            jws.ProcessJWSInstalledWithRpm.process(ansible_result("Not installed"))
+            is False
         )
 
 
@@ -33,13 +33,11 @@ class TestProcessHasJBossEula(unittest.TestCase):
 
     def test_has_eula_file(self):
         """Return true if jboss eula file exists."""
-        self.assertEqual(jws.ProcessHasJBossEULA.process(ansible_result("true")), True)
+        assert jws.ProcessHasJBossEULA.process(ansible_result("true")) is True
 
     def test_has_no_eula_file(self):
         """Return false if jboss eula file does not exist."""
-        self.assertEqual(
-            jws.ProcessHasJBossEULA.process(ansible_result("false")), False
-        )
+        assert jws.ProcessHasJBossEULA.process(ansible_result("false")) is False
 
 
 class TestProcessTomcatPartOfRedhatProduct(unittest.TestCase):
@@ -47,14 +45,15 @@ class TestProcessTomcatPartOfRedhatProduct(unittest.TestCase):
 
     def test_true(self):
         """Return True if tomcat was installed as part of a redhat product."""
-        self.assertEqual(
-            jws.ProcessTomcatPartOfRedhatProduct.process(ansible_result("True")), True
+        assert (
+            jws.ProcessTomcatPartOfRedhatProduct.process(ansible_result("True")) is True
         )
 
     def test_false(self):
         """Return False if tomcat is not part of a redhat product."""
-        self.assertEqual(
-            jws.ProcessTomcatPartOfRedhatProduct.process(ansible_result("False")), False
+        assert (
+            jws.ProcessTomcatPartOfRedhatProduct.process(ansible_result("False"))
+            is False
         )
 
 
@@ -63,11 +62,11 @@ class TestProcessJWSHasCert(unittest.TestCase):
 
     def test_true(self):
         """Return True if /etc/pki/product/185.pem exists."""
-        self.assertEqual(
-            jws.ProcessJWSHasCert.process(ansible_result("/etc/pki/product/185.pem")),
-            True,
+        assert (
+            jws.ProcessJWSHasCert.process(ansible_result("/etc/pki/product/185.pem"))
+            is True
         )
 
     def test_false(self):
         """Return False if /etc/pki/product/185.pem does not exist."""
-        self.assertEqual(jws.ProcessJWSHasCert.process(ansible_result("")), False)
+        assert jws.ProcessJWSHasCert.process(ansible_result("")) is False

--- a/quipucords/scanner/network/processing/test_karaf.py
+++ b/quipucords/scanner/network/processing/test_karaf.py
@@ -13,17 +13,18 @@ class TestProcessKarafRunningProcesses(unittest.TestCase):
 
     def test_success_case(self):
         """Strip spaces from good input."""
-        self.assertEqual(
-            karaf.ProcessKarafRunningProcesses.process(ansible_result(" good ")), "good"
+        assert (
+            karaf.ProcessKarafRunningProcesses.process(ansible_result(" good "))
+            == "good"
         )
 
     def test_find_warning(self):
         """Fail if we get the special find warning string."""
-        self.assertEqual(
+        assert (
             karaf.ProcessKarafRunningProcesses.process(
                 ansible_result(karaf.FIND_WARNING)
-            ),
-            process.NO_DATA,
+            )
+            == process.NO_DATA
         )
 
 
@@ -32,9 +33,11 @@ class TestProcessFindKaraf(unittest.TestCase):
 
     def test_success_case(self):
         """Return stdout_lines in case of success."""
-        self.assertEqual(
-            karaf.ProcessFindKaraf.process(ansible_result("a\nb\nc")), ["a", "b", "c"]
-        )
+        assert karaf.ProcessFindKaraf.process(ansible_result("a\nb\nc")) == [
+            "a",
+            "b",
+            "c",
+        ]
 
 
 class TestProcessLocateKaraf(unittest.TestCase):
@@ -42,13 +45,15 @@ class TestProcessLocateKaraf(unittest.TestCase):
 
     def test_success(self):
         """Found karaf.jar."""
-        self.assertEqual(
-            karaf.ProcessLocateKaraf.process(ansible_result("a\nb\nc")), ["a", "b", "c"]
-        )
+        assert karaf.ProcessLocateKaraf.process(ansible_result("a\nb\nc")) == [
+            "a",
+            "b",
+            "c",
+        ]
 
     def test_not_found(self):
         """Did not find karaf.jar."""
-        self.assertEqual(karaf.ProcessLocateKaraf.process(ansible_result("")), [])
+        assert karaf.ProcessLocateKaraf.process(ansible_result("")) == []
 
 
 class TestProcessKarafInitFiles(unittest.TestCase):
@@ -59,11 +64,8 @@ class TestProcessKarafInitFiles(unittest.TestCase):
     def test_no_fuse(self):
         """No 'fuse' found."""
         for processor in self.processors:
-            self.assertEqual(
-                # Blank line in input to check that processor will skip it.
-                processor.process(ansible_result("foo\nbar\n\nbaz")),
-                [],
-            )
+            # Blank line in input to check that processor will skip it.
+            assert processor.process(ansible_result("foo\nbar\n\nbaz")) == []
 
     def test_fuse_skipped(self):
         """'fuse' not found for Systemctl."""
@@ -72,20 +74,19 @@ class TestProcessKarafInitFiles(unittest.TestCase):
             if processor.IGNORE_WORDS is not None:
                 expected = []
 
-            self.assertEqual(
+            assert (
                 processor.process(
                     ansible_result("  foo\n  sys-fs-fuse-connections.mount\n  baz fuse")
-                ),
-                expected,
+                )
+                == expected
             )
 
     def test_fuse(self):
         """'fuse' found."""
         for processor in self.processors:
-            self.assertEqual(
-                processor.process(ansible_result("  foo\n  fuse bar\n  baz fuse")),
-                ["fuse bar"],
-            )
+            assert processor.process(
+                ansible_result("  foo\n  fuse bar\n  baz fuse")
+            ) == ["fuse bar"]
 
 
 class TestProcessKarafHomeBinFuse(unittest.TestCase):
@@ -93,21 +94,15 @@ class TestProcessKarafHomeBinFuse(unittest.TestCase):
 
     def test_success(self):
         """Found karaf.jar."""
-        self.assertEqual(
-            karaf.ProcessKarafHomeBinFuse.process(
-                ansible_results([{"item": "foo", "stdout": "bin/fuse"}])
-            ),
-            {"foo": True},
-        )
+        assert karaf.ProcessKarafHomeBinFuse.process(
+            ansible_results([{"item": "foo", "stdout": "bin/fuse"}])
+        ) == {"foo": True}
 
     def test_not_found(self):
         """Did not find karaf home bin fuse."""
-        self.assertEqual(
-            karaf.ProcessKarafHomeBinFuse.process(
-                ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            {"foo": False},
-        )
+        assert karaf.ProcessKarafHomeBinFuse.process(
+            ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
+        ) == {"foo": False}
 
 
 class TestProcessKarafHomeSystemOrgJboss(unittest.TestCase):
@@ -115,21 +110,15 @@ class TestProcessKarafHomeSystemOrgJboss(unittest.TestCase):
 
     def test_success(self):
         """Found karaf.jar."""
-        self.assertEqual(
-            karaf.ProcessKarafHomeSystemOrgJboss.process(
-                ansible_results([{"item": "foo", "stdout": "bar"}])
-            ),
-            {str(["bar"]): True},
-        )
+        assert karaf.ProcessKarafHomeSystemOrgJboss.process(
+            ansible_results([{"item": "foo", "stdout": "bar"}])
+        ) == {str(["bar"]): True}
 
     def test_not_found(self):
         """Did not find karaf home bin fuse."""
-        self.assertEqual(
-            karaf.ProcessKarafHomeSystemOrgJboss.process(
-                ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            {"[]": False},
-        )
+        assert karaf.ProcessKarafHomeSystemOrgJboss.process(
+            ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
+        ) == {"[]": False}
 
 
 class TestProcessJbossFuseCamelVersion(unittest.TestCase):
@@ -137,58 +126,47 @@ class TestProcessJbossFuseCamelVersion(unittest.TestCase):
 
     def test_success(self):
         """Found camel-core."""
-        self.assertEqual(
-            karaf.ProcessJbossFuseCamelVersion.process(
-                ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
-            ),
-            [{"install_home": "/fake/dir", "version": ["redhat-630187"]}],
-        )
+        assert karaf.ProcessJbossFuseCamelVersion.process(
+            ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
+        ) == [{"install_home": "/fake/dir", "version": ["redhat-630187"]}]
 
     def test_not_found(self):
         """Did not find camel-core."""
-        self.assertEqual(
+        assert (
             karaf.ProcessJbossFuseCamelVersion.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
     def on_eap_test_success(self):
         """Found camel on eap home dir."""
-        self.assertEqual(
-            karaf.ProcessJbossFuseOnEapCamelVersion.process(
-                ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
-            ),
-            [{"install_home": "/fake/dir", "version": ["redhat-630187"]}],
-        )
+        assert karaf.ProcessJbossFuseOnEapCamelVersion.process(
+            ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
+        ) == [{"install_home": "/fake/dir", "version": ["redhat-630187"]}]
 
     def on_eap_test_not_found(self):
         """Did not find camel on eap home dir."""
-        self.assertEqual(
+        assert (
             karaf.ProcessJbossFuseOnEapCamelVersion.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
     def locate_test_success(self):
         """Found camel with locate."""
-        self.assertEqual(
-            karaf.ProcessLocateCamel.process(
-                ansible_results(
-                    [{"item": "/fake/dir", "stdout_lines": "redhat-630187"}]
-                )
-            ),
-            list(set("redhat-630187")),
-        )
+        assert karaf.ProcessLocateCamel.process(
+            ansible_results([{"item": "/fake/dir", "stdout_lines": "redhat-630187"}])
+        ) == list(set("redhat-630187"))
 
     def locate_test_not_found(self):
         """Did not find camel with locate."""
-        self.assertEqual(
+        assert (
             karaf.ProcessLocateCamel.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
 
@@ -197,58 +175,47 @@ class TestProcessJbossFuseActivemqVersion(unittest.TestCase):
 
     def test_success(self):
         """Found activemq."""
-        self.assertEqual(
-            karaf.ProcessJbossFuseActivemqVersion.process(
-                ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
-            ),
-            [{"install_home": "/fake/dir", "version": ["redhat-630187"]}],
-        )
+        assert karaf.ProcessJbossFuseActivemqVersion.process(
+            ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
+        ) == [{"install_home": "/fake/dir", "version": ["redhat-630187"]}]
 
     def test_not_found(self):
         """Did not find activemq."""
-        self.assertEqual(
+        assert (
             karaf.ProcessJbossFuseActivemqVersion.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
     def on_eap_test_success(self):
         """Found activemq on eap home dir."""
-        self.assertEqual(
-            karaf.ProcessJbossFuseOnEapActivemqVersion.process(
-                ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
-            ),
-            [{"install_home": "/fake/dir", "version": ["redhat-630187"]}],
-        )
+        assert karaf.ProcessJbossFuseOnEapActivemqVersion.process(
+            ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
+        ) == [{"install_home": "/fake/dir", "version": ["redhat-630187"]}]
 
     def on_eap_test_not_found(self):
         """Did not find activemq on eap home dir."""
-        self.assertEqual(
+        assert (
             karaf.ProcessJbossFuseOnEapActivemqVersion.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
     def locate_test_success(self):
         """Found activemq with locate."""
-        self.assertEqual(
-            karaf.ProcessLocateActivemq.process(
-                ansible_results(
-                    [{"item": "/fake/dir", "stdout_lines": "redhat-630187"}]
-                )
-            ),
-            list(set("redhat-630187")),
-        )
+        assert karaf.ProcessLocateActivemq.process(
+            ansible_results([{"item": "/fake/dir", "stdout_lines": "redhat-630187"}])
+        ) == list(set("redhat-630187"))
 
     def locate_test_not_found(self):
         """Did not find activemq with locate."""
-        self.assertEqual(
+        assert (
             karaf.ProcessLocateActivemq.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
 
@@ -257,56 +224,45 @@ class TestProcessJbossFuseCxfVersion(unittest.TestCase):
 
     def test_success(self):
         """Found cxf."""
-        self.assertEqual(
-            karaf.ProcessJbossFuseCxfVersion.process(
-                ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
-            ),
-            [{"install_home": "/fake/dir", "version": ["redhat-630187"]}],
-        )
+        assert karaf.ProcessJbossFuseCxfVersion.process(
+            ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
+        ) == [{"install_home": "/fake/dir", "version": ["redhat-630187"]}]
 
     def test_not_found(self):
         """Did not find cxf."""
-        self.assertEqual(
+        assert (
             karaf.ProcessJbossFuseCxfVersion.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
     def on_eap_test_success(self):
         """Found cxf on eap home dir."""
-        self.assertEqual(
-            karaf.ProcessJbossFuseOnEapCxfVersion.process(
-                ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
-            ),
-            [{"install_home": "/fake/dir", "version": ["redhat-630187"]}],
-        )
+        assert karaf.ProcessJbossFuseOnEapCxfVersion.process(
+            ansible_results([{"item": "/fake/dir", "stdout": "redhat-630187"}])
+        ) == [{"install_home": "/fake/dir", "version": ["redhat-630187"]}]
 
     def on_eap_test_not_found(self):
         """Did not find cxf on eap home dir."""
-        self.assertEqual(
+        assert (
             karaf.ProcessJbossFuseOnEapCxfVersion.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )
 
     def locate_test_success(self):
         """Found cxf with locate."""
-        self.assertEqual(
-            karaf.ProcessLocateCxf.process(
-                ansible_results(
-                    [{"item": "/fake/dir", "stdout_lines": "redhat-630187"}]
-                )
-            ),
-            list(set("redhat-630187")),
-        )
+        assert karaf.ProcessLocateCxf.process(
+            ansible_results([{"item": "/fake/dir", "stdout_lines": "redhat-630187"}])
+        ) == list(set("redhat-630187"))
 
     def locate_test_not_found(self):
         """Did not find cxf with locate."""
-        self.assertEqual(
+        assert (
             karaf.ProcessLocateCxf.process(
                 ansible_results([{"item": "foo", "stdout": "", "rc": 1}])
-            ),
-            [],
+            )
+            == []
         )

--- a/quipucords/scanner/network/processing/test_process.py
+++ b/quipucords/scanner/network/processing/test_process.py
@@ -20,27 +20,27 @@ class TestIsSudoErrorValue(TestCase):
 
     def test_string_not_error(self):
         """A string that is not a sudo error."""
-        self.assertFalse(process.is_sudo_error_value("foo"))
+        assert not process.is_sudo_error_value("foo")
 
     def test_string_sudo_error(self):
         """A string with the sudo error value."""
-        self.assertTrue(process.is_sudo_error_value(process.SUDO_ERROR))
+        assert process.is_sudo_error_value(process.SUDO_ERROR)
 
     def test_list_not_error(self):
         """A list that is not a sudo error."""
-        self.assertFalse(process.is_sudo_error_value(["foo"]))
+        assert not process.is_sudo_error_value(["foo"])
 
     def test_list_sudo_error(self):
         """A list with the sudo error."""
-        self.assertTrue(process.is_sudo_error_value([process.SUDO_ERROR]))
+        assert process.is_sudo_error_value([process.SUDO_ERROR])
 
     def test_result_not_error(self):
         """An Ansible result that is not a sudo error."""
-        self.assertFalse(process.is_sudo_error_value(ansible_result("foo")))
+        assert not process.is_sudo_error_value(ansible_result("foo"))
 
     def test_result_sudo_error(self):
         """An Ansible result that is a sudo error."""
-        self.assertTrue(process.is_sudo_error_value(ansible_result(process.SUDO_ERROR)))
+        assert process.is_sudo_error_value(ansible_result(process.SUDO_ERROR))
 
 
 class TestIsAnsibleTaskResult(TestCase):
@@ -48,27 +48,25 @@ class TestIsAnsibleTaskResult(TestCase):
 
     def test_not_dict(self):
         """A value that is not a dictionary."""
-        self.assertFalse(process.is_ansible_task_result("foo"))
+        assert not process.is_ansible_task_result("foo")
 
     def test_malformed_dict(self):
         """A dictionary with the wrong contents."""
-        self.assertFalse(process.is_ansible_task_result({"a": "b"}))
+        assert not process.is_ansible_task_result({"a": "b"})
 
     def test_skipped(self):
         """The result of a skipped task."""
-        self.assertTrue(process.is_ansible_task_result({process.SKIPPED: True}))
+        assert process.is_ansible_task_result({process.SKIPPED: True})
 
     def test_ansible_result(self):
         """A single Ansible result."""
-        self.assertTrue(process.is_ansible_task_result(ansible_result("a")))
+        assert process.is_ansible_task_result(ansible_result("a"))
 
     def test_with_items_result(self):
         """The result of a with_items task."""
-        self.assertTrue(
-            process.is_ansible_task_result(
-                ansible_results(
-                    [{"item": "a", "stdout": "a"}, {"item": "b", "stdout": "b"}]
-                )
+        assert process.is_ansible_task_result(
+            ansible_results(
+                [{"item": "a", "stdout": "a"}, {"item": "b", "stdout": "b"}]
             )
         )
 
@@ -150,88 +148,87 @@ class TestProcess(TestCase):
 
     def test_not_result_no_processing(self):
         """Test a value that is not a task result, and needs no processing."""
-        self.assertEqual(
-            process.process(self.scan_task, {}, NOT_TASK_RESULT_KEY, "foo", HOST), "foo"
+        assert (
+            process.process(self.scan_task, {}, NOT_TASK_RESULT_KEY, "foo", HOST)
+            == "foo"
         )
 
     def test_not_result_sudo_error(self):
         """Test a value that is not a task result, but is a sudo error."""
-        self.assertEqual(
+        assert (
             process.process(
                 self.scan_task, {}, NOT_TASK_RESULT_KEY, process.SUDO_ERROR, HOST
-            ),
-            process.NO_DATA,
+            )
+            == process.NO_DATA
         )
 
     def test_processing_bad_input(self):
         """Test a key that is not a task result, but needs processing."""
-        self.assertEqual(
-            process.process(self.scan_task, {}, TEST_KEY, "foo", HOST), process.NO_DATA
+        assert (
+            process.process(self.scan_task, {}, TEST_KEY, "foo", HOST)
+            == process.NO_DATA
         )
 
     def test_no_processing(self):
         """Test a key that doesn't need to be processed."""
-        self.assertEqual(
-            process.process(
-                self.scan_task, {}, NOT_A_KEY, ansible_result(process.NO_DATA), HOST
-            ),
-            ansible_result(process.NO_DATA),
-        )
+        assert process.process(
+            self.scan_task, {}, NOT_A_KEY, ansible_result(process.NO_DATA), HOST
+        ) == ansible_result(process.NO_DATA)
 
     def test_simple_processor(self):
         """Test a key whose processor succeeds."""
-        self.assertEqual(
+        assert (
             process.process(
                 self.scan_task, {}, TEST_KEY, ansible_result(process.NO_DATA), HOST
-            ),
-            1,
+            )
+            == 1
         )
 
     def test_missing_dependency(self):
         """Test a key whose processor is missing a dependency."""
-        self.assertEqual(
+        assert (
             process.process(
                 self.scan_task, {}, DEPENDENT_KEY, ansible_result(process.NO_DATA), HOST
-            ),
-            process.NO_DATA,
+            )
+            == process.NO_DATA
         )
 
     def test_satisfied_dependency(self):
         """Test a key whose processor has a dependency, which is present."""
-        self.assertEqual(
+        assert (
             process.process(
                 self.scan_task,
                 {DEPENDENT_KEY: ansible_result("")},
                 NO_PROCESSOR_KEY,
                 "result",
                 HOST,
-            ),
-            "result",
+            )
+            == "result"
         )
 
     def test_skipped_task(self):
         """Test a task that Ansible skipped."""
-        self.assertEqual(
-            process.process(self.scan_task, {}, TEST_KEY, {"skipped": True}, HOST),
-            process.NO_DATA,
+        assert (
+            process.process(self.scan_task, {}, TEST_KEY, {"skipped": True}, HOST)
+            == process.NO_DATA
         )
 
     def test_task_errored(self):
         """Test a task that errored on the remote machine."""
-        self.assertEqual(
+        assert (
             process.process(
                 self.scan_task, {}, TEST_KEY, ansible_result("error!", rc=1), HOST
-            ),
-            process.NO_DATA,
+            )
+            == process.NO_DATA
         )
 
     def test_processor_errored(self):
         """Test a task where the processor itself errors."""
-        self.assertEqual(
+        assert (
             process.process(
                 self.scan_task, {}, PROCESSOR_ERROR_KEY, ansible_result(""), HOST
-            ),
-            process.NO_DATA,
+            )
+            == process.NO_DATA
         )
 
 

--- a/quipucords/scanner/network/processing/test_redhat_packages.py
+++ b/quipucords/scanner/network/processing/test_redhat_packages.py
@@ -14,34 +14,34 @@ class TestProcessRedHatPackagesCerts(unittest.TestCase):
         """Return stdout with no trailing ;."""
         in_line = "69.pem;183.pem;"
         expected = "69.pem;183.pem"
-        self.assertEqual(
-            redhat_packages.ProcessRedHatPackagesCerts.process(ansible_result(in_line)),
-            expected,
+        assert (
+            redhat_packages.ProcessRedHatPackagesCerts.process(ansible_result(in_line))
+            == expected
         )
 
     def test_no_pems_found(self):
         """Return empty string if it is given."""
         in_line = ""
         expected = ""
-        self.assertEqual(
-            redhat_packages.ProcessRedHatPackagesCerts.process(ansible_result(in_line)),
-            expected,
+        assert (
+            redhat_packages.ProcessRedHatPackagesCerts.process(ansible_result(in_line))
+            == expected
         )
 
     def test_single_pem(self):
         """Return stdout with no trailing ;."""
         in_line = "69.pem;"
         expected = "69.pem"
-        self.assertEqual(
-            redhat_packages.ProcessRedHatPackagesCerts.process(ansible_result(in_line)),
-            expected,
+        assert (
+            redhat_packages.ProcessRedHatPackagesCerts.process(ansible_result(in_line))
+            == expected
         )
 
     def test_ansible_error(self):
         """Did not find pem (empty string should be returned)."""
-        self.assertEqual(
+        assert (
             redhat_packages.ProcessRedHatPackagesCerts.process(
                 ansible_results([{"stdout": "", "rc": 1}])
-            ),
-            "",
+            )
+            == ""
         )

--- a/quipucords/scanner/network/processing/test_subman.py
+++ b/quipucords/scanner/network/processing/test_subman.py
@@ -12,23 +12,18 @@ class TestProcessSubmanConsumed(unittest.TestCase):
 
     def test_success_case(self):
         """Found subman_consumed."""
-        self.assertEqual(
-            subman.ProcessSubmanConsumed.process(
-                ansible_result("subnameA - 1\nsubnameB - 2\nsubnameC - 3")
-            ),
-            [
-                {"name": "subnameA", "entitlement_id": "1"},
-                {"name": "subnameB", "entitlement_id": "2"},
-                {"name": "subnameC", "entitlement_id": "3"},
-            ],
-        )
+        assert subman.ProcessSubmanConsumed.process(
+            ansible_result("subnameA - 1\nsubnameB - 2\nsubnameC - 3")
+        ) == [
+            {"name": "subnameA", "entitlement_id": "1"},
+            {"name": "subnameB", "entitlement_id": "2"},
+            {"name": "subnameC", "entitlement_id": "3"},
+        ]
 
     def test_not_found(self):
         """Did not find subman_consumed."""
-        self.assertEqual(subman.ProcessSubmanConsumed.process(ansible_result("")), [])
+        assert subman.ProcessSubmanConsumed.process(ansible_result("")) == []
 
     def test_empty_string(self):
         """Found empty string."""
-        self.assertEqual(
-            subman.ProcessSubmanConsumed.process(ansible_result("\n\r")), []
-        )
+        assert subman.ProcessSubmanConsumed.process(ansible_result("\n\r")) == []

--- a/quipucords/scanner/network/processing/test_system_purpose.py
+++ b/quipucords/scanner/network/processing/test_system_purpose.py
@@ -32,9 +32,9 @@ class TestProcessSystemPurpose(unittest.TestCase):
             "usage_type": "dev",
         }
 
-        self.assertEqual(
-            system_purpose.ProcessSystemPurpose.process(ansible_result(input_data)),
-            expected,
+        assert (
+            system_purpose.ProcessSystemPurpose.process(ansible_result(input_data))
+            == expected
         )
 
     def test_invalid_json_case(self):
@@ -52,7 +52,7 @@ class TestProcessSystemPurpose(unittest.TestCase):
 
         expected = None
 
-        self.assertEqual(
-            system_purpose.ProcessSystemPurpose.process(ansible_result(input_data)),
-            expected,
+        assert (
+            system_purpose.ProcessSystemPurpose.process(ansible_result(input_data))
+            == expected
         )

--- a/quipucords/scanner/network/processing/test_user_data.py
+++ b/quipucords/scanner/network/processing/test_user_data.py
@@ -16,39 +16,39 @@ class TestProcessSystemUserCount(unittest.TestCase):
                 "root:x:0:0:root:/root:/bin/bash\nb\nc"
             )
         }
-        self.assertEqual(
+        assert (
             user_data.ProcessSystemUserCount.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            1,
+            )
+            == 1
         )
         # stdout_lines looks like ['', 'b']
         dependencies["internal_system_user_count"] = ansible_result(
             "\ntestuser:x:502:502::/home/testuser:/bin/bash\n"
             "sysuser:x:32:32:system user:/:/sbin/nologin"
         )
-        self.assertEqual(
+        assert (
             user_data.ProcessSystemUserCount.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            1,
+            )
+            == 1
         )
         dependencies["internal_system_user_count"] = ansible_result("Failed", 1)
-        self.assertEqual(
+        assert (
             user_data.ProcessSystemUserCount.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
 
     def test_not_found(self):
         """No result for the system_user_count fact."""
         dependencies = {}
-        self.assertEqual(
+        assert (
             user_data.ProcessSystemUserCount.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
 
 
@@ -58,34 +58,28 @@ class TestProcessUserLoginHistory(unittest.TestCase):
     def test_success_case(self):
         """Found user login history fact."""
         dependencies = {"internal_user_login_history": ansible_result("a\nb\nc")}
-        self.assertEqual(
-            user_data.ProcessUserLoginHistory.process(
-                "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            ["a", "b", "c"],
-        )
+        assert user_data.ProcessUserLoginHistory.process(
+            "QPC_FORCE_POST_PROCESS", dependencies
+        ) == ["a", "b", "c"]
         # stdout_lines looks like ['', 'b']
         dependencies["internal_user_login_history"] = ansible_result("\nb\n")
-        self.assertEqual(
-            user_data.ProcessUserLoginHistory.process(
-                "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            ["b"],
-        )
+        assert user_data.ProcessUserLoginHistory.process(
+            "QPC_FORCE_POST_PROCESS", dependencies
+        ) == ["b"]
         dependencies["internal_user_login_history"] = ansible_result("Failed", 1)
-        self.assertEqual(
+        assert (
             user_data.ProcessUserLoginHistory.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )
 
     def test_not_found(self):
         """Did not find user login history."""
         dependencies = {}
-        self.assertEqual(
+        assert (
             user_data.ProcessUserLoginHistory.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
-            ),
-            "",
+            )
+            == ""
         )

--- a/quipucords/scanner/network/processing/test_virt.py
+++ b/quipucords/scanner/network/processing/test_virt.py
@@ -12,29 +12,28 @@ class TestProcessVirtXenPrivcmdFound(unittest.TestCase):
 
     def test_success_case(self):
         """Found internal_xen_privcmd_found fact."""
-        self.assertEqual(
-            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("Y\r\n"), {}), True
+        assert (
+            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("Y\r\n"), {}) is True
         )
-        self.assertEqual(
-            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("N\r\n"), {}), False
+        assert (
+            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("N\r\n"), {})
+            is False
         )
 
     def test_sudo_case(self):
         """Sudo found internal_xen_privcmd_found fact."""
-        self.assertEqual(
-            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("\r\nY\r\n"), {}),
-            True,
+        assert (
+            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("\r\nY\r\n"), {})
+            is True
         )
-        self.assertEqual(
-            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("\r\nN\r\n"), {}),
-            False,
+        assert (
+            virt.ProcessVirtXenPrivcmdFound.process(ansible_result("\r\nN\r\n"), {})
+            is False
         )
 
     def test_not_found(self):
         """Did not find internal_xen_privcmd_found fact."""
-        self.assertEqual(
-            virt.ProcessVirtXenPrivcmdFound.process(ansible_result(""), {}), False
-        )
+        assert virt.ProcessVirtXenPrivcmdFound.process(ansible_result(""), {}) is False
 
 
 class TestProcessVirtKvmFound(unittest.TestCase):
@@ -42,27 +41,19 @@ class TestProcessVirtKvmFound(unittest.TestCase):
 
     def test_success_case(self):
         """Found internal_kvm_found fact."""
-        self.assertEqual(
-            virt.ProcessVirtKvmFound.process(ansible_result("Y\r\n"), {}), True
-        )
-        self.assertEqual(
-            virt.ProcessVirtKvmFound.process(ansible_result("N\r\n"), {}), False
-        )
+        assert virt.ProcessVirtKvmFound.process(ansible_result("Y\r\n"), {}) is True
+        assert virt.ProcessVirtKvmFound.process(ansible_result("N\r\n"), {}) is False
 
     def test_sudo_case(self):
         """Sudo found internal_kvm_found fact."""
-        self.assertEqual(
-            virt.ProcessVirtKvmFound.process(ansible_result("\r\nY\r\n"), {}), True
-        )
-        self.assertEqual(
-            virt.ProcessVirtKvmFound.process(ansible_result("\r\nN\r\n"), {}), False
+        assert virt.ProcessVirtKvmFound.process(ansible_result("\r\nY\r\n"), {}) is True
+        assert (
+            virt.ProcessVirtKvmFound.process(ansible_result("\r\nN\r\n"), {}) is False
         )
 
     def test_not_found(self):
         """Did not find internal_kvm_found fact."""
-        self.assertEqual(
-            virt.ProcessVirtKvmFound.process(ansible_result(""), {}), False
-        )
+        assert virt.ProcessVirtKvmFound.process(ansible_result(""), {}) is False
 
 
 class TestProcessVirtXenGuest(unittest.TestCase):
@@ -70,27 +61,19 @@ class TestProcessVirtXenGuest(unittest.TestCase):
 
     def test_success_case(self):
         """Found internal_xen_guest fact."""
-        self.assertEqual(
-            virt.ProcessVirtXenGuest.process(ansible_result("1\r\n"), {}), True
-        )
-        self.assertEqual(
-            virt.ProcessVirtXenGuest.process(ansible_result("0\r\n"), {}), False
-        )
+        assert virt.ProcessVirtXenGuest.process(ansible_result("1\r\n"), {}) is True
+        assert virt.ProcessVirtXenGuest.process(ansible_result("0\r\n"), {}) is False
 
     def test_sudo_case(self):
         """Sudo found internal_xen_guest fact."""
-        self.assertEqual(
-            virt.ProcessVirtXenGuest.process(ansible_result("\r\n1\r\n"), {}), True
-        )
-        self.assertEqual(
-            virt.ProcessVirtXenGuest.process(ansible_result("\r\n0\r\n"), {}), False
+        assert virt.ProcessVirtXenGuest.process(ansible_result("\r\n1\r\n"), {}) is True
+        assert (
+            virt.ProcessVirtXenGuest.process(ansible_result("\r\n0\r\n"), {}) is False
         )
 
     def test_not_found(self):
         """Did not find internal_xen_guest fact."""
-        self.assertEqual(
-            virt.ProcessVirtXenGuest.process(ansible_result(""), {}), False
-        )
+        assert virt.ProcessVirtXenGuest.process(ansible_result(""), {}) is False
 
 
 class TestProcessSystemManufacturer(unittest.TestCase):
@@ -98,27 +81,25 @@ class TestProcessSystemManufacturer(unittest.TestCase):
 
     def test_success_case(self):
         """Found internal_sys_manufacturer fact."""
-        self.assertEqual(
+        assert (
             virt.ProcessSystemManufacturer.process(
                 ansible_result("FooVmWareBar\r\n"), {}
-            ),
-            "FooVmWareBar",
+            )
+            == "FooVmWareBar"
         )
 
     def test_sudo_case(self):
         """Sudo found internal_sys_manufacturer fact."""
-        self.assertEqual(
+        assert (
             virt.ProcessSystemManufacturer.process(
                 ansible_result("\r\nFooVmWareBar\r\n"), {}
-            ),
-            "FooVmWareBar",
+            )
+            == "FooVmWareBar"
         )
 
     def test_not_found(self):
         """Did not find internal_sys_manufacturer fact."""
-        self.assertEqual(
-            virt.ProcessSystemManufacturer.process(ansible_result(""), {}), None
-        )
+        assert virt.ProcessSystemManufacturer.process(ansible_result(""), {}) is None
 
 
 class TestProcessVirtCpuModelNameKvm(unittest.TestCase):
@@ -126,29 +107,28 @@ class TestProcessVirtCpuModelNameKvm(unittest.TestCase):
 
     def test_success_case(self):
         """Found internal_cpu_model_name_kvm fact."""
-        self.assertEqual(
-            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("Y\r\n"), {}), True
+        assert (
+            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("Y\r\n"), {}) is True
         )
-        self.assertEqual(
-            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("N\r\n"), {}), False
+        assert (
+            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("N\r\n"), {})
+            is False
         )
 
     def test_sudo_case(self):
         """Sudo found internal_cpu_model_name_kvm fact."""
-        self.assertEqual(
-            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("\r\nY\r\n"), {}),
-            True,
+        assert (
+            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("\r\nY\r\n"), {})
+            is True
         )
-        self.assertEqual(
-            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("\r\nN\r\n"), {}),
-            False,
+        assert (
+            virt.ProcessVirtCpuModelNameKvm.process(ansible_result("\r\nN\r\n"), {})
+            is False
         )
 
     def test_not_found(self):
         """Did not find internal_cpu_model_name_kvm fact."""
-        self.assertEqual(
-            virt.ProcessVirtCpuModelNameKvm.process(ansible_result(""), {}), False
-        )
+        assert virt.ProcessVirtCpuModelNameKvm.process(ansible_result(""), {}) is False
 
 
 class TestProcessVirtType(unittest.TestCase):
@@ -164,11 +144,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_VMWARE,
+            )
+            == virt.VIRT_TYPE_VMWARE
         )
 
     def test_dmidecode_virtualbox_case(self):
@@ -181,11 +161,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_VIRTUALBOX,
+            )
+            == virt.VIRT_TYPE_VIRTUALBOX
         )
 
     def test_dmidecode_virtualpc_case(self):
@@ -198,11 +178,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_VIRTUALPC,
+            )
+            == virt.VIRT_TYPE_VIRTUALPC
         )
 
     def test_dmidecode_kvm_case(self):
@@ -215,11 +195,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_KVM,
+            )
+            == virt.VIRT_TYPE_KVM
         )
 
     def test_dmidecode_no_manu_case(self):
@@ -231,11 +211,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            None,
+            )
+            is None
         )
 
     def test_kvm_command_kvm_case(self):
@@ -248,11 +228,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": True,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_KVM,
+            )
+            == virt.VIRT_TYPE_KVM
         )
 
     def test_cpu_model_name_kvm_case(self):
@@ -265,11 +245,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_KVM,
+            )
+            == virt.VIRT_TYPE_KVM
         )
 
     def test_xen_guest_case(self):
@@ -282,11 +262,11 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_XEN,
+            )
+            == virt.VIRT_TYPE_XEN
         )
 
     def test_xen_command_case(self):
@@ -299,16 +279,16 @@ class TestProcessVirtType(unittest.TestCase):
             "internal_kvm_found": False,
             "internal_xen_privcmd_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtType.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            virt.VIRT_TYPE_XEN,
+            )
+            == virt.VIRT_TYPE_XEN
         )
 
     def test_not_found(self):
         """Did not find virt_type fact."""
-        self.assertEqual(virt.ProcessVirtType.process(ansible_result(""), {}), None)
+        assert virt.ProcessVirtType.process(ansible_result(""), {}) is None
 
 
 class TestProcessVirtVirt(unittest.TestCase):
@@ -321,11 +301,11 @@ class TestProcessVirtVirt(unittest.TestCase):
             "virt_type": virt.VIRT_TYPE_VIRTUALBOX,
             "internal_kvm_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtVirt.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            "virt-guest",
+            )
+            == "virt-guest"
         )
 
     def test_virt_virt_with_kvm_case(self):
@@ -334,11 +314,11 @@ class TestProcessVirtVirt(unittest.TestCase):
             "virt_type": virt.VIRT_TYPE_VIRTUALBOX,
             "internal_kvm_found": True,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtVirt.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            "virt-host",
+            )
+            == "virt-host"
         )
 
     def test_virt_virt_with_deps_case(self):
@@ -347,9 +327,9 @@ class TestProcessVirtVirt(unittest.TestCase):
             "virt_type": None,
             "internal_kvm_found": False,
         }
-        self.assertEqual(
+        assert (
             virt.ProcessVirtVirt.process(
                 ansible_result(process.QPC_FORCE_POST_PROCESS), dependencies
-            ),
-            None,
+            )
+            is None
         )

--- a/quipucords/scanner/network/processing/test_yum.py
+++ b/quipucords/scanner/network/processing/test_yum.py
@@ -52,8 +52,8 @@ class TestProcessEnableYumRepolist(unittest.TestCase):
             },
         ]
 
-        self.assertEqual(
-            yum.ProcessEnableYumRepolist.process(ansible_result(input_data)), expected
+        assert (
+            yum.ProcessEnableYumRepolist.process(ansible_result(input_data)) == expected
         )
 
     def test_error_occurred(self):
@@ -61,10 +61,10 @@ class TestProcessEnableYumRepolist(unittest.TestCase):
         input_data = "Loaded plugins: product-id, security, \
             subscription-manager\r\n"
         expected = []
-        self.assertEqual(
-            yum.ProcessEnableYumRepolist.process(ansible_result(input_data)), expected
+        assert (
+            yum.ProcessEnableYumRepolist.process(ansible_result(input_data)) == expected
         )
 
     def test_not_found(self):
         """Did not find yum_enabled_repolist."""
-        self.assertEqual(yum.ProcessEnableYumRepolist.process(ansible_result("")), [])
+        assert yum.ProcessEnableYumRepolist.process(ansible_result("")) == []

--- a/quipucords/scanner/network/tests_network_connect.py
+++ b/quipucords/scanner/network/tests_network_connect.py
@@ -135,7 +135,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
             "ansible_become_method": "sudo",
             "ansible_become_user": "root",
         }
-        self.assertEqual(vars_dict, expected)
+        assert vars_dict == expected
 
     def test_get_exclude_host(self):
         """Test get_exclude_hosts() method."""
@@ -147,19 +147,19 @@ class NetworkConnectTaskRunnerTest(TestCase):
         """Test ConnectResultStore."""
         result_store = ConnectResultStore(self.scan_task)
 
-        self.assertEqual(result_store.remaining_hosts(), ["1.2.3.4"])
-        self.assertEqual(result_store.scan_task.systems_count, 1)
-        self.assertEqual(result_store.scan_task.systems_scanned, 0)
-        self.assertEqual(result_store.scan_task.systems_failed, 0)
+        assert result_store.remaining_hosts() == ["1.2.3.4"]
+        assert result_store.scan_task.systems_count == 1
+        assert result_store.scan_task.systems_scanned == 0
+        assert result_store.scan_task.systems_failed == 0
 
         result_store.record_result(
             "1.2.3.4", self.source, self.cred, SystemConnectionResult.UNREACHABLE
         )
 
-        self.assertEqual(result_store.remaining_hosts(), [])
-        self.assertEqual(result_store.scan_task.systems_count, 1)
-        self.assertEqual(result_store.scan_task.systems_scanned, 0)
-        self.assertEqual(result_store.scan_task.systems_unreachable, 1)
+        assert result_store.remaining_hosts() == []
+        assert result_store.scan_task.systems_count == 1
+        assert result_store.scan_task.systems_scanned == 0
+        assert result_store.scan_task.systems_unreachable == 1
 
     def test_connect_inventory(self):
         """Test construct ansible inventory dictionary."""
@@ -300,47 +300,47 @@ class NetworkConnectTaskRunnerTest(TestCase):
         _, result = scanner.run_with_result_store(
             Value("i", ScanJob.JOB_RUN), result_store
         )
-        self.assertEqual(result, ScanTask.COMPLETED)
+        assert result == ScanTask.COMPLETED
 
     # Similar tests as above modified for source2 (Does not have exclude hosts)
     def test_result_store_src2(self):
         """Test ConnectResultStore."""
         result_store = ConnectResultStore(self.scan_task3)
         hosts = ["1.2.3.4", "1.2.3.5", "1.2.3.6"]
-        self.assertCountEqual(result_store.remaining_hosts(), hosts)
-        self.assertEqual(result_store.scan_task.systems_count, 3)
-        self.assertEqual(result_store.scan_task.systems_scanned, 0)
-        self.assertEqual(result_store.scan_task.systems_failed, 0)
+        assert len(result_store.remaining_hosts()) == len(hosts)
+        assert result_store.scan_task.systems_count == 3
+        assert result_store.scan_task.systems_scanned == 0
+        assert result_store.scan_task.systems_failed == 0
 
         host = hosts.pop()
         result_store.record_result(
             host, self.source2, self.cred, SystemConnectionResult.SUCCESS
         )
 
-        self.assertCountEqual(result_store.remaining_hosts(), hosts)
-        self.assertEqual(result_store.scan_task.systems_count, 3)
-        self.assertEqual(result_store.scan_task.systems_scanned, 1)
-        self.assertEqual(result_store.scan_task.systems_failed, 0)
+        assert len(result_store.remaining_hosts()) == len(hosts)
+        assert result_store.scan_task.systems_count == 3
+        assert result_store.scan_task.systems_scanned == 1
+        assert result_store.scan_task.systems_failed == 0
 
         host = hosts.pop()
         # Check failure without cred
         result_store.record_result(
             host, self.source2, None, SystemConnectionResult.FAILED
         )
-        self.assertCountEqual(result_store.remaining_hosts(), hosts)
-        self.assertEqual(result_store.scan_task.systems_count, 3)
-        self.assertEqual(result_store.scan_task.systems_scanned, 1)
-        self.assertEqual(result_store.scan_task.systems_failed, 1)
+        assert len(result_store.remaining_hosts()) == len(hosts)
+        assert result_store.scan_task.systems_count == 3
+        assert result_store.scan_task.systems_scanned == 1
+        assert result_store.scan_task.systems_failed == 1
 
         host = hosts.pop()
         # Check failure with cred
         result_store.record_result(
             host, self.source2, self.cred, SystemConnectionResult.FAILED
         )
-        self.assertCountEqual(result_store.remaining_hosts(), hosts)
-        self.assertEqual(result_store.scan_task.systems_count, 3)
-        self.assertEqual(result_store.scan_task.systems_scanned, 1)
-        self.assertEqual(result_store.scan_task.systems_failed, 2)
+        assert len(result_store.remaining_hosts()) == len(hosts)
+        assert result_store.scan_task.systems_count == 3
+        assert result_store.scan_task.systems_scanned == 1
+        assert result_store.scan_task.systems_failed == 2
 
     def test_connect_inventory_src2(self):
         """Test construct ansible inventory dictionary."""
@@ -372,7 +372,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
                 },
             }
         }
-        self.assertEqual(inventory_dict, expected)
+        assert inventory_dict == expected
 
     @patch("ansible_runner.run")
     @patch(
@@ -446,7 +446,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         _, result = scanner.run_with_result_store(
             Value("i", ScanJob.JOB_RUN), result_store
         )
-        self.assertEqual(result, ScanTask.COMPLETED)
+        assert result == ScanTask.COMPLETED
 
     @patch("ansible_runner.run")
     def test_connect_paramiko(self, mock_run):
@@ -488,7 +488,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         mock_run.assert_called()
         calls = mock_run.mock_calls
         # Check to see if the parameter was passed into the runner.run()
-        self.assertIn("verbosity=1", str(calls[0]))
+        assert "verbosity=1" in str(calls[0])
 
     @patch("ansible_runner.run")
     @patch("scanner.network.connect.settings.DJANGO_SECRET_PATH", "None")
@@ -520,7 +520,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         conn_dict = scanner.run_with_result_store(
             Value("i", ScanJob.JOB_RUN), result_store
         )
-        self.assertEqual(conn_dict[1], ScanTask.FAILED)
+        assert conn_dict[1] == ScanTask.FAILED
 
     @patch("scanner.network.connect.ConnectTaskRunner.run_with_result_store")
     def test_cancel_connect(self, mock_run):
@@ -544,7 +544,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         mock_run.side_effect = NetworkCancelException()
         scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
         _, scan_result = scanner.run(Value("i", ScanJob.JOB_RUN))
-        self.assertEqual(scan_result, ScanTask.CANCELED)
+        assert scan_result == ScanTask.CANCELED
 
     @patch("scanner.network.connect.ConnectTaskRunner.run_with_result_store")
     def test_pause_connect(self, mock_run):
@@ -568,13 +568,13 @@ class NetworkConnectTaskRunnerTest(TestCase):
         mock_run.side_effect = NetworkPauseException()
         scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
         _, scan_result = scanner.run(Value("i", ScanJob.JOB_RUN))
-        self.assertEqual(scan_result, ScanTask.PAUSED)
+        assert scan_result == ScanTask.PAUSED
 
     def test_run_manager_interupt(self):
         """Test manager interupt for run method."""
         scanner = ConnectTaskRunner(self.scan_job, self.scan_task)
         conn_dict = scanner.run(Value("i", ScanJob.JOB_TERMINATE_CANCEL))
-        self.assertEqual(conn_dict[1], ScanTask.CANCELED)
+        assert conn_dict[1] == ScanTask.CANCELED
 
     @patch("scanner.network.connect.ConnectTaskRunner.run_with_result_store")
     def test_run_success_return_connect(self, mock_run):
@@ -583,7 +583,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         mock_run.side_effect = [[None, ScanTask.COMPLETED]]
         scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
         _, scan_result = scanner.run(Value("i", ScanJob.JOB_RUN))
-        self.assertEqual(scan_result, ScanTask.COMPLETED)
+        assert scan_result == ScanTask.COMPLETED
 
     @patch("scanner.network.connect._connect")
     def test_connect_exception(self, mock_run):
@@ -592,7 +592,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         mock_run.side_effect = AnsibleRunnerException("fail")
         scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
         _, scan_result = scanner.run(Value("i", ScanJob.JOB_RUN))
-        self.assertEqual(scan_result, ScanTask.FAILED)
+        assert scan_result == ScanTask.FAILED
 
     @patch("ansible_runner.run")
     def test_empty_hosts(self, mock_run):
@@ -603,4 +603,4 @@ class NetworkConnectTaskRunnerTest(TestCase):
         _, result = scanner.run_with_result_store(
             Value("i", ScanJob.JOB_RUN), result_store
         )
-        self.assertEqual(result, ScanTask.COMPLETED)
+        assert result == ScanTask.COMPLETED

--- a/quipucords/scanner/network/tests_network_connect_callback.py
+++ b/quipucords/scanner/network/tests_network_connect_callback.py
@@ -71,9 +71,9 @@ class TestConnectResultCallback(TestCase):
         )
         for event in events:
             callback.event_callback(event)
-        self.assertEqual(callback.result_store.scan_task.systems_count, 3)
-        self.assertEqual(callback.result_store.scan_task.systems_scanned, 1)
-        self.assertEqual(callback.result_store.scan_task.systems_failed, 0)
+        assert callback.result_store.scan_task.systems_count == 3
+        assert callback.result_store.scan_task.systems_scanned == 1
+        assert callback.result_store.scan_task.systems_failed == 0
 
     def test_task_on_failed(self):
         """Test the callback on failed."""
@@ -90,8 +90,8 @@ class TestConnectResultCallback(TestCase):
         )
         for event in events:
             callback.event_callback(event)
-        self.assertEqual(callback.result_store.scan_task.systems_failed, 0)
-        self.assertEqual(callback.result_store.scan_task.systems_count, 3)
+        assert callback.result_store.scan_task.systems_failed == 0
+        assert callback.result_store.scan_task.systems_count == 3
 
     def test_task_on_unreachable(self):
         """Test the callback on unreachable."""
@@ -108,9 +108,9 @@ class TestConnectResultCallback(TestCase):
         )
         for event in events:
             callback.event_callback(event)
-        self.assertEqual(callback.result_store.scan_task.systems_failed, 0)
-        self.assertEqual(callback.result_store.scan_task.systems_unreachable, 1)
-        self.assertEqual(callback.result_store.scan_task.systems_count, 3)
+        assert callback.result_store.scan_task.systems_failed == 0
+        assert callback.result_store.scan_task.systems_unreachable == 1
+        assert callback.result_store.scan_task.systems_count == 3
 
     def test_exceptions_for_tasks(self):
         """Test exception for each task."""
@@ -152,13 +152,13 @@ class TestConnectResultCallback(TestCase):
             results_store, self.cred, self.source, self.interrupt
         )
         result = callback.cancel_callback()
-        self.assertEqual(result, False)
+        assert result is False
         # Test cancel state
         for stop_value in STOP_STATES.values():
             self.interrupt = Mock(value=stop_value)
             callback = ConnectResultCallback(
                 results_store, self.cred, self.source, self.interrupt
             )
-            self.assertEqual(callback.interrupt.value, stop_value)
+            assert callback.interrupt.value == stop_value
             result = callback.cancel_callback()
-            self.assertEqual(result, True)
+            assert result is True

--- a/quipucords/scanner/network/tests_network_inspect.py
+++ b/quipucords/scanner/network/tests_network_inspect.py
@@ -116,7 +116,7 @@ class NetworkInspectScannerTest(TestCase):
             }
         }
 
-        self.assertEqual(inventory_dict[1], expected)
+        assert inventory_dict[1] == expected
 
     def test_scan_inventory_grouping(self):
         """Test construct ansible inventory dictionary."""
@@ -179,7 +179,7 @@ class NetworkInspectScannerTest(TestCase):
             }
         }
 
-        self.assertEqual(inventory_dict[1], expected)
+        assert inventory_dict[1] == expected
 
     @patch("ansible_runner.run")
     def test_inspect_scan_failure(self, mock_run):
@@ -198,7 +198,7 @@ class NetworkInspectScannerTest(TestCase):
         scanner = InspectTaskRunner(self.scan_job, self.scan_task)
         scan_task_status = scanner.run(Value("i", ScanJob.JOB_RUN))
         mock_scan.assert_called_with(ANY, self.host_list)
-        self.assertEqual(scan_task_status[1], ScanTask.FAILED)
+        assert scan_task_status[1] == ScanTask.FAILED
 
     @patch("ansible_runner.run")
     def test_inspect_scan_fail_no_facts(self, mock_run):
@@ -210,7 +210,7 @@ class NetworkInspectScannerTest(TestCase):
             scanner.connect_scan_task = self.connect_scan_task
             scan_task_status = scanner.run(Value("i", ScanJob.JOB_RUN))
             mock_run.assert_called()
-            self.assertEqual(scan_task_status[1], ScanTask.FAILED)
+            assert scan_task_status[1] == ScanTask.FAILED
 
     @pytest.mark.skip("This test is not running properly and taking a long time")
     def test_ssh_crash(self):
@@ -226,7 +226,7 @@ class NetworkInspectScannerTest(TestCase):
             base_ssh_executable=path,
         )
         # pylint: enable=unexpected-keyword-arg
-        self.assertEqual(result, ScanTask.COMPLETED)
+        assert result == ScanTask.COMPLETED
 
     @pytest.mark.skip("This test is not running properly and taking a long time")
     def test_ssh_hang(self):
@@ -304,7 +304,7 @@ class NetworkInspectScannerTest(TestCase):
         scanner = InspectTaskRunner(self.scan_job, self.scan_task)
         terminate = Value("i", ScanJob.JOB_TERMINATE_CANCEL)
         scan_task_status = scanner.run(terminate)
-        self.assertEqual(scan_task_status[1], ScanTask.CANCELED)
+        assert scan_task_status[1] == ScanTask.CANCELED
 
     @patch("scanner.network.inspect.InspectTaskRunner._obtain_discovery_data")
     def test_no_reachable_host(self, discovery):
@@ -312,7 +312,7 @@ class NetworkInspectScannerTest(TestCase):
         discovery.return_value = [], [], [], []
         scanner = InspectTaskRunner(self.scan_job, self.scan_task)
         scan_task_status = scanner.run(Value("i", ScanJob.JOB_RUN))
-        self.assertEqual(scan_task_status[1], ScanTask.FAILED)
+        assert scan_task_status[1] == ScanTask.FAILED
 
     def test_cancel_inspect(self):
         """Test cancel of inspect."""
@@ -342,4 +342,4 @@ class NetworkInspectScannerTest(TestCase):
         mock_run.assert_called()
         calls = mock_run.mock_calls
         # Check to see if the parameter was passed into the runner.run()
-        self.assertIn("verbosity=1", str(calls[0]))
+        assert "verbosity=1" in str(calls[0])

--- a/quipucords/scanner/network/tests_utils.py
+++ b/quipucords/scanner/network/tests_utils.py
@@ -36,7 +36,7 @@ class TestConstructVars(unittest.TestCase):
             "ansible_become_user": "root",
             "ansible_become_method": "sudo",
         }
-        self.assertEqual(vars_dict, expected)
+        assert vars_dict == expected
 
 
 class TestExpandHostpattern(unittest.TestCase):
@@ -44,28 +44,31 @@ class TestExpandHostpattern(unittest.TestCase):
 
     def test_single_hostname(self):
         """A single hostname."""
-        self.assertEqual(utils.expand_hostpattern("domain.com"), ["domain.com"])
+        assert utils.expand_hostpattern("domain.com") == ["domain.com"]
 
     def test_single_hostname_with_port(self):
         """Users can specify a port, too."""
-        self.assertEqual(utils.expand_hostpattern("domain.com:1234"), ["domain.com"])
+        assert utils.expand_hostpattern("domain.com:1234") == ["domain.com"]
 
     def test_hostname_range(self):
         """A range of hostnames."""
-        self.assertEqual(
-            utils.expand_hostpattern("[a:c].domain.com"),
-            ["a.domain.com", "b.domain.com", "c.domain.com"],
-        )
+        assert utils.expand_hostpattern("[a:c].domain.com") == [
+            "a.domain.com",
+            "b.domain.com",
+            "c.domain.com",
+        ]
 
     def test_single_ip_address(self):
         """A single IP address."""
-        self.assertEqual(utils.expand_hostpattern("1.2.3.4"), ["1.2.3.4"])
+        assert utils.expand_hostpattern("1.2.3.4") == ["1.2.3.4"]
 
     def test_ip_range(self):
         """A range of IP addresses."""
-        self.assertEqual(
-            utils.expand_hostpattern("1.2.3.[4:6]"), ["1.2.3.4", "1.2.3.5", "1.2.3.6"]
-        )
+        assert utils.expand_hostpattern("1.2.3.[4:6]") == [
+            "1.2.3.4",
+            "1.2.3.5",
+            "1.2.3.6",
+        ]
 
 
 def test_raw_facts_template():

--- a/quipucords/scanner/satellite/tests_sat_connect.py
+++ b/quipucords/scanner/satellite/tests_sat_connect.py
@@ -76,7 +76,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_sat5_bad_status(self):
         """Test the running connect task for Satellite 5."""
@@ -87,7 +87,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_sat6_bad_status(self):
         """Test the running connect task for Sat 6 with bad status."""
@@ -99,7 +99,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_sat6_bad_api_version(self):
         """Test the running connect task for Sat6 with bad api version."""
@@ -111,7 +111,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_conn_err(self):
         """Test the running connect task with connection error."""
@@ -122,7 +122,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_sat_err(self):
         """Test the running connect task with satellite error."""
@@ -133,7 +133,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_auth_err(self):
         """Test the running connect task with satellite auth error."""
@@ -145,7 +145,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_timeout_err(self):
         """Test the running connect task with timeout error."""
@@ -156,7 +156,7 @@ class ConnectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_sat6_v2(self):
         """Test the running connect task for Sat6 with api version 2."""
@@ -176,18 +176,18 @@ class ConnectTaskRunnerTest(TestCase):
                     mock_sat_status.assert_called_once_with(ANY)
                     mock_host_count.assert_called_once_with()
                     mock_hosts.assert_called_once_with()
-                    self.assertEqual(status[1], ScanTask.COMPLETED)
+                    assert status[1] == ScanTask.COMPLETED
 
     def test_run_sat6_v2_cancel(self):
         """Test the running connect task (cancel)."""
         task = ConnectTaskRunner(self.scan_job, self.scan_task)
 
         status = task.run(Value("i", ScanJob.JOB_TERMINATE_CANCEL))
-        self.assertEqual(status[1], ScanTask.CANCELED)
+        assert status[1] == ScanTask.CANCELED
 
     def test_run_sat6_v2_pause(self):
         """Test the running connect task (pause)."""
         task = ConnectTaskRunner(self.scan_job, self.scan_task)
 
         status = task.run(Value("i", ScanJob.JOB_TERMINATE_PAUSE))
-        self.assertEqual(status[1], ScanTask.PAUSED)
+        assert status[1] == ScanTask.PAUSED

--- a/quipucords/scanner/satellite/tests_sat_factory.py
+++ b/quipucords/scanner/satellite/tests_sat_factory.py
@@ -43,32 +43,32 @@ class SatelliteFactoryTest(TestCase):
         satellite_version = None
         api_version = 1
         api = create(satellite_version, api_version, self.scan_job, self.scan_task)
-        self.assertEqual(api, None)
+        assert api is None
 
     def test_create_sat5(self):
         """Test the method to create a Sat 5 interface."""
         satellite_version = SATELLITE_VERSION_5
         api_version = 1
         api = create(satellite_version, api_version, self.scan_job, self.scan_task)
-        self.assertEqual(api.__class__, SatelliteFive)
+        assert api.__class__ == SatelliteFive
 
     def test_create_sat6_v1(self):
         """Test the method to create a Sat 6 interface."""
         satellite_version = SATELLITE_VERSION_6
         api_version = 1
         api = create(satellite_version, api_version, self.scan_job, self.scan_task)
-        self.assertEqual(api.__class__, SatelliteSixV1)
+        assert api.__class__ == SatelliteSixV1
 
     def test_create_sat6_v2(self):
         """Test the method to create a Sat 6 interface."""
         satellite_version = SATELLITE_VERSION_6
         api_version = 2
         api = create(satellite_version, api_version, self.scan_job, self.scan_task)
-        self.assertEqual(api.__class__, SatelliteSixV2)
+        assert api.__class__ == SatelliteSixV2
 
     def test_create_sat6_unknown(self):
         """Test the method to create a Sat 6 interface."""
         satellite_version = SATELLITE_VERSION_6
         api_version = 9
         api = create(satellite_version, api_version, self.scan_job, self.scan_task)
-        self.assertEqual(api, None)
+        assert api is None

--- a/quipucords/scanner/satellite/tests_sat_five.py
+++ b/quipucords/scanner/satellite/tests_sat_five.py
@@ -82,7 +82,7 @@ class SatelliteFiveTest(TestCase):
         client.auth.logout.return_value = "key"
         client.system.list_user_systems.return_value = ["sys1", "sys2", "sys3"]
         systems_count = self.api.host_count()
-        self.assertEqual(systems_count, 3)
+        assert systems_count == 3
 
     @patch("xmlrpc.client.ServerProxy")
     def test_host_count_with_err(self, mock_serverproxy):
@@ -106,9 +106,9 @@ class SatelliteFiveTest(TestCase):
         client.system.list_user_systems.return_value = systems
         systems_count = self.api.host_count()
         hosts = self.api.hosts()
-        self.assertEqual(systems_count, 3)
-        self.assertEqual(len(hosts), 3)
-        self.assertEqual(hosts, ["sys1_1", "sys2_2", "sys3_3"])
+        assert systems_count == 3
+        assert len(hosts) == 3
+        assert hosts == ["sys1_1", "sys2_2", "sys3_3"]
 
     @patch("xmlrpc.client.ServerProxy")
     def test_hosts_with_err(self, mock_serverproxy):
@@ -174,12 +174,12 @@ class SatelliteFiveTest(TestCase):
         self.api.process_results([raw_result], virt, {1: 2}, [])
         inspect_results = self.scan_task.inspection_result.systems.all()
         sys_1_result = inspect_results.filter(name="sys1_1").first()
-        self.assertEqual(sys_1_result.name, "sys1_1")
-        self.assertEqual(sys_1_result.status, "success")
+        assert sys_1_result.name == "sys1_1"
+        assert sys_1_result.status == "success"
         result = {}
         for fact in sys_1_result.facts.all():
             result[fact.name] = json.loads(fact.value)
-        self.assertEqual(result, expected)
+        assert result == expected
 
     @patch("xmlrpc.client.ServerProxy")
     def test_host_details_virt_guest(self, mock_serverproxy):
@@ -229,12 +229,12 @@ class SatelliteFiveTest(TestCase):
         self.api.process_results([raw_result], virt, {1: 2}, [])
         inspect_results = self.scan_task.inspection_result.systems.all()
         sys_1_result = inspect_results.filter(name="sys1_1").first()
-        self.assertEqual(sys_1_result.name, "sys1_1")
-        self.assertEqual(sys_1_result.status, "success")
+        assert sys_1_result.name == "sys1_1"
+        assert sys_1_result.status == "success"
         result = {}
         for fact in sys_1_result.facts.all():
             result[fact.name] = json.loads(fact.value)
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_prepare_host_s5(self):
         """Test the prepare host method for satellite 5."""
@@ -271,7 +271,7 @@ class SatelliteFiveTest(TestCase):
             return_value=connect_data_return_value,
         ) as mock_connect:
             host_params = self.api.prepare_host(chunk)
-            self.assertEqual(expected, host_params)
+            assert expected == host_params
             mock_connect.assert_called_once_with(ANY)
 
     @patch("xmlrpc.client.ServerProxy")
@@ -292,12 +292,12 @@ class SatelliteFiveTest(TestCase):
         self.api.process_results([raw_result], virt, {1: 2}, [])
         inspect_results = self.scan_task.inspection_result.systems.all()
         sys_1_result = inspect_results.filter(name="sys2_2").first()
-        self.assertEqual(sys_1_result.name, "sys2_2")
-        self.assertEqual(sys_1_result.status, "failed")
+        assert sys_1_result.name == "sys2_2"
+        assert sys_1_result.status == "failed"
         result = {}
         for fact in sys_1_result.facts.all():
             result[fact.name] = json.loads(fact.value)
-        self.assertEqual(result, {})
+        assert result == {}
 
     @patch("xmlrpc.client.ServerProxy")
     def test_virtual_guests_with_err(self, mock_serverproxy):
@@ -316,7 +316,7 @@ class SatelliteFiveTest(TestCase):
         guests = [{"id": 2}]
         client.system.list_virtual_guests.return_value = guests
         virt_guests = self.api.virtual_guests(1)
-        self.assertEqual(virt_guests, ({2: 1}, 1))
+        assert virt_guests == ({2: 1}, 1)
 
     @patch("xmlrpc.client.ServerProxy")
     def test_virtual_hosts_with_err(self, mock_serverproxy):
@@ -340,8 +340,8 @@ class SatelliteFiveTest(TestCase):
         virtual_hosts, virtual_guests = self.api.virtual_hosts()
         virt_host = {1: {"id": 1, "name": "host1", "uuid": 1, "num_virtual_guests": 1}}
         virt_guest = {2: 1}
-        self.assertEqual(virtual_hosts, virt_host)
-        self.assertEqual(virtual_guests, virt_guest)
+        assert virtual_hosts == virt_host
+        assert virtual_guests == virt_guest
 
     @patch("xmlrpc.client.ServerProxy")
     def test_physical_hosts_with_err(self, mock_serverproxy):
@@ -360,7 +360,7 @@ class SatelliteFiveTest(TestCase):
         hosts = [{"id": 1, "name": "host1"}]
         client.system.list_physical_systems.return_value = hosts
         phyiscal_hosts = self.api.physical_hosts()
-        self.assertEqual(phyiscal_hosts, [1])
+        assert phyiscal_hosts == [1]
 
     @patch("xmlrpc.client.ServerProxy")
     def test_hosts_facts_with_err(self, mock_serverproxy):
@@ -406,6 +406,6 @@ class SatelliteFiveTest(TestCase):
             ) as mock_physical:
                 self.api.hosts_facts(Value("i", ScanJob.JOB_RUN))
                 inspect_result = self.scan_task.inspection_result
-                self.assertEqual(len(inspect_result.systems.all()), 1)
+                assert len(inspect_result.systems.all()) == 1
                 mock_vhosts.assert_called_once_with()
                 mock_physical.assert_called_once_with()

--- a/quipucords/scanner/satellite/tests_sat_inspect.py
+++ b/quipucords/scanner/satellite/tests_sat_inspect.py
@@ -84,7 +84,7 @@ class InspectTaskRunnerTest(TestCase):
         task = InspectTaskRunner(scan_job, inspect_task)
         status = task.run(Value("i", ScanJob.JOB_RUN))
 
-        self.assertEqual(status[1], ScanTask.FAILED)
+        assert status[1] == ScanTask.FAILED
 
     def test_run_unknown_sat(self):
         """Test running the inspect scan for unknown sat."""
@@ -95,7 +95,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_sat5_bad_status(self):
         """Test the running inspect task for Satellite 5."""
@@ -107,7 +107,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_sat6_bad_status(self):
         """Test the running inspect task for Sat 6 with bad status."""
@@ -120,7 +120,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_sat6_bad_api_version(self):
         """Test the running inspect task for Sat6 with bad api version."""
@@ -133,7 +133,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_conn_err(self):
         """Test the running inspect task with connection error."""
@@ -145,7 +145,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_auth_err(self):
         """Test the running inspect task with satellite auth error."""
@@ -158,7 +158,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_sat_err(self):
         """Test the running inspect task with satellite error."""
@@ -170,7 +170,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_timeout(self):
         """Test the running inspect task with timeout error."""
@@ -182,7 +182,7 @@ class InspectTaskRunnerTest(TestCase):
         ) as mock_sat_status:
             status = task.run(Value("i", ScanJob.JOB_RUN))
             mock_sat_status.assert_called_once_with(ANY)
-            self.assertEqual(status[1], ScanTask.FAILED)
+            assert status[1] == ScanTask.FAILED
 
     def test_run_with_excep(self):
         """Test the running inspect task with general exception."""
@@ -195,7 +195,7 @@ class InspectTaskRunnerTest(TestCase):
             with self.assertRaises(Exception):
                 status = task.run(Value("i", ScanJob.JOB_RUN))
                 mock_sat_status.assert_called_once_with(ANY)
-                self.assertEqual(status[1], ScanTask.FAILED)
+                assert status[1] == ScanTask.FAILED
 
     def test_run_with_sat(self):
         """Test the running inspect task with satellite."""
@@ -210,7 +210,7 @@ class InspectTaskRunnerTest(TestCase):
                 status = task.run(Value("i", ScanJob.JOB_RUN))
                 mock_sat_status.assert_called_once_with(ANY)
                 mock_facts.assert_called_once_with(ANY)
-                self.assertEqual(status[1], ScanTask.COMPLETED)
+                assert status[1] == ScanTask.COMPLETED
 
     def test_run_with_sat_cancel(self):
         """Test the running inspect task with satellite cancelled."""
@@ -218,7 +218,7 @@ class InspectTaskRunnerTest(TestCase):
         task = InspectTaskRunner(scan_job, inspect_task)
 
         status = task.run(Value("i", ScanJob.JOB_TERMINATE_CANCEL))
-        self.assertEqual(status[1], ScanTask.CANCELED)
+        assert status[1] == ScanTask.CANCELED
 
     def test_run_with_sat_pause(self):
         """Test the running inspect task with satellite paused."""
@@ -226,4 +226,4 @@ class InspectTaskRunnerTest(TestCase):
         task = InspectTaskRunner(scan_job, inspect_task)
 
         status = task.run(Value("i", ScanJob.JOB_TERMINATE_PAUSE))
-        self.assertEqual(status[1], ScanTask.PAUSED)
+        assert status[1] == ScanTask.PAUSED

--- a/quipucords/scanner/satellite/tests_sat_six.py
+++ b/quipucords/scanner/satellite/tests_sat_six.py
@@ -106,8 +106,8 @@ class SatelliteSixV1Test(TestCase):
             mocker.get(url, status_code=200, json=jsonresult)
             orgs = self.api.get_orgs()
             orgs2 = self.api.get_orgs()
-            self.assertEqual(orgs, [1, 7, 8])
-            self.assertEqual(orgs, orgs2)
+            assert orgs == [1, 7, 8]
+            assert orgs == orgs2
 
     def test_get_orgs_with_err(self):
         """Test the method to get orgs with err."""
@@ -135,7 +135,7 @@ class SatelliteSixV1Test(TestCase):
             }
             mocker.get(url, status_code=200, json=jsonresult)
             systems_count = self.api.host_count()
-            self.assertEqual(systems_count, 3)
+            assert systems_count == 3
 
     @patch("scanner.satellite.six.SatelliteSixV1.get_orgs")
     def test_host_count_with_err(self, mock_get_orgs):
@@ -176,9 +176,9 @@ class SatelliteSixV1Test(TestCase):
             mocker.get(url, status_code=200, json=jsonresult)
             systems_count = self.api.host_count()
             hosts = self.api.hosts()
-            self.assertEqual(systems_count, 3)
-            self.assertEqual(len(hosts), 3)
-            self.assertEqual(hosts, ["sys1_1", "sys2_2", "sys3_3"])
+            assert systems_count == 3
+            assert len(hosts) == 3
+            assert hosts == ["sys1_1", "sys2_2", "sys3_3"]
 
     @patch("scanner.satellite.six.SatelliteSixV1.get_orgs")
     def test_hosts_with_err(self, mock_get_orgs):
@@ -266,7 +266,7 @@ class SatelliteSixV1Test(TestCase):
                 "os_name": "RedHat",
                 "os_version": "7.4",
             }
-            self.assertEqual(host_info, expected)
+            assert host_info == expected
 
     def test_prepare_host_s61(self):
         """Test the prepare host method for satellite 6.1."""
@@ -312,7 +312,7 @@ class SatelliteSixV1Test(TestCase):
             return_value=connect_data_return_value,
         ) as mock_connect:
             host_params = SatelliteSixV1.prepare_host(self.api, chunk)
-            self.assertEqual(expected, host_params)
+            assert expected == host_params
             mock_connect.assert_called_once_with(ANY)
 
     def test_request_host_details_err(self):
@@ -343,9 +343,9 @@ class SatelliteSixV1Test(TestCase):
                 "host_fields_response": {},
                 "host_subscriptions_response": {},
             }
-            self.assertEqual(result, expected)
+            assert result == expected
             inspect_result = self.scan_task.inspection_result
-            self.assertEqual(len(inspect_result.systems.all()), 0)
+            assert len(inspect_result.systems.all()) == 0
 
     def test_post_processing(self):
         """Test process_results method with mock data."""
@@ -450,12 +450,12 @@ class SatelliteSixV1Test(TestCase):
                 process_results(self.api, [result], 1)
                 inspect_results = self.scan_task.inspection_result.systems.all()
                 sys_1_result = inspect_results.filter(name="sys_1").first()
-                self.assertEqual(sys_1_result.name, "sys_1")
-                self.assertEqual(sys_1_result.status, "success")
+                assert sys_1_result.name == "sys_1"
+                assert sys_1_result.status == "success"
                 result = {}
                 for fact in sys_1_result.facts.all():
                     result[fact.name] = json.loads(fact.value)
-                self.assertEqual(result, expected)
+                assert result == expected
                 mock_fields.assert_called_once_with(ANY, ANY)
                 mock_subs.assert_called_once_with(ANY)
 
@@ -504,7 +504,7 @@ class SatelliteSixV1Test(TestCase):
                     mocker.get(url, status_code=200, json=jsonresult)
                     self.api.hosts_facts(Value("i", ScanJob.JOB_RUN))
                     inspect_result = self.scan_task.inspection_result
-                    self.assertEqual(len(inspect_result.systems.all()), 1)
+                    assert len(inspect_result.systems.all()) == 1
 
 
 # pylint: disable=too-many-instance-attributes
@@ -566,7 +566,7 @@ class SatelliteSixV2Test(TestCase):
             }
             mocker.get(url, status_code=200, json=jsonresult)
             systems_count = self.api.host_count()
-            self.assertEqual(systems_count, 3)
+            assert systems_count == 3
 
     def test_host_count_with_err(self):
         """Test the method host_count with error."""
@@ -599,9 +599,9 @@ class SatelliteSixV2Test(TestCase):
             mocker.get(url, status_code=200, json=jsonresult)
             systems_count = self.api.host_count()
             hosts = self.api.hosts()
-            self.assertEqual(systems_count, 3)
-            self.assertEqual(len(hosts), 3)
-            self.assertEqual(hosts, ["sys1_1", "sys2_2", "sys3_3"])
+            assert systems_count == 3
+            assert len(hosts) == 3
+            assert hosts == ["sys1_1", "sys2_2", "sys3_3"]
 
     def test_hosts_with_err(self):
         """Test the method hosts with error."""
@@ -644,12 +644,12 @@ class SatelliteSixV2Test(TestCase):
                 "host_fields_response": {},
                 "host_subscriptions_response": {},
             }
-            self.assertEqual(result, expected)
+            assert result == expected
             process_results(self.api, [result], 1)
             inspect_results = self.scan_task.inspection_result.systems.all()
             sys_1_result = inspect_results.filter(name="sys_1").first()
-            self.assertEqual(sys_1_result.name, "sys_1")
-            self.assertEqual(sys_1_result.status, "failed")
+            assert sys_1_result.name == "sys_1"
+            assert sys_1_result.status == "failed"
 
     def test_host_fields(self):
         """Test the method host_fields."""
@@ -719,7 +719,7 @@ class SatelliteSixV2Test(TestCase):
                 "os_name": "RedHat",
                 "os_version": "7.4",
             }
-            self.assertEqual(host_info, expected)
+            assert host_info == expected
 
     def test_get_https_with_err(self):
         """Test the host subscriptons method with bad status code."""
@@ -749,7 +749,7 @@ class SatelliteSixV2Test(TestCase):
                 "host_fields_response": {},
                 "host_subscriptions_response": {},
             }
-            self.assertEqual(result, expected)
+            assert result == expected
 
     def test_processing_subs_err_nojson(self):
         """Test the flow of post processing with bad code and not json."""
@@ -776,8 +776,8 @@ class SatelliteSixV2Test(TestCase):
             process_results(self.api, [result], 1)
             inspect_results = self.scan_task.inspection_result.systems.all()
             sys_1_result = inspect_results.filter(name="sys_1").first()
-            self.assertEqual(sys_1_result.name, "sys_1")
-            self.assertEqual(sys_1_result.status, "failed")
+            assert sys_1_result.name == "sys_1"
+            assert sys_1_result.status == "failed"
 
     def test_host_not_subscribed(self):
         """Test the host subscriptons method for not subscribed error."""
@@ -809,8 +809,8 @@ class SatelliteSixV2Test(TestCase):
         process_results(self.api, [result], 1)
         inspect_results = self.scan_task.inspection_result.systems.all()
         sys_1_result = inspect_results.filter(name="sys_1").first()
-        self.assertEqual(sys_1_result.name, "sys_1")
-        self.assertEqual(sys_1_result.status, "failed")
+        assert sys_1_result.name == "sys_1"
+        assert sys_1_result.status == "failed"
 
     def test_host_subscriptons(self):
         """Test the host subscriptons method."""
@@ -862,7 +862,7 @@ class SatelliteSixV2Test(TestCase):
                     },
                 ]
             }
-            self.assertEqual(subs, expected)
+            assert subs == expected
 
     def test_post_processing_err(self):
         """Test error flow & check that a failed system is marked."""
@@ -875,8 +875,8 @@ class SatelliteSixV2Test(TestCase):
         process_results(self.api, [response], 1)
         inspect_results = self.scan_task.inspection_result.systems.all()
         sys_1_result = inspect_results.filter(name="sys_1").first()
-        self.assertEqual(sys_1_result.name, "sys_1")
-        self.assertEqual(sys_1_result.status, "failed")
+        assert sys_1_result.name == "sys_1"
+        assert sys_1_result.status == "failed"
 
     def test_post_processing(self):
         """Test process_results method with mock data."""
@@ -978,12 +978,12 @@ class SatelliteSixV2Test(TestCase):
                 process_results(self.api, [result], 1)
                 inspect_results = self.scan_task.inspection_result.systems.all()
                 sys_1_result = inspect_results.filter(name="sys_1").first()
-                self.assertEqual(sys_1_result.name, "sys_1")
-                self.assertEqual(sys_1_result.status, "success")
+                assert sys_1_result.name == "sys_1"
+                assert sys_1_result.status == "success"
                 result = {}
                 for fact in sys_1_result.facts.all():
                     result[fact.name] = json.loads(fact.value)
-                self.assertEqual(result, expected)
+                assert result == expected
                 mock_fields.assert_called_once_with(ANY, ANY)
                 mock_subs.assert_called_once_with(ANY)
                 mock_fields.assert_called_once_with(ANY, ANY)
@@ -1048,4 +1048,4 @@ class SatelliteSixV2Test(TestCase):
             mocker.get(url, status_code=200, json=jsonresult)
             api.hosts_facts(Value("i", ScanJob.JOB_RUN))
             inspect_result = scan_task.inspection_result
-            self.assertEqual(len(inspect_result.systems.all()), 1)
+            assert len(inspect_result.systems.all()) == 1

--- a/quipucords/scanner/satellite/tests_sat_utils.py
+++ b/quipucords/scanner/satellite/tests_sat_utils.py
@@ -67,22 +67,22 @@ class SatelliteUtilsTest(TestCase):
     def test_get_credential(self):
         """Test the method to extract credential."""
         cred = get_credential(self.scan_task)
-        self.assertEqual(cred, self.cred)
+        assert cred == self.cred
 
     def test_get_connect_data(self):
         """Test method to get connection data from task."""
         host, port, user, password = get_connect_data(self.scan_task)
-        self.assertEqual(host, "1.2.3.4")
-        self.assertEqual(port, 443)
-        self.assertEqual(user, "username")
-        self.assertEqual(password, "password")
+        assert host == "1.2.3.4"
+        assert port == 443
+        assert user == "username"
+        assert password == "password"
 
     def test_construct_url(self):
         """Test method to construct satellite url."""
         expected = "https://1.2.3.4:443/api/status"
         status_url = "https://{sat_host}:{port}/api/status"
         url = construct_url(status_url, "1.2.3.4")
-        self.assertEqual(url, expected)
+        assert url == expected
 
     def test_execute_request(self):
         """Test the method to execute a request against a satellite server."""
@@ -92,9 +92,9 @@ class SatelliteUtilsTest(TestCase):
             jsonresult = {"api_version": 2}
             mocker.get(url, status_code=200, json=jsonresult)
             response, formatted_url = execute_request(self.scan_task, status_url)
-            self.assertEqual(url, formatted_url)
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json(), jsonresult)
+            assert url == formatted_url
+            assert response.status_code == 200
+            assert response.json() == jsonresult
 
     @patch(
         "scanner.satellite.utils._status6",
@@ -103,9 +103,9 @@ class SatelliteUtilsTest(TestCase):
     def test_status_sat6(self, mock_status5):
         """Test a patched status request to Satellite 6 server."""
         status_code, api_version, satellite_version = status(self.scan_task)
-        self.assertEqual(status_code, 200)
-        self.assertEqual(api_version, SATELLITE_VERSION_6)
-        self.assertEqual(satellite_version, SATELLITE_VERSION_6)
+        assert status_code == 200
+        assert api_version == SATELLITE_VERSION_6
+        assert satellite_version == SATELLITE_VERSION_6
         mock_status5.assert_called_once_with(ANY)
 
     @patch("xmlrpc.client.ServerProxy")
@@ -115,9 +115,9 @@ class SatelliteUtilsTest(TestCase):
         client.auth.login.return_value = "key"
         client.auth.logout.return_value = "key"
         status_code, api_version, satellite_version = _status5(self.scan_task)
-        self.assertEqual(status_code, 200)
-        self.assertEqual(api_version, SATELLITE_VERSION_5)
-        self.assertEqual(satellite_version, SATELLITE_VERSION_5)
+        assert status_code == 200
+        assert api_version == SATELLITE_VERSION_5
+        assert satellite_version == SATELLITE_VERSION_5
 
     @patch("xmlrpc.client.ServerProxy")
     def test_status5_xmlfault(self, mock_serverproxy):
@@ -139,9 +139,9 @@ class SatelliteUtilsTest(TestCase):
             jsonresult = {"api_version": 2}
             mocker.get(url, status_code=200, json=jsonresult)
             status_code, api_version, satellite_version = status(self.scan_task)
-            self.assertEqual(status_code, 200)
-            self.assertEqual(api_version, 2)
-            self.assertEqual(satellite_version, SATELLITE_VERSION_6)
+            assert status_code == 200
+            assert api_version == 2
+            assert satellite_version == SATELLITE_VERSION_6
 
     @patch("xmlrpc.client.ServerProxy")
     def test_status_error(self, mock_serverproxy):
@@ -163,14 +163,14 @@ class SatelliteUtilsTest(TestCase):
         data = {"uuid": "100", "new::color": "blue", "key": "value"}
         expected = {"id": "100", "color": "blue"}
         mapped = data_map(map_dict, data)
-        self.assertEqual(mapped, expected)
+        assert mapped == expected
 
     def test_get_sat5_client(self):
         """Test the sat5 client helper."""
         client, user, password = get_sat5_client(self.scan_task)
-        self.assertIsNotNone(client)
-        self.assertEqual(user, "username")
-        self.assertEqual(password, "password")
+        assert client is not None
+        assert user == "username"
+        assert password == "password"
 
     def test_validate_task_stats(self):
         """Test validate task stats no errors."""

--- a/quipucords/scanner/vcenter/tests_vc_connect.py
+++ b/quipucords/scanner/vcenter/tests_vc_connect.py
@@ -59,7 +59,7 @@ class ConnectTaskRunnerTest(TestCase):
         vm_names = ["vm1", "vm2"]
         # pylint: disable=protected-access
         self.runner._store_connect_data(vm_names, self.cred, self.source)
-        self.assertEqual(len(self.scan_job.connection_results.task_results.all()), 1)
+        assert len(self.scan_job.connection_results.task_results.all()) == 1
 
     def test_get_vm_names(self):
         """Test the get vm names method."""
@@ -80,8 +80,8 @@ class ConnectTaskRunnerTest(TestCase):
         content.propertyCollector.RetrievePropertiesEx(ANY).objects = objects
 
         vm_names = get_vm_names(content)
-        self.assertTrue(isinstance(vm_names, list))
-        self.assertEqual(vm_names, ["vm1", "vm2"])
+        assert isinstance(vm_names, list)
+        assert vm_names == ["vm1", "vm2"]
 
     def test_connect(self):
         """Test the VCenter connect method."""
@@ -93,20 +93,20 @@ class ConnectTaskRunnerTest(TestCase):
                 return_value=["vm1", "vm2", "vm2"],
             ) as mock_names:
                 vm_names = self.runner.connect()
-                self.assertEqual(vm_names, ["vm1", "vm2", "vm2"])
+                assert vm_names == ["vm1", "vm2", "vm2"]
                 mock_vcenter_connect.assert_called_once_with(ANY)
                 mock_names.assert_called_once_with(ANY)
 
     def test_get_result_none(self):
         """Test get result method when no results exist."""
         results = self.scan_task.get_result().systems.first()
-        self.assertEqual(results, None)
+        assert results is None
 
     def test_get_result(self):
         """Test get result method when results exist."""
         conn_result = self.scan_task.connection_result
         results = self.scan_task.get_result()
-        self.assertEqual(results, conn_result)
+        assert results == conn_result
 
     def test_failed_run(self):
         """Test the run method."""
@@ -114,7 +114,7 @@ class ConnectTaskRunnerTest(TestCase):
             ConnectTaskRunner, "connect", side_effect=invalid_login
         ) as mock_connect:
             status = self.runner.run(Value("i", ScanJob.JOB_RUN))
-            self.assertEqual(ScanTask.FAILED, status[1])
+            assert ScanTask.FAILED == status[1]
             mock_connect.assert_called_once_with()
 
     def test_unreachable_run(self):
@@ -123,7 +123,7 @@ class ConnectTaskRunnerTest(TestCase):
             ConnectTaskRunner, "connect", side_effect=unreachable_host
         ) as mock_connect:
             status = self.runner.run(Value("i", ScanJob.JOB_RUN))
-            self.assertEqual(ScanTask.FAILED, status[1])
+            assert ScanTask.FAILED == status[1]
             mock_connect.assert_called_once_with()
 
     def test_run(self):
@@ -132,15 +132,15 @@ class ConnectTaskRunnerTest(TestCase):
             ConnectTaskRunner, "connect", return_value=["vm1", "vm2"]
         ) as mock_connect:
             status = self.runner.run(Value("i", ScanJob.JOB_RUN))
-            self.assertEqual(ScanTask.COMPLETED, status[1])
+            assert ScanTask.COMPLETED == status[1]
             mock_connect.assert_called_once_with()
 
     def test_cancel(self):
         """Test the run method with cancel."""
         status = self.runner.run(Value("i", ScanJob.JOB_TERMINATE_CANCEL))
-        self.assertEqual(ScanTask.CANCELED, status[1])
+        assert ScanTask.CANCELED == status[1]
 
     def test_pause(self):
         """Test the run method with pause."""
         status = self.runner.run(Value("i", ScanJob.JOB_TERMINATE_PAUSE))
-        self.assertEqual(ScanTask.PAUSED, status[1])
+        assert ScanTask.PAUSED == status[1]

--- a/quipucords/scanner/vcenter/tests_vc_inspect.py
+++ b/quipucords/scanner/vcenter/tests_vc_inspect.py
@@ -74,18 +74,18 @@ class InspectTaskRunnerTest(TestCase):
             nics.append(nic)
         guest.net = nics
         mac_addresses, ip_addresses = get_nics(guest.net)
-        self.assertEqual(mac_addresses, ["mac0", "mac1"])
-        self.assertEqual(ip_addresses, ["ip0", "ip1"])
+        assert mac_addresses == ["mac0", "mac1"]
+        assert ip_addresses == ["ip0", "ip1"]
 
     def test__none(self):
         """Test get result method when no results exist."""
         results = self.scan_task.get_result().systems.first()
-        self.assertEqual(results, None)
+        assert results is None
 
     def test_get_result(self):
         """Test get results method when results exist."""
         results = self.scan_task.get_result()
-        self.assertEqual(results, self.scan_task.inspection_result)
+        assert results == self.scan_task.inspection_result
 
     def test_parse_parent_props(self):
         """Test the parse_parent_props_method."""
@@ -103,7 +103,7 @@ class InspectTaskRunnerTest(TestCase):
             "parent": str(folder),
         }
         results = self.runner.parse_parent_props(obj, props)
-        self.assertEqual(results, expected_facts)
+        assert results == expected_facts
 
     def test_parse_cluster_props(self):
         """Test the parse_cluster_props_method."""
@@ -121,7 +121,7 @@ class InspectTaskRunnerTest(TestCase):
 
         expected_facts = {"cluster.name": "cluster1", "cluster.datacenter": "dc1"}
         results = self.runner.parse_cluster_props(props, parents_dict)
-        self.assertEqual(results, expected_facts)
+        assert results == expected_facts
 
     def test_parse_host_props(self):
         """Test the parse_host_props_method."""
@@ -160,7 +160,7 @@ class InspectTaskRunnerTest(TestCase):
         }
 
         results = self.runner.parse_host_props(props, cluster_dict)
-        self.assertEqual(results, expected_facts)
+        assert results == expected_facts
 
     # pylint: disable=too-many-locals
     @patch("scanner.vcenter.inspect.datetime")
@@ -240,9 +240,9 @@ class InspectTaskRunnerTest(TestCase):
                 # Must read as JSON as this is what task.py does
                 sys_fact[raw_fact.name] = json.loads(raw_fact.value)
 
-            self.assertEqual(1, len(sys_results))
-            self.assertEqual("vm1", sys_results.first().name)
-            self.assertEqual(expected_facts, sys_fact)
+            assert 1 == len(sys_results)
+            assert "vm1" == sys_results.first().name
+            assert expected_facts == sys_fact
 
     # pylint: disable=too-many-locals
     def test_retrieve_properties(self):
@@ -310,7 +310,7 @@ class InspectTaskRunnerTest(TestCase):
             InspectTaskRunner, "inspect", side_effect=invalid_login
         ) as mock_connect:
             status = self.runner.run(Value("i", ScanJob.JOB_RUN))
-            self.assertEqual(ScanTask.FAILED, status[1])
+            assert ScanTask.FAILED == status[1]
             mock_connect.assert_called_once_with()
 
     def test_prereq_failed(self):
@@ -318,21 +318,21 @@ class InspectTaskRunnerTest(TestCase):
         self.connect_scan_task.status = ScanTask.FAILED
         self.connect_scan_task.save()
         status = self.runner.run(Value("i", ScanJob.JOB_RUN))
-        self.assertEqual(ScanTask.FAILED, status[1])
+        assert ScanTask.FAILED == status[1]
 
     def test_run(self):
         """Test the run method."""
         with patch.object(InspectTaskRunner, "inspect") as mock_connect:
             status = self.runner.run(Value("i", ScanJob.JOB_RUN))
-            self.assertEqual(ScanTask.COMPLETED, status[1])
+            assert ScanTask.COMPLETED == status[1]
             mock_connect.assert_called_once_with()
 
     def test_cancel(self):
         """Test the cancel method."""
         status = self.runner.run(Value("i", ScanJob.JOB_TERMINATE_CANCEL))
-        self.assertEqual(ScanTask.CANCELED, status[1])
+        assert ScanTask.CANCELED == status[1]
 
     def test_pause(self):
         """Test the pause method."""
         status = self.runner.run(Value("i", ScanJob.JOB_TERMINATE_PAUSE))
-        self.assertEqual(ScanTask.PAUSED, status[1])
+        assert ScanTask.PAUSED == status[1]

--- a/quipucords/scanner/vcenter/tests_vc_utils.py
+++ b/quipucords/scanner/vcenter/tests_vc_utils.py
@@ -45,7 +45,7 @@ class VCenterUtilsTest(TestCase):
             "scanner.vcenter.utils.SmartConnectNoSSL", return_value=mock_vcenter
         ) as mock_smart_connect:
             vcenter = vcenter_connect(self.scan_task)
-            self.assertEqual(mock_vcenter, vcenter)
+            assert mock_vcenter == vcenter
             mock_smart_connect.assert_called_once_with(
                 host=ANY, user=ANY, pwd=ANY, port=ANY
             )


### PR DESCRIPTION
plain asserts are way more powerful for debugging with pytest.

"BUT WHY?", you might be asking... I decided to write about it [here](https://bruno-fs.github.io/posts/test-assertion-styles/)

NOTE: pylint directive `use-implicit-booleaness-not-comparison` is failing. I think we should disable those globally in tests.
Thoughts?