### PR TITLE
chore: Adding the man command to the server image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN dnf install \
         glibc-langpack-en \
         jq \
         make \
+        man-db \
+        man \
         openssh-clients \
         python39 \
         sshpass \


### PR DESCRIPTION

chore: Adding the man command to the server image

Adding the `man-db` and `man` packages to the quipucords server docker image.

This provides the man command, but no man pages are installed by default.
(default microdnf behavior is --nodocs)

Before PR:

```
$ podman run quipucords man ls
Error: preparing container 5cac... for attach: crun: executable file `man` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found
```

After PR:

```
$ podman run quipucords man ls
No manual entry for ls
```
