### PR TITLE
fix: fix broken build-container on Mac M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV PYTHONPATH=/app/quipucords
 ENV QUIPUCORDS_LOG_LEVEL=INFO
 
 COPY scripts/dnf /usr/local/bin/dnf
+ARG BUILD_PACKAGES="gcc postgresql-devel python39-devel"
 RUN dnf install \
         git \
         glibc-langpack-en \
@@ -25,6 +26,7 @@ RUN dnf install \
         sshpass \
         tar \
         which \
+        ${BUILD_PACKAGES} \
         -y &&\
     dnf clean all &&\
     python3 -m venv /opt/venv
@@ -34,6 +36,8 @@ RUN pip install --upgrade pip wheel
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+RUN dnf remove ${BUILD_PACKAGES} -y && \
+    dnf clean all
 
 # Fetch UI code
 COPY Makefile .


### PR DESCRIPTION

fix: fix broken build-container on Mac M1

make build-container was failing on M1 Macs. Dockerfile could not install psycopg2_binary as it tries to build it for aarch64. Was missing gcc, postgresql-devel and the python39-devel packages.