### PR TITLE
rename model status-setting methods

### DIFF
--- a/quipucords/api/scan/view.py
+++ b/quipucords/api/scan/view.py
@@ -253,7 +253,7 @@ class ScanViewSet(ModelViewSet):
                 )
                 if jobs_to_cancel:
                     for job in jobs_to_cancel:
-                        job.cancel()
+                        job.status_cancel()
                         cancel_scan.send(sender=self.__class__, instance=job)
 
                 for job in scan.jobs.all():

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -456,7 +456,7 @@ class ScanJob(models.Model):
         paused_tasks = self.tasks.filter(Q(status=ScanTask.PAUSED))
         if paused_tasks:
             for task in paused_tasks:
-                task.restart()
+                task.status_restart()
 
         self.status = target_status
         self.status_message = _(messages.SJ_STATUS_MSG_RUNNING)

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -529,7 +529,7 @@ class ScanJob(models.Model):
         self._log_stats("COMPLETION STATS.")
         self.log_current_status()
 
-    def fail(self, message):
+    def status_fail(self, message):
         """Change status from RUNNING to FAILED.
 
         :param message: The error message associated with failure

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -481,7 +481,7 @@ class ScanJob(models.Model):
         )
         if tasks_to_pause:
             for task in tasks_to_pause:
-                task.pause()
+                task.status_pause()
 
         self.status = target_status
         self.status_message = _(messages.SJ_STATUS_MSG_PAUSED)

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -489,7 +489,7 @@ class ScanJob(models.Model):
         self.log_current_status()
 
     @transaction.atomic
-    def cancel(self):
+    def status_cancel(self):
         """Change status from CREATED/PENDING/RUNNING/PAUSED to CANCELED."""
         self.end_time = datetime.utcnow()
         target_status = ScanTask.CANCELED

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -444,7 +444,7 @@ class ScanJob(models.Model):
         self.save()
         self.log_current_status()
 
-    def restart(self):
+    def status_restart(self):
         """Change status from PENDING/PAUSED/RUNNING to PENDING."""
         target_status = ScanTask.PENDING
         has_error = self.validate_status_change(

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -431,7 +431,7 @@ class ScanJob(models.Model):
 
             self.tasks.add(fingerprint_task)  # pylint: disable=no-member
 
-    def start(self):
+    def status_start(self):
         """Change status from PENDING to RUNNING."""
         self.start_time = datetime.utcnow()
         target_status = ScanTask.RUNNING

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -508,7 +508,7 @@ class ScanJob(models.Model):
         )
         if tasks_to_cancel:
             for task in tasks_to_cancel:
-                task.cancel()
+                task.status_cancel()
 
         self.status = target_status
         self.status_message = _(messages.SJ_STATUS_MSG_CANCELED)

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -515,7 +515,7 @@ class ScanJob(models.Model):
         self.save()
         self.log_current_status()
 
-    def complete(self):
+    def status_complete(self):
         """Change status from RUNNING to COMPLETE."""
         self.end_time = datetime.utcnow()
         target_status = ScanTask.COMPLETED

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -464,7 +464,7 @@ class ScanJob(models.Model):
         self.log_current_status()
 
     @transaction.atomic
-    def pause(self):
+    def status_pause(self):
         """Change status from PENDING/RUNNING to PAUSED."""
         target_status = ScanTask.PAUSED
         has_error = self.validate_status_change(

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -132,7 +132,7 @@ class ScanJobTest(TestCase):
         scan_job.pause()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
-        scan_job.start()
+        scan_job.status_start()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
         scan_job.cancel()
@@ -168,7 +168,7 @@ class ScanJobTest(TestCase):
         self.assertEqual(len(tasks), 1)
 
         # Start job
-        scan_job.start()
+        scan_job.status_start()
 
     def test_pause_restart_task(self):
         """Test pause and restart task."""
@@ -185,7 +185,7 @@ class ScanJobTest(TestCase):
         self.assertEqual(connect_task.status, ScanTask.PENDING)
 
         # Start job
-        scan_job.start()
+        scan_job.status_start()
         self.assertEqual(scan_job.status, ScanTask.RUNNING)
 
         scan_job.pause()

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -135,7 +135,7 @@ class ScanJobTest(TestCase):
         scan_job.status_start()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
-        scan_job.cancel()
+        scan_job.status_cancel()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
         scan_job.status_restart()
@@ -198,7 +198,7 @@ class ScanJobTest(TestCase):
         self.assertEqual(scan_job.status, ScanTask.PENDING)
         self.assertEqual(connect_task.status, ScanTask.PENDING)
 
-        scan_job.cancel()
+        scan_job.status_cancel()
         connect_task = scan_job.tasks.first()  # pylint: disable=no-member
         self.assertEqual(scan_job.status, ScanTask.CANCELED)
         self.assertEqual(connect_task.status, ScanTask.CANCELED)

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -141,11 +141,11 @@ class ScanJobTest(TestCase):
         scan_job.status_restart()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
-        scan_job.fail("test failure")
+        scan_job.status_fail("test failure")
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
         scan_job.status = ScanTask.CREATED
-        scan_job.fail("test failure")
+        scan_job.status_fail("test failure")
         self.assertEqual(scan_job.status, ScanTask.CREATED)
 
         scan_job.status = ScanTask.RUNNING

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -138,7 +138,7 @@ class ScanJobTest(TestCase):
         scan_job.cancel()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
-        scan_job.restart()
+        scan_job.status_restart()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
         scan_job.fail("test failure")
@@ -193,7 +193,7 @@ class ScanJobTest(TestCase):
         self.assertEqual(scan_job.status, ScanTask.PAUSED)
         self.assertEqual(connect_task.status, ScanTask.PAUSED)
 
-        scan_job.restart()
+        scan_job.status_restart()
         connect_task = scan_job.tasks.first()  # pylint: disable=no-member
         self.assertEqual(scan_job.status, ScanTask.PENDING)
         self.assertEqual(connect_task.status, ScanTask.PENDING)

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -129,7 +129,7 @@ class ScanJobTest(TestCase):
         scan_job.complete()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
-        scan_job.pause()
+        scan_job.status_pause()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
         scan_job.status_start()
@@ -188,7 +188,7 @@ class ScanJobTest(TestCase):
         scan_job.status_start()
         self.assertEqual(scan_job.status, ScanTask.RUNNING)
 
-        scan_job.pause()
+        scan_job.status_pause()
         connect_task = scan_job.tasks.first()  # pylint: disable=no-member
         self.assertEqual(scan_job.status, ScanTask.PAUSED)
         self.assertEqual(connect_task.status, ScanTask.PAUSED)

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -126,7 +126,7 @@ class ScanJobTest(TestCase):
         scan_job.queue()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
-        scan_job.complete()
+        scan_job.status_complete()
         self.assertEqual(scan_job.status, ScanTask.FAILED)
 
         scan_job.status_pause()
@@ -149,7 +149,7 @@ class ScanJobTest(TestCase):
         self.assertEqual(scan_job.status, ScanTask.CREATED)
 
         scan_job.status = ScanTask.RUNNING
-        scan_job.complete()
+        scan_job.status_complete()
         self.assertEqual(scan_job.status, ScanTask.COMPLETED)
 
     def test_start_task(self):

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -287,7 +287,7 @@ class ScanJobViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
         # pylint: disable=no-else-return
         if scan.status == ScanTask.PAUSED:
             # Update job state before starting job
-            scan.restart()
+            scan.status_restart()
             restart_scan.send(sender=self.__class__, instance=scan)
             serializer = ScanJobSerializer(scan)
             json_scan = serializer.data

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -271,7 +271,7 @@ class ScanJobViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 
         # Kill job before changing job state
         cancel_scan.send(sender=self.__class__, instance=scan)
-        scan.cancel()
+        scan.status_cancel()
         serializer = ScanJobSerializer(scan)
         json_scan = serializer.data
         json_scan = expand_scanjob(json_scan)

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -246,7 +246,7 @@ class ScanJobViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
         if scan.status == ScanTask.RUNNING:
             # Kill job before changing job state
             pause_scan.send(sender=self.__class__, instance=scan)
-            scan.pause()
+            scan.status_pause()
             serializer = ScanJobSerializer(scan)
             json_scan = serializer.data
             json_scan = expand_scanjob(json_scan)

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -357,7 +357,7 @@ class ScanTask(models.Model):
         self.log_current_status()
 
     # All task types
-    def cancel(self):
+    def status_cancel(self):
         """Change status to CANCELED."""
         self.end_time = datetime.utcnow()
         self.status = ScanTask.CANCELED

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -349,7 +349,7 @@ class ScanTask(models.Model):
         self.log_current_status()
 
     # All task types
-    def pause(self):
+    def status_pause(self):
         """Change status to PAUSED."""
         self.status = ScanTask.PAUSED
         self.status_message = _(messages.ST_STATUS_MSG_PAUSED)

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -341,7 +341,7 @@ class ScanTask(models.Model):
         self.log_current_status()
 
     # All task types
-    def restart(self):
+    def status_restart(self):
         """Change status to PENDING."""
         self.status = ScanTask.PENDING
         self.status_message = _(messages.ST_STATUS_MSG_RESTARTED)

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -367,8 +367,8 @@ class ScanTask(models.Model):
 
     # All task types
     @transaction.atomic
-    def complete(self, message=None):
-        """Complete a task."""
+    def status_complete(self, message=None):
+        """Change status to COMPLETED."""
         self.refresh_from_db()
         self.end_time = datetime.utcnow()
         self.status = ScanTask.COMPLETED

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -331,7 +331,7 @@ class ScanTask(models.Model):
         )
 
     # All task types
-    def start(self):
+    def status_start(self):
         """Change status to RUNNING."""
         self.start_time = datetime.utcnow()
         self.status = ScanTask.RUNNING

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -383,8 +383,8 @@ class ScanTask(models.Model):
         self.log_current_status()
 
     # All task types
-    def fail(self, message):
-        """Fail a task.
+    def status_fail(self, message):
+        """Change status to FAILED.
 
         :param message: The error message associated with failure
         """

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -108,7 +108,7 @@ class ScanTaskTest(TestCase):
             scan_type=ScanTask.SCAN_TYPE_CONNECT,
             status=ScanTask.PENDING,
         )
