### PR TITLE
misc scan manager (and related) cleanups

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -373,3 +373,7 @@ CELERY_TASK_ALWAYS_EAGER = env.bool("CELERY_TASK_ALWAYS_EAGER", False)
 
 # Load Feature Flags
 QPC_FEATURE_FLAGS = FeatureFlag()
+
+# Old hidden/buried configurations that should be removed or renamed
+MAX_TIMEOUT_ORDERLY_SHUTDOWN = env.int("MAX_TIMEOUT_ORDERLY_SHUTDOWN", 30)
+QUIPUCORDS_MANAGER_HEARTBEAT = env.int("QUIPUCORDS_MANAGER_HEARTBEAT", 60 * 15)

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -27,7 +27,7 @@ def create_task_runner(scan_job: ScanJob, scan_task: ScanTask):
         return create_inspect_task_runner(scan_job, scan_task)
     if scan_type == ScanTask.SCAN_TYPE_FINGERPRINT:
         return FingerprintTaskRunner(scan_job, scan_task)
-    return None
+    raise NotImplementedError
 
 
 def create_connect_task_runner(scan_job: ScanJob, scan_task: ScanTask):

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -55,7 +55,7 @@ class ScanJobRunner(Process):
             self.scan_job.fail(error_message)
             return ScanTask.FAILED
 
-        # Load tasks that have no been run or are in progress
+        # Load tasks that have not been run or are in progress
         task_runners = []
 
         incomplete_scan_tasks = self.scan_job.tasks.filter(
@@ -177,7 +177,10 @@ class ScanJobRunner(Process):
         return None
 
     def _run_task(self, runner):
-        """Run a sigle scan task."""
+        """Run a single scan task.
+
+        :param runner: ScanTaskRunner
+        """
         # pylint: disable=no-else-return
         if self.manager_interrupt.value == ScanJob.JOB_TERMINATE_CANCEL:
             self.manager_interrupt.value = ScanJob.JOB_TERMINATE_ACK
@@ -241,7 +244,6 @@ class ScanJobRunner(Process):
     def _create_details_report(self):
         """Send collected host scan facts to fact endpoint.
 
-        :param facts: The array of fact dictionaries
         :returns: bool indicating if there are errors and dict with result.
         """
         inspect_tasks = self.scan_job.tasks.filter(

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -15,8 +15,7 @@ from api.models import ScanJob, ScanTask
 from fingerprinter.task import FingerprintTaskRunner
 from scanner.get_scanner import get_scanner
 
-# Get an instance of a logger
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 class ScanJobRunner(Process):

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -60,7 +60,6 @@ class Manager(Thread):
 
     def log_info(self):
         """Log the status of the scan manager."""
-        current_scan_job = None
         if self.current_job_runner:
             current_scan_job = self.current_job_runner.identifier
             scan_job_message = f"Currently running scan job {current_scan_job}"

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -12,8 +12,7 @@ from django.db.models import Q
 from api.models import ScanJob, ScanTask
 from scanner.job import ScanJobRunner
 
-# Get an instance of a logger
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 class DisabledManager:
@@ -81,7 +80,7 @@ class Manager(Thread):
 
     def work(self):
         """Start to execute scans in the queue."""
-        if len(self.scan_queue) > 0:  # pylint: disable=C1801
+        if len(self.scan_queue) > 0:
             self.current_job_runner = self.scan_queue.pop()
             if self.current_job_runner.scan_job.status in [
                 ScanTask.PENDING,

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -1,5 +1,7 @@
 """Queue Manager module."""
 
+from __future__ import annotations
+
 import logging
 from threading import Thread, Timer
 from time import sleep
@@ -44,9 +46,9 @@ class Manager(Thread):
     def __init__(self):
         """Initialize the manager."""
         Thread.__init__(self)
-        self.scan_queue = []
-        self.current_job_runner = None
-        self.terminated_job_runner = None
+        self.scan_queue = []  # type: list[ScanJobRunner]
+        self.current_job_runner = None  # type: ScanJobRunner | None
+        self.terminated_job_runner = None  # type: ScanJobRunner | None
         self.termination_elapsed_time = 0
         self.running = True
         logger.info("%s: Scan manager instance created.", SCAN_MANAGER_LOG_PREFIX)
@@ -101,19 +103,20 @@ class Manager(Thread):
                     error, log_level=logging.ERROR
                 )
 
-    def put(self, job):
-        """Add job to scan queue.
+    def put(self, job: ScanJobRunner):
+        """Add a ScanJobRunner to scan queue.
 
-        :param job: Job to be performed.
+        :param job: ScanJobRunner to run.
         """
         self.scan_queue.insert(0, job)
         self.log_info()
 
     # pylint: disable=inconsistent-return-statements
-    def kill(self, job, command):
-        """Kill a job or remove it from the running queue.
+    def kill(self, job: ScanJob, command: str):
+        """Kill a ScanJob or remove it from the running queue.
 
-        :param job: The job to kill.
+        :param job: The ScanJob to kill.
+        :param command: string "cancel" or "pause".
         :returns: True if killed, False otherwise.
         """
         killed = False

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -79,7 +79,7 @@ class Manager(Thread):
         )
 
     def work(self):
-        """Start to excute scans in the queue."""
+        """Start to execute scans in the queue."""
         if len(self.scan_queue) > 0:  # pylint: disable=C1801
             self.current_job_runner = self.scan_queue.pop()
             if self.current_job_runner.scan_job.status in [

--- a/quipucords/scanner/task.py
+++ b/quipucords/scanner/task.py
@@ -67,7 +67,7 @@ class ScanTaskRunner(metaclass=ABCMeta):
         before returning.
 
         :param manager_interrupt: Shared memory Value which can inform
-        a task of the need to shutdown immediately
+        a task of the need to shut down immediately
         :returns: Returns a status message to be saved/displayed and
         the ScanTask.STATUS_CHOICES status
         """


### PR DESCRIPTION
In a separate branch, I'm trying to understand and tease apart some of the scan management code so that I can start replacing local threads/processes/pools with Celery tasks. This PR just yanks some cleanup commits from that other branch so that branch doesn't grow too big too fast. There will be many more like this to make Celery a reality for quipucords.

- Replace more of those deep `os.environ` calls with more sensible Django settings.
- Fix or expand some old docstrings as I encounter them. I'm also adding a few type hints because the types are sometimes not at all obvious (or even counterintuitive based on variable names).
- Extract a few class methods into standalone functions because I expect soon I will need to call them from other places.