### PR TITLE
refactor(ScanJobRunner): unbind "runner" logic from multiprocessing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,7 @@ from functools import partial
 from urllib.parse import urljoin
 
 import pytest
+from django.test import override_settings
 
 
 @pytest.fixture(autouse=True)
@@ -20,10 +21,10 @@ def scan_manager(mocker):
     _manager = DummyScanManager()
     mocker.patch("scanner.manager.Manager", DummyScanManager)
     mocker.patch("scanner.manager.SCAN_MANAGER", _manager)
-    yield _manager
-    for job in _manager._queue:
-        job.kill()
-    _manager._queue = []
+    with override_settings(
+        QPC_DISABLE_MULTIPROCESSING_SCAN_JOB_RUNNER=True,
+    ):
+        yield _manager
 
 
 @pytest.fixture(scope="session")

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -32,6 +32,9 @@ BASE_DIR = Path(__file__).absolute().parent.parent
 PRODUCTION = env.bool("PRODUCTION", False)
 
 QPC_DISABLE_THREADED_SCAN_MANAGER = env.bool("QPC_DISABLE_THREADED_SCAN_MANAGER", False)
+QPC_DISABLE_MULTIPROCESSING_SCAN_JOB_RUNNER = env.bool(
+    "QPC_DISABLE_MULTIPROCESSING_SCAN_JOB_RUNNER", False
+)
 
 # This suppresses warnings for models where an explicit primary key is not defined.
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -33,7 +33,9 @@ class DisabledManager:
 
     def put(self, *args, **kwargs):
         """Log a warning message because DisabledManager does nothing."""
-        logger.warning("Cannot put a job on the scan manager because it is disabled.")
+        logger.warning(
+            "Cannot put a scanner on queue because scan manager is disabled."
+        )
 
 
 class Manager(Thread):
@@ -102,10 +104,10 @@ class Manager(Thread):
                     error, log_level=logging.ERROR
                 )
 
-    def put(self, job: ScanJobRunner):
+    def put(self, scanner: ScanJobRunner):
         """Add a ScanJobRunner to scan queue.
 
-        :param job: ScanJobRunner to run.
+        :param scanner: ScanJobRunner to run.
         """
         assert isinstance(scanner, ProcessBasedScanJobRunner), (
             "Non-multiprocessing ScanJobRunner can't be used alongside thread "

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db.models import Q
 
 from api.models import ScanJob, ScanTask
-from scanner.job import ScanJobRunner
+from scanner.job import ProcessBasedScanJobRunner, ScanJobRunner
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,11 @@ class Manager(Thread):
 
         :param job: ScanJobRunner to run.
         """
-        self.scan_queue.insert(0, job)
+        assert isinstance(scanner, ProcessBasedScanJobRunner), (
+            "Non-multiprocessing ScanJobRunner can't be used alongside thread "
+            "based ScanManager."
+        )
+        self.scan_queue.insert(0, scanner)
         self.log_info()
 
     # pylint: disable=inconsistent-return-statements

--- a/quipucords/tests/dummy_scan_manager.py
+++ b/quipucords/tests/dummy_scan_manager.py
@@ -1,20 +1,6 @@
 """Dummy scan manager module - a replacement on [Scan]Manager for tests."""
 
-import multiprocessing
-from contextlib import contextmanager
-from datetime import datetime
-from multiprocessing import Process
-
-
-@contextmanager
-def set_mp_start_method(start_method):
-    """Set the multiprocessing start method for the yielded block."""
-    current_start_method = multiprocessing.get_start_method()
-    try:
-        multiprocessing.set_start_method(start_method, force=True)
-        yield
-    finally:
-        multiprocessing.set_start_method(current_start_method, force=True)
+from scanner.job import ScanJobRunner
 
 
 class SingletonMeta(type):
@@ -40,8 +26,6 @@ class DummyScanManager(metaclass=SingletonMeta):
     def __init__(self):
         """Inititialize DummyScanManager."""
         self._queue = []
-        self._start_dt = None
-        self.timeout_seconds = 15
 
     def put(self, job):
         """Add job to queue."""
@@ -51,32 +35,11 @@ class DummyScanManager(metaclass=SingletonMeta):
         """Check if DummyScanManager is 'alive'."""
         return True
 
-    @property
-    def _timed_out(self):
-        elapsed_time = datetime.now() - self._start_dt
-        if elapsed_time.seconds > self.timeout_seconds:
-            return True
-        return False
-
     def work(self):
         """Execute scan queue synchronously."""
-        self._start_dt = datetime.now()
-        if self._timed_out:
-            return
         while self._queue:
-            current_job: Process = self._queue.pop()
-            # Some uses of the Scan manager's work() attempts to fetch data
-            # from OpenShift. In such test cases, we Mock the OpenShiftApi.
-            # Note that Mocks do not work on MacOS as the default invocation
-            # method is spawn instead of a fork. If using spawn, a new Python
-            # interpreter is launched in which the Mocks are not honored so
-            # we need to invoke the tested code via fork.
-            with set_mp_start_method("fork"):
-                current_job.start()
-            while current_job.exitcode is None:
-                if self._timed_out:
-                    current_job.kill()
-                    return
+            job_runner: ScanJobRunner = self._queue.pop()
+            job_runner.start()
 
     def kill(self, job, command):  # pylint: disable=unused-argument
         """Mimic ScanManager kill method signature."""


### PR DESCRIPTION
With this small change we can finally run tests synchronously.

The "timeout" related code was also removed from DummyScanManager because that same behavior in tests can be achieved through pytest-timeout (with --timeout=15).