### PR TITLE
more scanner runner cleanup

### DIFF
--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -116,16 +116,6 @@ class SyncScanJobRunner:
         for scan_task in incomplete_scan_tasks:
             runner_class = get_task_runner_class(scan_task)
             runner = runner_class(self.scan_job, scan_task)
-            if not runner:
-                error_message = (
-                    "Scan task has not recognized"
-                    f" type/source combination: {scan_task}"
-                )
-
-                scan_task.fail(error_message)
-                self.scan_job.fail(error_message)
-                return ScanTask.FAILED
-
             if isinstance(runner, FingerprintTaskRunner):
                 fingerprint_task_runner = runner
             else:

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -25,24 +25,14 @@ def create_task_runner(scan_job: ScanJob, scan_task: ScanTask):
     """Create ScanTaskRunner using scan_type and source_type."""
     scan_type = scan_task.scan_type
     if scan_type == ScanTask.SCAN_TYPE_CONNECT:
-        return create_connect_task_runner(scan_job, scan_task)
+        scanner = get_scanner(scan_task.source.source_type)
+        return scanner.ConnectTaskRunner(scan_job, scan_task)
     if scan_type == ScanTask.SCAN_TYPE_INSPECT:
-        return create_inspect_task_runner(scan_job, scan_task)
+        scanner = get_scanner(scan_task.source.source_type)
+        return scanner.InspectTaskRunner(scan_job, scan_task)
     if scan_type == ScanTask.SCAN_TYPE_FINGERPRINT:
         return FingerprintTaskRunner(scan_job, scan_task)
     raise NotImplementedError
-
-
-def create_connect_task_runner(scan_job: ScanJob, scan_task: ScanTask):
-    """Create connection TaskRunner using source_type."""
-    scanner = get_scanner(scan_task.source.source_type)
-    return scanner.ConnectTaskRunner(scan_job, scan_task)
-
-
-def create_inspect_task_runner(scan_job: ScanJob, scan_task: ScanTask):
-    """Create inspection TaskRunner using source_type."""
-    scanner = get_scanner(scan_task.source.source_type)
-    return scanner.InspectTaskRunner(scan_job, scan_task)
 
 
 class ScanJobRunner:

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -96,9 +96,7 @@ class SyncScanJobRunner:
 
     def run(self):
         """Execute runner."""
-        # pylint: disable=inconsistent-return-statements
-        # pylint: disable=no-else-return
-        # pylint: disable=too-many-locals,too-many-statements
+        # pylint: disable=too-many-statements
         # pylint: disable=too-many-return-statements,too-many-branches
         if interrupt_status := self.check_manager_interrupt():
             return interrupt_status
@@ -180,7 +178,7 @@ class SyncScanJobRunner:
                 raise error
             if task_status in [ScanTask.CANCELED, ScanTask.PAUSED]:
                 return task_status
-            elif task_status != ScanTask.COMPLETED:
+            if task_status != ScanTask.COMPLETED:
                 # Task did not complete successfully
                 failed_tasks.append(fingerprint_task_runner.scan_task)
                 fingerprint_task_runner.scan_task.log_message(
@@ -217,7 +215,6 @@ class SyncScanJobRunner:
 
         :param runner: ScanTaskRunner
         """
-        # pylint: disable=no-else-return
         if interrupt_status := self.check_manager_interrupt():
             return interrupt_status
         runner.scan_task.start()

--- a/quipucords/scanner/runner.py
+++ b/quipucords/scanner/runner.py
@@ -84,7 +84,7 @@ class ScanTaskRunner(metaclass=ABCMeta):
     def check_for_interrupt(self, manager_interrupt: Value):
         """Check if task runner should stop.
 
-        This method should preferably be called after long running commands.
+        This method should preferably be called after long-running commands.
 
         :param manager_interrupt: Signal to indicate job is canceled
         """
@@ -111,7 +111,7 @@ class ScanTaskRunner(metaclass=ABCMeta):
         Actual logic for each implementation of ScanTaskRunner.
 
         :param manager_interrupt: Shared memory Value which can inform
-        a task of the need to shutdown immediately
+        a task of the need to shut down immediately
 
         :returns: Returns a status message to be saved/displayed and
         the ScanTask.STATUS_CHOICES status


### PR DESCRIPTION
More code cleanup and logic separation to clear the way for Celery tasks.

The reason I have separated **finding** the class from **instantiating** the class is that I plan to use this later with Celery, where passing the heavy model objects into task functions isn't achievable. I haven't finished prototyping that (in a separate branch), but _I think_ this is a step in that direction.