### PR TITLE
fix: source validation and error message

### DIFF
--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -64,7 +64,7 @@ NET_CIDR_RANGE = (
 )
 NET_INVALID_PORT = "Source of type network must have ssh port in range [0, 65535]"
 NET_HC_DO_NOT_EXIST = "Host credential with id=%d could not be found in database."
-NET_SSL_OPTIONS_NOT_ALLOWED = "Invalid SSL options for network source: %s"
+NET_SSL_OPTIONS_NOT_ALLOWED = "Invalid SSL options for network source: %(options)s"
 INVALID_OPTIONS = "Invalid options for '%(source_type)s': %(options)s."
 SOURCE_ONE_HOST = "This source must have a single host."
 SOURCE_EXCLUDE_HOSTS_INCLUDED = "The exclude_hosts option is not valid for this source."

--- a/quipucords/api/source/serializer.py
+++ b/quipucords/api/source/serializer.py
@@ -127,10 +127,11 @@ class SourceSerializer(NotEmptySerializer):
         if invalid_options:
             error = {
                 "options": [
-                    _(message).format(
-                        source_type=source_type,
-                        options=", ".join(invalid_options),
-                    )
+                    _(message)
+                    % {
+                        "source_type": source_type,
+                        "options": ", ".join(invalid_options),
+                    }
                 ]
             }
             raise ValidationError(error)
@@ -569,11 +570,10 @@ class SourceSerializer(NotEmptySerializer):
         else:
             default_port = 443
         self._set_default_port(attrs, default_port)
-        if credentials:
-            self._validate_number_hosts_and_credentials(
-                hosts_list,
-                source_type,
-                credentials,
-                exclude_hosts_list,
-            )
+        self._validate_number_hosts_and_credentials(
+            hosts_list,
+            source_type,
+            credentials,
+            exclude_hosts_list,
+        )
         return attrs


### PR DESCRIPTION
A regression on camayoc side highlighted the new code was allowing the addition of extra hosts in sources that only allowed for a single host.

Also, the error message for invalid options was not being properly formatted.