### PR TITLE
fix(CredentialSerializer): remove custom "strict" validation

### DIFF
--- a/quipucords/api/credential/serializer.py
+++ b/quipucords/api/credential/serializer.py
@@ -108,19 +108,6 @@ class CredentialSerializer(NotEmptySerializer):
             raise ValidationError(_(messages.CRED_TYPE_NOT_ALLOWED_UPDATE))
         return cred_type
 
-    def validate(self, attrs):
-        """Validate if fields received are appropriate for each credential."""
-        errors = {}
-        if hasattr(self, "initial_data"):
-            unknown_keys = set(self.initial_data.keys()) - set(self.fields.keys())
-            for key in unknown_keys:
-                errors[key] = (
-                    messages.FIELD_NOT_ALLOWED_FOR_DATA_SOURCE % attrs["cred_type"]
-                )
-        if errors:
-            raise ValidationError(errors)
-        return attrs
-
     def to_representation(self, instance):
         """Overload DRF representation method to mask encrypted fields."""
         _data = super().to_representation(instance)

--- a/quipucords/api/credential/test_serializer.py
+++ b/quipucords/api/credential/test_serializer.py
@@ -105,11 +105,11 @@ def test_openshift_cred_correct_fields():
         ),
     ),
 )
-def test_openshift_cred_unallowed_fields(input_data, improper_fields):
-    """Test if serializer is invalid when passing unallowed fields."""
+def test_improper_fields(input_data, improper_fields):
+    """Test if serializer is invalid when passing improper fields."""
     serializer = CredentialSerializer(data=input_data)
-    assert not serializer.is_valid()
-    assert improper_fields == set(serializer.errors.keys())
+    assert serializer.is_valid()
+    assert all(serializer.data.get(field) is None for field in improper_fields)
 
 
 @pytest.mark.django_db

--- a/quipucords/api/credential/tests_credential.py
+++ b/quipucords/api/credential/tests_credential.py
@@ -443,8 +443,10 @@ class CredentialTest(TestCase):
             "ssh_keyfile": "keyfile",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["ssh_keyfile"]
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.ssh_keyfile is None
 
     def test_vc_create_extra_become_pass(self):
         """Test VCenter with extra become password."""
@@ -457,8 +459,10 @@ class CredentialTest(TestCase):
             "become_password": "pass2",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["become_password"]
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.become_password is None
 
     def test_vcentercred_update(self):
         """Ensure we can create and update a vcenter credential."""
@@ -552,8 +556,10 @@ class CredentialTest(TestCase):
             "ssh_passphrase": "pass2",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["ssh_passphrase"]
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.ssh_passphrase is None
 
     def test_sat_cred_create(self):
         """Ensure we can create a new satellite credential."""
@@ -612,8 +618,11 @@ class CredentialTest(TestCase):
         response = self.client.patch(
             url, json.dumps(update_data), content_type="application/json", format="json"
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["ssh_keyfile"]
+        assert response.status_code == status.HTTP_200_OK
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.name == "newName"
+        assert cred.ssh_keyfile is None
 
     def test_sat_create_extra_keyfile(self):
         """Test Satellite without password."""
@@ -626,8 +635,10 @@ class CredentialTest(TestCase):
             "ssh_keyfile": "keyfile",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["ssh_keyfile"]
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.ssh_keyfile is None
 
     def test_sat_create_extra_becomepass(self):
         """Test Satellite with extra become password."""
@@ -640,8 +651,10 @@ class CredentialTest(TestCase):
             "become_password": "pass2",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["become_password"]
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.become_password is None
 
     def test_sat_create_extra_keyfile_pass(self):
         """Test Satellite with extra keyfile passphase."""
@@ -654,8 +667,10 @@ class CredentialTest(TestCase):
             "ssh_passphrase": "pass2",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["ssh_passphrase"]
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.ssh_keyfile is None
 
     def test_openshift_cred_create(self):
         """Ensure we can create a new openshift credential."""
@@ -690,8 +705,12 @@ class CredentialTest(TestCase):
             "username": "test_username",
         }
         response = self.client.post(url, json.dumps(data), "application/json")
-        assert response.status_code, status.HTTP_400_BAD_REQUEST
-        assert response.data["become_password"] and response.data["username"]
+        assert response.status_code
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Credential.objects.count() == 1
+        cred = Credential.objects.get()
+        assert cred.become_password is None
+        assert cred.username is None
 
 
 # tuple of triples (input, expected output, pytest-param-id)


### PR DESCRIPTION
The extra validation for non expected keys was both poorly ported from the original CredentialSerializer implementation and unnecessary. DRF Serializers default behavior is to completely ignore unexpected data, so the validation was only required when everything was just one huge serializer.

updates DISCOVERY-287

context here: https://url.corp.redhat.com/95032f2