### PR TITLE
fix: removed unneeded json.dumps for a Source hosts

### DIFF
--- a/quipucords/fingerprinter/tests_fingerprint_task.py
+++ b/quipucords/fingerprinter/tests_fingerprint_task.py
@@ -1,6 +1,5 @@
 """Test the fact engine API."""
 
-import json
 from copy import deepcopy
 from datetime import datetime
 from unittest import mock
@@ -122,7 +121,7 @@ class EngineTest(TestCase):
         self.server_id = ServerInformation.create_or_retrieve_server_id()
         self.source = Source(
             name="source1",
-            hosts=json.dumps(["1.2.3.4"]),
+            hosts=["1.2.3.4"],
             source_type="network",
             port=22,
         )


### PR DESCRIPTION
fix: removed unneeded json.dumps for a Source hosts

Remove an unneeded json.dumps for the hosts of a Source. Source hosts are now Python objects. This passed earlier because the hosts field was not being used in those tests.