### PR TITLE
refactor: get rid of ReadOnlyCredentialSerializer

### DIFF
--- a/quipucords/api/credential/serializer.py
+++ b/quipucords/api/credential/serializer.py
@@ -235,14 +235,3 @@ class NetworkCredentialSerializer(CredentialSerializer):
             data["ssh_keyfile"] = None
         elif ssh_keyfile:
             data["password"] = None
-
-
-class ReadOnlyCredentialSerializer(NotEmptySerializer):
-    """A specialized serializer for scanner needs."""
-
-    class Meta:
-        """Metadata for the serializer."""
-
-        model = Credential
-        fields = "__all__"
-        read_only_fields = [field.name for field in Credential._meta.fields]

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -7,7 +7,7 @@ from api.connresult.serializer import (
     SystemConnectionResultSerializer,
     TaskConnectionResultSerializer,
 )
-from api.credential.serializer import CredentialSerializer, ReadOnlyCredentialSerializer
+from api.credential.serializer import CredentialSerializer
 from api.deployments_report.serializer import (
     DeploymentReportSerializer,
     SystemFingerprintSerializer,

--- a/quipucords/scanner/network/connect.py
+++ b/quipucords/scanner/network/connect.py
@@ -8,6 +8,7 @@ import pexpect
 from ansible_runner.exceptions import AnsibleRunnerException
 from django.conf import settings
 from django.db import transaction
+from django.forms import model_to_dict
 
 import log_messages
 from api.models import (
@@ -17,7 +18,6 @@ from api.models import (
     ScanTask,
     SystemConnectionResult,
 )
-from api.serializers import ReadOnlyCredentialSerializer as CredentialSerializer
 from api.serializers import SourceSerializer
 from api.vault import decrypt_data_as_unicode, write_to_yaml
 from scanner.network.connect_callback import ConnectResultCallback
@@ -236,7 +236,7 @@ def _connect(  # pylint: disable=too-many-arguments
             list of host that failed connection
     """
     # pylint: disable=too-many-locals, disable=too-many-statements, too-many-branches
-    cred_data = CredentialSerializer(credential).data
+    cred_data = model_to_dict(credential)
     group_names, inventory = construct_inventory(
         hosts=hosts,
         credential=cred_data,

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -5,6 +5,7 @@ import os.path
 import ansible_runner
 from ansible_runner.exceptions import AnsibleRunnerException
 from django.conf import settings
+from django.forms import model_to_dict
 
 import log_messages
 from api.models import (
@@ -14,7 +15,6 @@ from api.models import (
     SystemConnectionResult,
     SystemInspectionResult,
 )
-from api.serializers import ReadOnlyCredentialSerializer as CredentialSerializer
 from api.vault import write_to_yaml
 from scanner.exceptions import ScanFailureError
 from scanner.network.exceptions import ScannerException
@@ -289,8 +289,8 @@ class InspectTaskRunner(ScanTaskRunner):
         for result in self.connect_scan_task.connection_result.systems.all():
             if result.status == SystemConnectionResult.SUCCESS:
                 host_cred = result.credential
-                serializer = CredentialSerializer(host_cred)
-                connected.append((result.name, serializer.data))
+                cred_data = model_to_dict(host_cred)
+                connected.append((result.name, cred_data))
 
         for result in self.scan_task.inspection_result.systems.all():
             if result.status == SystemInspectionResult.SUCCESS:

--- a/quipucords/scanner/network/tests_network_connect.py
+++ b/quipucords/scanner/network/tests_network_connect.py
@@ -5,11 +5,11 @@ from multiprocessing import Value
 from unittest.mock import Mock, patch
 
 from ansible_runner.exceptions import AnsibleRunnerException
+from django.forms import model_to_dict
 from django.test import TestCase
 
 from api.connresult.model import SystemConnectionResult
 from api.models import Credential, ScanJob, ScanOptions, ScanTask, Source, SourceOptions
-from api.serializers import ReadOnlyCredentialSerializer as CredentialSerializer
 from api.serializers import SourceSerializer
 from scanner.network import ConnectTaskRunner
 from scanner.network.connect import ConnectResultStore, _connect, construct_inventory
@@ -123,8 +123,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
 
     def test_construct_vars(self):
         """Test constructing ansible vars dictionary."""
-        hc_serializer = CredentialSerializer(self.cred)
-        cred = hc_serializer.data
+        cred = model_to_dict(self.cred)
         vars_dict = _construct_vars(22, cred)
         expected = {
             "ansible_become_pass": "become",
@@ -168,8 +167,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         hosts = source["hosts"]
         exclude_hosts = source["exclude_hosts"]
         connection_port = source["port"]
-        hc_serializer = CredentialSerializer(self.cred)
-        cred = hc_serializer.data
+        cred = model_to_dict(self.cred)
         _, inventory_dict = construct_inventory(
             hosts=hosts,
             credential=cred,
@@ -348,8 +346,7 @@ class NetworkConnectTaskRunnerTest(TestCase):
         source = serializer.data
         hosts = source["hosts"]
         connection_port = source["port"]
-        hc_serializer = CredentialSerializer(self.cred)
-        cred = hc_serializer.data
+        cred = model_to_dict(self.cred)
         _, inventory_dict = construct_inventory(
             hosts=hosts,
             credential=cred,

--- a/quipucords/scanner/network/tests_network_inspect.py
+++ b/quipucords/scanner/network/tests_network_inspect.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, Mock, patch
 import pytest
 import requests_mock
 from ansible_runner.exceptions import AnsibleRunnerException
+from django.forms import model_to_dict
 from django.test import TestCase
 from django.urls import reverse
 
@@ -19,7 +20,6 @@ from api.models import (
     SourceOptions,
     SystemConnectionResult,
 )
-from api.serializers import ReadOnlyCredentialSerializer as CredentialSerializer
 from api.serializers import SourceSerializer
 from scanner.network import InspectTaskRunner
 from scanner.network.exceptions import NetworkCancelException, NetworkPauseException
@@ -47,8 +47,7 @@ class NetworkInspectScannerTest(TestCase):
         )
         self.cred.save()
 
-        hc_serializer = CredentialSerializer(self.cred)
-        self.cred_data = hc_serializer.data
+        self.cred_data = model_to_dict(self.cred)
 
         # setup source for scan
         self.source = Source(name="source1", port=22, hosts=["1.2.3.4"])
@@ -123,14 +122,12 @@ class NetworkInspectScannerTest(TestCase):
         serializer = SourceSerializer(self.source)
         source = serializer.data
         connection_port = source["port"]
-        hc_serializer = CredentialSerializer(self.cred)
-        cred = hc_serializer.data
         inventory_dict = construct_inventory(
             [
-                ("1.2.3.1", cred),
-                ("1.2.3.2", cred),
-                ("1.2.3.3", cred),
-                ("1.2.3.4", cred),
+                ("1.2.3.1", self.cred_data),
+                ("1.2.3.2", self.cred_data),
+                ("1.2.3.3", self.cred_data),
+                ("1.2.3.4", self.cred_data),
             ],
             connection_port,
             1,


### PR DESCRIPTION
Here I'm revisiting credential serializer again 😮‍💨 

Found out a way to get rid of `ReadOnlyCredentialSerializer`