-        task.pause()
+        task.status_pause()
         task.save()
         self.assertEqual(messages.ST_STATUS_MSG_PAUSED, task.status_message)
         self.assertEqual(task.status, ScanTask.PAUSED)

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -101,7 +101,7 @@ class ScanTaskTest(TestCase):
         self.assertEqual(task.status, ScanTask.PENDING)
 
     def test_successful_pause(self):
-        """Create a scan task and pause it."""
+        """Create a scan task and status_pause it."""
         task = ScanTask.objects.create(
             job=self.scan_job,
             source=self.source,

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -158,7 +158,7 @@ class ScanTaskTest(TestCase):
         # pylint: disable=invalid-name
         MSG = "Test Fail."
         end_time = datetime.utcnow()
-        task.fail(MSG)
+        task.status_fail(MSG)
         task.save()
         self.assertEqual(MSG, task.status_message)
         self.assertEqual(task.status, ScanTask.FAILED)

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -139,7 +139,7 @@ class ScanTaskTest(TestCase):
             status=ScanTask.PENDING,
         )
         end_time = datetime.utcnow()
-        task.complete("great")
+        task.status_complete("great")
         task.save()
         self.assertEqual("great", task.status_message)
         self.assertEqual(task.status, ScanTask.COMPLETED)

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -95,7 +95,7 @@ class ScanTaskTest(TestCase):
             scan_type=ScanTask.SCAN_TYPE_CONNECT,
             status=ScanTask.PENDING,
         )
