### PR TITLE
refactor: gracefuly handle when interrupt signal is not set

### DIFF
--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -188,6 +188,9 @@ class SyncScanJobRunner:
 
     def check_manager_interrupt(self) -> str | None:
         """Check if this job is being interrupted, and handle it if necessary."""
+        if not self.manager_interrupt:
+            return None
+
         if self.manager_interrupt.value == ScanJob.JOB_TERMINATE_CANCEL:
             self.manager_interrupt.value = ScanJob.JOB_TERMINATE_ACK
             self.scan_job.status_cancel()

--- a/quipucords/scanner/network/connect.py
+++ b/quipucords/scanner/network/connect.py
@@ -165,7 +165,7 @@ class ConnectTaskRunner(ScanTaskRunner):
         remaining_hosts = result_store.remaining_hosts()
 
         for cred_id in credentials:
-            check_manager_interrupt(manager_interrupt.value)
+            check_manager_interrupt(manager_interrupt)
             credential = Credential.objects.get(pk=cred_id)
             if not remaining_hosts:
                 message = f"Skipping credential {credential.name}. No remaining hosts."
@@ -253,7 +253,7 @@ def _connect(  # pylint: disable=too-many-arguments
     )
     scan_task.log_message(log_message)
     for idx, group_name in enumerate(group_names):
-        check_manager_interrupt(manager_interrupt.value)
+        check_manager_interrupt(manager_interrupt)
         group_ips = (
             inventory.get("all").get("children").get(group_name).get("hosts").keys()
         )
@@ -309,7 +309,10 @@ def _connect(  # pylint: disable=too-many-arguments
         final_status = runner_obj.status
         if final_status != "successful":
             if final_status == "canceled":
-                if manager_interrupt.value == ScanJob.JOB_TERMINATE_CANCEL:
+                if (
+                    manager_interrupt
+                    and manager_interrupt.value == ScanJob.JOB_TERMINATE_CANCEL
+                ):
                     msg = log_messages.NETWORK_PLAYBOOK_STOPPED % (
                         "CONNECT",
                         "canceled",

--- a/quipucords/scanner/network/connect_callback.py
+++ b/quipucords/scanner/network/connect_callback.py
@@ -143,6 +143,8 @@ class ConnectResultCallback:
         """Control the cancel callback for runner."""
         if self.stopped:
             return True
+        if not self.interrupt:
+            return False
         for stop_type, stop_value in STOP_STATES.items():
             if self.interrupt.value == stop_value:
                 self.result_store.scan_task.log_message(

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -198,7 +198,7 @@ class InspectTaskRunner(ScanTaskRunner):
 
         # Build Ansible Runner Dependencies
         for idx, group_name in enumerate(group_names):
-            check_manager_interrupt(manager_interrupt.value)
+            check_manager_interrupt(manager_interrupt)
             log_message = (
                 "START INSPECT PROCESSING GROUP"
                 f" {(idx + 1):d} of {len(group_names):d}"
@@ -250,9 +250,8 @@ class InspectTaskRunner(ScanTaskRunner):
 
             final_status = runner_obj.status
             if final_status != "successful":
-                if final_status == "canceled":
-                    interrupt = manager_interrupt.value
-                    if interrupt == ScanJob.JOB_TERMINATE_CANCEL:
+                if final_status == "canceled" and manager_interrupt:
+                    if manager_interrupt.value == ScanJob.JOB_TERMINATE_CANCEL:
                         msg = log_messages.NETWORK_PLAYBOOK_STOPPED % (
                             "INSPECT",
                             "canceled",
@@ -263,7 +262,7 @@ class InspectTaskRunner(ScanTaskRunner):
                             "paused",
                         )
                     self.scan_task.log_message(msg)
-                    check_manager_interrupt(interrupt)
+                    check_manager_interrupt(manager_interrupt)
                 if final_status not in ["unreachable", "failed"]:
                     if final_status == "timeout":
                         error_msg = log_messages.NETWORK_TIMEOUT_ERR

--- a/quipucords/scanner/network/inspect_callback.py
+++ b/quipucords/scanner/network/inspect_callback.py
@@ -210,6 +210,8 @@ class InspectResultCallback:
         """Control the cancel callback for runner."""
         if self.stopped:
             return True
+        if not self.interrupt:
+            return False
         for stop_type, stop_value in STOP_STATES.items():
             if self.interrupt.value == stop_value:
                 self.scan_task.log_message(

--- a/quipucords/scanner/network/utils.py
+++ b/quipucords/scanner/network/utils.py
@@ -1,6 +1,7 @@
 """Scanner used for host connection discovery."""
 
 from functools import cache
+from multiprocessing import Value
 
 import yaml
 from ansible.parsing.utils.addresses import parse_address
@@ -18,11 +19,13 @@ STOP_STATES = {
 }
 
 
-def check_manager_interrupt(interrupt_value):
+def check_manager_interrupt(interrupt: Value):
     """Check if cancel & pause exception should be raised."""
-    if interrupt_value == ScanJob.JOB_TERMINATE_CANCEL:
+    if not interrupt:
+        return
+    if interrupt.value == ScanJob.JOB_TERMINATE_CANCEL:
         raise NetworkCancelException()
-    if interrupt_value == ScanJob.JOB_TERMINATE_PAUSE:
+    if interrupt.value == ScanJob.JOB_TERMINATE_PAUSE:
         raise NetworkPauseException()
 
 

--- a/quipucords/scanner/runner.py
+++ b/quipucords/scanner/runner.py
@@ -88,6 +88,8 @@ class ScanTaskRunner(metaclass=ABCMeta):
 
         :param manager_interrupt: Signal to indicate job is canceled
         """
+        if not manager_interrupt:
+            return
         if manager_interrupt.value == ScanJob.JOB_TERMINATE_CANCEL:
             raise ScanCancelException()
         if manager_interrupt.value == ScanJob.JOB_TERMINATE_PAUSE:


### PR DESCRIPTION
As we migrate functionality into Celery tasks, we will no longer be passing multiprocessing `Value` interrupt-handling objects throughout the system. We will need a completely different mechanism to stop processing activity in asynchronous Celery workers.

I introduced this change in a local branch where I am working on those Celery tasks, but I pulled it out to this separate branch/PR for early review in isolation. For now, I am simply wrapping all uses of the interrupt object with conditional checks. If it's not set, we simply proceed as though we're not being interrupted.