### PR TITLE
refactor(.gitignore): ignore flakeheaven cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,8 @@ quipucords/roles/
 # asdf
 .tool-versions
 
+# flakeheaven
+.flakeheaven_cache
+
 # local files
 var/


### PR DESCRIPTION
I'm not sure when or what triggered this change, but recently (within the last week maybe?), `flakeheaven` has been using a local `.flakeheaven_cache` directory in the project root.