-        task.restart()
+        task.status_restart()
         task.save()
         self.assertEqual(messages.ST_STATUS_MSG_RESTARTED, task.status_message)
         self.assertEqual(task.status, ScanTask.PENDING)

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -122,7 +122,7 @@ class ScanTaskTest(TestCase):
             status=ScanTask.PENDING,
         )
         end_time = datetime.utcnow()
-        task.cancel()
+        task.status_cancel()
         task.save()
         self.assertEqual(messages.ST_STATUS_MSG_CANCELED, task.status_message)
         self.assertEqual(task.status, ScanTask.CANCELED)

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -79,7 +79,7 @@ class ScanTaskTest(TestCase):
             status=ScanTask.PENDING,
         )
         start_time = datetime.utcnow()
-        task.start()
+        task.status_start()
         task.save()
         self.assertEqual(messages.ST_STATUS_MSG_RUNNING, task.status_message)
         self.assertEqual(task.status, ScanTask.RUNNING)

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -122,7 +122,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
     # Save Task status
     if task_status == ScanTask.CANCELED:
         runner.scan_task.cancel()
-        runner.scan_job.cancel()
+        runner.scan_job.status_cancel()
     elif task_status == ScanTask.PAUSED:
         runner.scan_task.pause()
         runner.scan_job.status_pause()
