### PR TITLE
split up job runner run method

### DIFF
--- a/quipucords/api/details_report/view.py
+++ b/quipucords/api/details_report/view.py
@@ -103,10 +103,9 @@ class DetailsReportsViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
 
         # Create FC model and save data
         details_report = create_details_report(create_report_version(), request.data)
-        scan_job = ScanJob(
+        scan_job = ScanJob.objects.create(
             scan_type=ScanTask.SCAN_TYPE_FINGERPRINT, details_report=details_report
         )
-        scan_job.save()
         if warn_deprecated:
             scan_job.log_message(
                 _(messages.FC_MISSING_REPORT_VERSION), log_level=logging.WARNING

--- a/quipucords/api/merge_report/view.py
+++ b/quipucords/api/merge_report/view.py
@@ -59,10 +59,9 @@ def sync_merge_reports(request):
     details_report_json = _reconcile_source_versions(details_report_json)
     report_version = details_report_json.get("report_version", None)
     details_report = create_details_report(report_version, details_report_json)
-    merge_job = ScanJob(
+    merge_job = ScanJob.objects.create(
         scan_type=ScanTask.SCAN_TYPE_FINGERPRINT, details_report=details_report
     )
-    merge_job.save()
     merge_job.queue()
     runner = ScanJobRunner(merge_job)
     runner.run()
@@ -159,10 +158,9 @@ def _create_async_merge_report_job(details_report_data):
 
     # Create new job to run
 
-    merge_job = ScanJob(
+    merge_job = ScanJob.objects.create(
         scan_type=ScanTask.SCAN_TYPE_FINGERPRINT, details_report=details_report
     )
-    merge_job.save()
     merge_job.log_current_status()
     job_serializer = ScanJobSerializer(merge_job)
     response_data = job_serializer.data

--- a/quipucords/api/scan/tests_scan.py
+++ b/quipucords/api/scan/tests_scan.py
@@ -644,30 +644,27 @@ class TestScanList(TestCase):
             become_password=None,
             ssh_keyfile=None,
         )
-        self.cred.save()
         self.cred_for_upload = self.cred.id
 
-        self.source = Source(name="source1", source_type="network", port=22)
-        self.source.save()
+        self.source = Source.objects.create(
+            name="source1", source_type="network", port=22
+        )
         self.source.credentials.add(self.cred)
-        self.source.save()
 
-        self.test1 = Scan(name="test1", scan_type=ScanTask.SCAN_TYPE_INSPECT)
-        self.test1.save()
+        self.test1 = Scan.objects.create(
+            name="test1", scan_type=ScanTask.SCAN_TYPE_INSPECT
+        )
         self.test1.sources.add(self.source)
-        self.test1.save()
 
-        self.test2 = Scan(name="test2", scan_type=ScanTask.SCAN_TYPE_CONNECT)
-        self.test2.save()
+        self.test2 = Scan.objects.create(
+            name="test2", scan_type=ScanTask.SCAN_TYPE_CONNECT
+        )
         self.test2.sources.add(self.source)
-        self.test2.save()
 
         # self.test1 will not have a most_recent_scanjob, self.test2
         # will.
-        job = ScanJob(scan=self.test2)
-        job.save()
+        job = ScanJob.objects.create(scan=self.test2)
         job.sources.add(self.source)
-        job.save()
 
         self.test2.most_recent_scanjob = job
         self.test2.save()

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -55,17 +55,13 @@ class ScanJobTest(TestCase):
         self.source.save()
         self.source.credentials.add(self.cred)
 
-        self.connect_scan = Scan(
+        self.connect_scan = Scan.objects.create(
             name="connect_test", scan_type=ScanTask.SCAN_TYPE_CONNECT
         )
-        self.connect_scan.save()
         self.connect_scan.sources.add(self.source)
-        self.connect_scan.save()
 
-        self.inspect_scan = Scan(name="inspect_test")
-        self.inspect_scan.save()
+        self.inspect_scan = Scan.objects.create(name="inspect_test")
         self.inspect_scan.sources.add(self.source)
-        self.inspect_scan.save()
 
     def create_job_expect_201(self, scan_id):
         """Create a scan, return the response as a dict."""
@@ -83,21 +79,18 @@ class ScanJobTest(TestCase):
         """Test create queue state change."""
         # Cannot use util because its testing queue
         # Create scan configuration
-        scan = Scan(name="test", scan_type=ScanTask.SCAN_TYPE_INSPECT)
-        scan.save()
+        scan = Scan.objects.create(name="test", scan_type=ScanTask.SCAN_TYPE_INSPECT)
 
         # Add source to scan
         scan.sources.add(self.source)
 
-        options_to_use = ScanOptions()
-        options_to_use.save()
+        options_to_use = ScanOptions.objects.create()
 
         scan.options = options_to_use
         scan.save()
 
         # Create Job
-        scan_job = ScanJob(scan=scan)
-        scan_job.save()
+        scan_job = ScanJob.objects.create(scan=scan)
 
         # Job in created state
         self.assertEqual(scan_job.status, ScanTask.CREATED)
@@ -1507,15 +1500,12 @@ class ScanJobTest(TestCase):
 
     def test_get_extra_vars(self):
         """Tests the get_extra_vars method with empty dict."""
-        extended = ExtendedProductSearchOptions()
-        extended.save()
-        disabled = DisabledOptionalProductsOptions()
-        disabled.save()
-        scan_options = ScanOptions(
+        extended = ExtendedProductSearchOptions.objects.create()
+        disabled = DisabledOptionalProductsOptions.objects.create()
+        scan_options = ScanOptions.objects.create(
             disabled_optional_products=disabled,
             enabled_extended_product_search=extended,
         )
-        scan_options.save()
         scan_job, _ = create_scan_job(
             self.source, ScanTask.SCAN_TYPE_INSPECT, scan_options=scan_options
         )
@@ -1535,10 +1525,8 @@ class ScanJobTest(TestCase):
 
     def test_get_extra_vars_missing_disable_product(self):
         """Tests the get_extra_vars with extended search None."""
-        disabled = DisabledOptionalProductsOptions()
-        disabled.save()
-        scan_options = ScanOptions(disabled_optional_products=disabled)
-        scan_options.save()
+        disabled = DisabledOptionalProductsOptions.objects.create()
+        scan_options = ScanOptions.objects.create(disabled_optional_products=disabled)
         scan_job, _ = create_scan_job(
             self.source, ScanTask.SCAN_TYPE_INSPECT, scan_options=scan_options
         )
@@ -1558,10 +1546,10 @@ class ScanJobTest(TestCase):
 
     def test_get_extra_vars_missing_extended_search(self):
         """Tests the get_extra_vars with disabled products None."""
-        extended = ExtendedProductSearchOptions()
-        extended.save()
-        scan_options = ScanOptions(enabled_extended_product_search=extended)
-        scan_options.save()
+        extended = ExtendedProductSearchOptions.objects.create()
+        scan_options = ScanOptions.objects.create(
+            enabled_extended_product_search=extended
+        )
         scan_job, _ = create_scan_job(
             self.source, ScanTask.SCAN_TYPE_INSPECT, scan_options=scan_options
         )
@@ -1609,21 +1597,18 @@ class ScanJobTest(TestCase):
 
     def test_get_extra_vars_extended_search(self):
         """Tests the get_extra_vars method with extended search."""
-        extended = ExtendedProductSearchOptions(
+        extended = ExtendedProductSearchOptions.objects.create(
             jboss_eap=True,
             jboss_fuse=True,
             jboss_brms=True,
             jboss_ws=True,
             search_directories=["a", "b"],
         )
-        extended.save()
-        disabled = DisabledOptionalProductsOptions()
-        disabled.save()
-        scan_options = ScanOptions(
+        disabled = DisabledOptionalProductsOptions.objects.create()
+        scan_options = ScanOptions.objects.create(
             disabled_optional_products=disabled,
             enabled_extended_product_search=extended,
         )
-        scan_options.save()
         scan_job, _ = create_scan_job(
             self.source, ScanTask.SCAN_TYPE_INSPECT, scan_options=scan_options
         )
@@ -1644,17 +1629,14 @@ class ScanJobTest(TestCase):
 
     def test_get_extra_vars_mixed(self):
         """Tests the get_extra_vars method with mixed values."""
-        extended = ExtendedProductSearchOptions()
-        extended.save()
-        disabled = DisabledOptionalProductsOptions(
+        extended = ExtendedProductSearchOptions.objects.create()
+        disabled = DisabledOptionalProductsOptions.objects.create(
             jboss_eap=True, jboss_fuse=True, jboss_brms=False, jboss_ws=False
         )
-        disabled.save()
-        scan_options = ScanOptions(
+        scan_options = ScanOptions.objects.create(
             disabled_optional_products=disabled,
             enabled_extended_product_search=extended,
         )
-        scan_options.save()
         scan_job, _ = create_scan_job(
             self.source, ScanTask.SCAN_TYPE_INSPECT, scan_options=scan_options
         )
@@ -1674,17 +1656,14 @@ class ScanJobTest(TestCase):
 
     def test_get_extra_vars_false(self):
         """Tests the get_extra_vars method with all False."""
-        extended = ExtendedProductSearchOptions()
-        extended.save()
-        disabled = DisabledOptionalProductsOptions(
+        extended = ExtendedProductSearchOptions.objects.create()
+        disabled = DisabledOptionalProductsOptions.objects.create(
             jboss_eap=True, jboss_fuse=True, jboss_brms=True, jboss_ws=True
         )
-        disabled.save()
-        scan_options = ScanOptions(
+        scan_options = ScanOptions.objects.create(
             disabled_optional_products=disabled,
             enabled_extended_product_search=extended,
         )
-        scan_options.save()
         scan_job, _ = create_scan_job(
             self.source, ScanTask.SCAN_TYPE_INSPECT, scan_options=scan_options
         )
@@ -1772,26 +1751,23 @@ class ScanJobTest(TestCase):
 
         # Create a connection system result
         conn_result = scan_task.prerequisites.first().connection_result
-        sys_result = SystemConnectionResult(
+        SystemConnectionResult.objects.create(
             name="Foo",
             credential=self.cred,
             status=SystemConnectionResult.SUCCESS,
             task_connection_result=conn_result,
         )
-        sys_result.save()
         # Create an inspection system result
         inspect_result = scan_task.inspection_result
-        sys_result = SystemInspectionResult(
+        sys_result = SystemInspectionResult.objects.create(
             name="Foo",
             status=SystemConnectionResult.SUCCESS,
             task_inspection_result=inspect_result,
         )
-        sys_result.save()
 
-        fact = RawFact(
+        RawFact.objects.create(
             name="fact_key", value="fact_value", system_inspection_result=sys_result
         )
-        fact.save()
 
         scan_job.save()
 

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -182,7 +182,6 @@ class ScanTask(models.Model):
         self, message, log_level=logging.INFO, static_options=None, exception=None
     ):
         """Log a message for this task."""
-        # pylint: disable=no-member
         if exception:
             logger.exception("Got an exception.")
 
@@ -194,7 +193,6 @@ class ScanTask(models.Model):
     # All scan task types
     def _log_scan_message(self, message, log_level=logging.INFO, static_options=None):
         """Log a message for this task."""
-        # pylint: disable=no-member
         if static_options is not None:
             actual_message = (
                 f"Job {self.job_id:d},"
@@ -216,7 +214,6 @@ class ScanTask(models.Model):
     def _log_fingerprint_message(self, message, log_level=logging.INFO):
         """Log a message for this task."""
         elapsed_time = self._compute_elapsed_time()
-        # pylint: disable=no-member
         details_report_id = None
         if self.details_report:
             details_report_id = self.details_report.id

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -35,15 +35,15 @@ class ScanTaskTest(TestCase):
         self.source.credentials.add(self.cred)
 
         # Create scan configuration
-        scan = Scan(name="scan_name", scan_type=ScanTask.SCAN_TYPE_CONNECT)
-        scan.save()
+        scan = Scan.objects.create(
+            name="scan_name", scan_type=ScanTask.SCAN_TYPE_CONNECT
+        )
 
         # Add source to scan
         scan.sources.add(self.source)
 
         # Create Job
-        self.scan_job = ScanJob(scan=scan)
-        self.scan_job.save()
+        self.scan_job = ScanJob.objects.create(scan=scan)
 
     def test_successful_create(self):
         """Create a scan task and serialize it."""

--- a/quipucords/api/source/tests_source.py
+++ b/quipucords/api/source/tests_source.py
@@ -1038,8 +1038,9 @@ class SourceTest(TestCase):
         source.credentials.add(cred)
         source.save()
 
-        scan = Scan(name="test_scan", scan_type=ScanTask.SCAN_TYPE_CONNECT)
-        scan.save()
+        scan = Scan.objects.create(
+            name="test_scan", scan_type=ScanTask.SCAN_TYPE_CONNECT
+        )
         scan.sources.add(source)
 
         url = reverse("source-detail", args=(source.id,))

--- a/quipucords/api/source/view.py
+++ b/quipucords/api/source/view.py
@@ -143,12 +143,12 @@ class SourceViewSet(ModelViewSet):
                     source_id = response.data["id"]
 
                     # Create the scan job
-                    scan_job = ScanJob(scan_type=ScanTask.SCAN_TYPE_CONNECT)
-                    scan_job.save()
+                    scan_job = ScanJob.objects.create(
+                        scan_type=ScanTask.SCAN_TYPE_CONNECT
+                    )
 
                     # Add the source
                     scan_job.sources.add(source_id)
-                    scan_job.save()
                     json_source["most_recent_connect_scan"] = scan_job.id
 
                     # Start the scan

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -227,10 +227,7 @@ class SyncScanJobRunner:
                 # something went wrong or cancel/pause
                 return task_status
 
-        if self.scan_job.scan_type in [
-            ScanTask.SCAN_TYPE_INSPECT,
-            ScanTask.SCAN_TYPE_FINGERPRINT,
-        ]:
+        if self.scan_job.scan_type != ScanTask.SCAN_TYPE_CONNECT:
             if not (details_report := fingerprint_task_runner.scan_task.details_report):
                 details_report, error_message = create_details_report_for_scan_job(
                     self.scan_job

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -6,7 +6,6 @@ import logging
 from multiprocessing import Process, Value
 
 from django.conf import settings
-from django.db.models import Q
 
 from api.common.common_report import create_report_version
 from api.details_report.util import (
@@ -42,7 +41,7 @@ def get_task_runners_for_job(
 ) -> tuple[list[ScanTaskRunner], FingerprintTaskRunner | None]:
     """Get ScanTaskRunners for all the tasks that need to run for this job."""
     incomplete_scan_tasks = scan_job.tasks.filter(
-        Q(status=ScanTask.RUNNING) | Q(status=ScanTask.PENDING)
+        status__in=[ScanTask.RUNNING, ScanTask.PENDING]
     ).order_by("sequence_number")
 
     fingerprint_task_runner: FingerprintTaskRunner | None = None

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -103,6 +103,9 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
     try:
         status_message, task_status = runner.run(*run_args)
     except Exception as error:
+        # Note: It should be very unlikely for this exception handling to be triggered.
+        # runner.run should already handle *most* exception types, and only a bug or
+        # truly unforeseen exception type should end up in here.
         failed_task = runner.scan_task
         context_message = (
             "Unexpected failure occurred. See context below.\n"

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -225,14 +225,15 @@ class SyncScanJobRunner:
             status_message, task_status = runner.run(self.manager_interrupt)
         except Exception as error:
             failed_task = runner.scan_task
-            context_message = "Unexpected failure occurred."
-            context_message += "See context below.\n"
-            context_message += f"SCAN JOB: {self.scan_job}\n"
-            context_message += f"TASK: {failed_task}\n"
+            context_message = (
+                "Unexpected failure occurred. See context below.\n"
+                f"SCAN JOB: {self.scan_job}\nTASK: {failed_task}\n"
+            )
             if failed_task.scan_type != ScanTask.SCAN_TYPE_FINGERPRINT:
-                context_message += f"SOURCE: {failed_task.source}\n"
                 creds = [str(cred) for cred in failed_task.source.credentials.all()]
-                context_message += f"CREDENTIALS: [{creds}]"
+                context_message += (
+                    f"SOURCE: {failed_task.source}\nCREDENTIALS: [{creds}]"
+                )
             failed_task.fail(context_message)
 
             message = f"FATAL ERROR. {str(error)}"

--- a/quipucords/scanner/network/processing/test_process.py
+++ b/quipucords/scanner/network/processing/test_process.py
@@ -114,7 +114,7 @@ class TestProcess(TestCase):
 
     def setUp(self):
         """Create test case setup."""
-        self.cred = Credential(
+        self.cred = Credential.objects.create(
             name="cred1",
             username="username",
             password="password",
@@ -123,30 +123,27 @@ class TestProcess(TestCase):
             become_user="root",
             become_password="become",
         )
-        self.cred.save()
 
-        self.source = Source(name="source1", port=22)
-        self.source.save()
+        self.source = Source.objects.create(name="source1", port=22)
         self.source.credentials.add(self.cred)
 
         self.source.hosts = ["1.2.3.4"]
         self.source.save()
 
         # Create scan configuration
-        scan = Scan(name="scan_name", scan_type=ScanTask.SCAN_TYPE_INSPECT)
-        scan.save()
+        scan = Scan.objects.create(
+            name="scan_name", scan_type=ScanTask.SCAN_TYPE_INSPECT
+        )
 
         # Add source to scan
         scan.sources.add(self.source)
 
         # Create Job
-        self.scan_job = ScanJob(scan=scan)
-        self.scan_job.save()
+        self.scan_job = ScanJob.objects.create(scan=scan)
 
-        self.scan_task = ScanTask(
+        self.scan_task = ScanTask.objects.create(
             job=self.scan_job, source=self.source, scan_type=ScanTask.SCAN_TYPE_INSPECT
         )
-        self.scan_task.save()
 
     def test_not_result_no_processing(self):
         """Test a value that is not a task result, and needs no processing."""

--- a/quipucords/scanner/test_util.py
+++ b/quipucords/scanner/test_util.py
@@ -14,8 +14,7 @@ def create_scan_job(
     :return: the scan job and task
     """
     # Create scan configuration
-    scan = Scan(name=scan_name, scan_type=scan_type)
-    scan.save()
+    scan = Scan.objects.create(name=scan_name, scan_type=scan_type)
 
     # Add source to scan
     if source is not None:
@@ -27,8 +26,7 @@ def create_scan_job(
         scan.save()
 
     # Create Job
-    scan_job = ScanJob(scan=scan)
-    scan_job.save()
+    scan_job = ScanJob.objects.create(scan=scan)
 
     scan_job.queue()
 
@@ -57,8 +55,7 @@ def create_scan_job_two_tasks(
     :return: the scan job and task
     """
     # Create scan configuration
-    scan = Scan(name=scan_name, scan_type=scan_type)
-    scan.save()
+    scan = Scan.objects.create(name=scan_name, scan_type=scan_type)
 
     # Add source to scan
     if source is not None:
@@ -72,8 +69,7 @@ def create_scan_job_two_tasks(
         scan.save()
 
     # Create Job
-    scan_job = ScanJob(scan=scan)
-    scan_job.save()
+    scan_job = ScanJob.objects.create(scan=scan)
 
     scan_job.queue()
 


### PR DESCRIPTION
This PR moves some code from `SyncScanJobRunner` to regular functions so that we can reuse them later with Celery tasks.

I'm also tidying up a little bit of related code along the way. It may help to look at the individual commit diffs.