@@ -190,7 +190,7 @@ class SyncScanJobRunner:
         """Check if this job is being interrupted, and handle it if necessary."""
         if self.manager_interrupt.value == ScanJob.JOB_TERMINATE_CANCEL:
             self.manager_interrupt.value = ScanJob.JOB_TERMINATE_ACK
-            self.scan_job.cancel()
+            self.scan_job.status_cancel()
             return ScanTask.CANCELED
 
         if self.manager_interrupt.value == ScanJob.JOB_TERMINATE_PAUSE:

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -206,7 +206,7 @@ class SyncScanJobRunner:
         if interrupt_status := self.check_manager_interrupt():
             return interrupt_status
 
-        self.scan_job.start()  # Only updates the ScanJob model in the database.
+        self.scan_job.status_start()
         if self.scan_job.status != ScanTask.RUNNING:
             error_message = (
                 "Job could not transition to running state.  See error logs."

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -125,7 +125,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
         runner.scan_job.cancel()
     elif task_status == ScanTask.PAUSED:
         runner.scan_task.pause()
-        runner.scan_job.pause()
+        runner.scan_job.status_pause()
     elif task_status == ScanTask.COMPLETED:
         runner.scan_task.complete(status_message)
     elif task_status == ScanTask.FAILED:
@@ -195,7 +195,7 @@ class SyncScanJobRunner:
 
         if self.manager_interrupt.value == ScanJob.JOB_TERMINATE_PAUSE:
             self.manager_interrupt.value = ScanJob.JOB_TERMINATE_ACK
-            self.scan_job.pause()
+            self.scan_job.status_pause()
             return ScanTask.PAUSED
 
         return None

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -127,7 +127,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
         runner.scan_task.status_pause()
         runner.scan_job.status_pause()
     elif task_status == ScanTask.COMPLETED:
-        runner.scan_task.complete(status_message)
+        runner.scan_task.status_complete(status_message)
     elif task_status == ScanTask.FAILED:
         runner.scan_task.fail(status_message)
     else:

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -291,5 +291,5 @@ class SyncScanJobRunner:
             self.scan_job.fail(error_message)
             return ScanTask.FAILED
 
-        self.scan_job.complete()
+        self.scan_job.status_complete()
         return ScanTask.COMPLETED

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -116,7 +116,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
         failed_task.fail(context_message)
 
         message = f"FATAL ERROR. {str(error)}"
-        runner.scan_job.fail(message)
+        runner.scan_job.status_fail(message)
         raise error
 
     # Save Task status
@@ -211,7 +211,7 @@ class SyncScanJobRunner:
             error_message = (
                 "Job could not transition to running state.  See error logs."
             )
-            self.scan_job.fail(error_message)
+            self.scan_job.status_fail(error_message)
             return ScanTask.FAILED
 
         task_runners, fingerprint_task_runner = get_task_runners_for_job(self.scan_job)
@@ -235,7 +235,7 @@ class SyncScanJobRunner:
                     self.scan_job
                 )
                 if not details_report:
-                    self.scan_job.fail(error_message)
+                    self.scan_job.status_fail(error_message)
                     return ScanTask.FAILED
 
             # Associate details report with scan job
@@ -288,7 +288,7 @@ class SyncScanJobRunner:
                 [str(task.sequence_number) for task in failed_tasks]
             )
             error_message = f"The following tasks failed: {failed_task_ids}"
-            self.scan_job.fail(error_message)
+            self.scan_job.status_fail(error_message)
             return ScanTask.FAILED
 
         self.scan_job.status_complete()

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -113,7 +113,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
         if failed_task.scan_type != ScanTask.SCAN_TYPE_FINGERPRINT:
             creds = [str(cred) for cred in failed_task.source.credentials.all()]
             context_message += f"SOURCE: {failed_task.source}\nCREDENTIALS: [{creds}]"
-        failed_task.fail(context_message)
+        failed_task.status_fail(context_message)
 
         message = f"FATAL ERROR. {str(error)}"
         runner.scan_job.status_fail(message)
@@ -129,7 +129,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
     elif task_status == ScanTask.COMPLETED:
         runner.scan_task.status_complete(status_message)
     elif task_status == ScanTask.FAILED:
-        runner.scan_task.fail(status_message)
+        runner.scan_task.status_fail(status_message)
     else:
         error_message = (
             f"ScanTask {runner.scan_task.sequence_number:d} failed."
@@ -137,7 +137,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
             " ScanTask.COMPLETED or ScanTask.FAILED. ScanTask returned"
             f' "{task_status}" and the following status message: {status_message}'
         )
-        runner.scan_task.fail(error_message)
+        runner.scan_task.status_fail(error_message)
         task_status = ScanTask.FAILED
     return task_status
 

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -124,7 +124,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
         runner.scan_task.cancel()
         runner.scan_job.status_cancel()
     elif task_status == ScanTask.PAUSED:
-        runner.scan_task.pause()
+        runner.scan_task.status_pause()
         runner.scan_job.status_pause()
     elif task_status == ScanTask.COMPLETED:
         runner.scan_task.complete(status_message)

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -98,7 +98,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
 
     :param runner: ScanTaskRunner
     """
-    runner.scan_task.start()  # Only updates the ScanTask model in the database.
+    runner.scan_task.status_start()  # Only updates the ScanTask model in the database.
     try:
         status_message, task_status = runner.run(*run_args)
     except Exception as error:

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -121,7 +121,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
 
     # Save Task status
     if task_status == ScanTask.CANCELED:
-        runner.scan_task.cancel()
+        runner.scan_task.status_cancel()
         runner.scan_job.status_cancel()
     elif task_status == ScanTask.PAUSED:
         runner.scan_task.status_pause()

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -256,7 +256,7 @@ class Manager(Thread):
                                 f"{self.log_prefix}:"
                                 " scan job has unexpectedly failed."
                             )
-                            terminated_job.fail(
+                            terminated_job.status_fail(
                                 "Scan manager failed job due to unexpected error."
                             )
                         else:

--- a/quipucords/scanner/network/tests_network_inspect.py
+++ b/quipucords/scanner/network/tests_network_inspect.py
@@ -82,7 +82,7 @@ class NetworkInspectScannerTest(TestCase):
         self.connect_scan_task.update_stats(
             "TEST_VC.", sys_count=2, sys_failed=1, sys_scanned=1
         )
-        self.connect_scan_task.complete()
+        self.connect_scan_task.status_complete()
 
         self.scan_task.update_stats("TEST NETWORK INSPECT.", sys_failed=0)
 

--- a/quipucords/scanner/test_util.py
+++ b/quipucords/scanner/test_util.py
@@ -33,7 +33,7 @@ def create_scan_job(
     # pylint: disable=no-member
     scan_task = scan_job.tasks.first()
     if scan_type == ScanTask.SCAN_TYPE_INSPECT:
-        scan_task.complete()
+        scan_task.status_complete()
         scan_task = scan_job.tasks.filter(scan_type=ScanTask.SCAN_TYPE_INSPECT).first()
 
     return scan_job, scan_task
@@ -77,6 +77,6 @@ def create_scan_job_two_tasks(
     scan_tasks = scan_job.tasks.all().order_by("sequence_number")
     if scan_type == ScanTask.SCAN_TYPE_INSPECT:
         for task in scan_tasks:
-            task.complete()
+            task.status_complete()
 
     return scan_job, scan_tasks

--- a/quipucords/scanner/vcenter/tests_vc_inspect.py
+++ b/quipucords/scanner/vcenter/tests_vc_inspect.py
@@ -45,7 +45,7 @@ class InspectTaskRunnerTest(TestCase):
 
         self.connect_scan_task = self.scan_task.prerequisites.first()
         self.connect_scan_task.update_stats("TEST_VC.", sys_count=5)
-        self.connect_scan_task.complete()
+        self.connect_scan_task.status_complete()
 
         # Create task runner
         self.runner = InspectTaskRunner(


### PR DESCRIPTION
This is a legibility improvement, IMO. Readability counts, and explicit is better than implicit.

Previously, `ScanJob` and `ScanTask` had methods like `start` and `fail`, but those methods don't _actually_ start or fail their respective jobs and tasks. They simply update (with conditional sanity-checking) their _status values_ in the database. Other code is responsible for actually starting, failing, etc. the functions that perform work for these jobs and tasks.

These new names still aren't perfect, but I think they are much clearer than the old names and should cause me (and hopefully anyone else new to our code) less confusion.