### PR TITLE
removing bulk of the invalid-name pylint disable directives.

### DIFF
--- a/quipucords/api/__init__.py
+++ b/quipucords/api/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """Configuration for the api app."""
 
 API_VERSION = 1

--- a/quipucords/api/common/entities.py
+++ b/quipucords/api/common/entities.py
@@ -127,10 +127,10 @@ class HostEntity:
         ip_addresses = self.ip_addresses
         ipv4_addresses = []
         if ip_addresses:
-            for ip in ip_addresses:  # pylint: disable=invalid-name
+            for ip_address in ip_addresses:
                 try:
-                    if ipaddress.ip_address(ip).version == 4:
-                        ipv4_addresses.append(ip)
+                    if ipaddress.ip_address(ip_address).version == 4:
+                        ipv4_addresses.append(ip_address)
                 except ValueError:
                     continue
         return ipv4_addresses

--- a/quipucords/api/common/tests_common_util.py
+++ b/quipucords/api/common/tests_common_util.py
@@ -18,7 +18,7 @@ from api.common.common_report import (
 class CommonUtilTest(TestCase):
     """Tests common util functions."""
 
-    # pylint: disable=too-many-arguments,invalid-name
+    # pylint: disable=too-many-arguments
     # pylint: disable=too-many-locals,too-many-branches
 
     def setUp(self):

--- a/quipucords/api/credential/tests_credential.py
+++ b/quipucords/api/credential/tests_credential.py
@@ -25,7 +25,6 @@ class CredentialTest(LoggedUserMixin, TestCase):
         management.call_command("flush", "--no-input")
         super().setUp()
 
-    # pylint: disable=invalid-name
     def create_credential(
         self,
         name="test_cred",

--- a/quipucords/api/deployments_report/model.py
+++ b/quipucords/api/deployments_report/model.py
@@ -158,7 +158,6 @@ class SystemFingerprint(models.Model):
     # Red Hat facts
     is_redhat = models.BooleanField(null=True)
     redhat_certs = models.TextField(unique=False, blank=True, null=True)
-    # pylint: disable=invalid-name
     redhat_package_count = models.PositiveIntegerField(
         unique=False, blank=True, null=True
     )

--- a/quipucords/api/deployments_report/serializer.py
+++ b/quipucords/api/deployments_report/serializer.py
@@ -117,7 +117,6 @@ class SystemFingerprintSerializer(ModelSerializer):
     # Red Hat facts
     is_redhat = BooleanField(**default_args)
     redhat_certs = CharField(**default_args)
-    # pylint: disable=invalid-name
     redhat_package_count = IntegerField(min_value=0, **default_args)
 
     metadata = JSONField(required=True)

--- a/quipucords/api/deployments_report/tests_deployments_report.py
+++ b/quipucords/api/deployments_report/tests_deployments_report.py
@@ -25,7 +25,6 @@ EXPECTED_NUMBER_OF_FINGERPRINTS = 38
 class DeploymentReportTest(LoggedUserMixin, TestCase):
     """Tests against the Deployment reports function."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Create test case setup."""
         management.call_command("flush", "--no-input")

--- a/quipucords/api/deployments_report/tests_fingerprint_model.py
+++ b/quipucords/api/deployments_report/tests_fingerprint_model.py
@@ -34,7 +34,6 @@ class FingerprintModelTest(TestCase):
         self.assertTrue(is_valid)
         serializer.save()
 
-    # pylint: disable=invalid-name
     def test_product_with_version_fingerprint(self):
         """Create a fingerprint with products."""
         product_dict = {

--- a/quipucords/api/details_report/tests_sync_report_creation.py
+++ b/quipucords/api/details_report/tests_sync_report_creation.py
@@ -16,7 +16,7 @@ from tests.mixins import LoggedUserMixin
 class DetailsReportTest(LoggedUserMixin, TestCase):
     """Tests against the DetailsReport model and view set."""
 
-    # pylint: disable=too-many-arguments,invalid-name
+    # pylint: disable=too-many-arguments
     # pylint: disable=too-many-locals,too-many-branches
 
     def setUp(self):

--- a/quipucords/api/details_report/util.py
+++ b/quipucords/api/details_report/util.py
@@ -27,7 +27,7 @@ SOURCE_TYPE_KEY = "source_type"
 SOURCE_NAME_KEY = "source_name"
 FACTS_KEY = "facts"
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 def build_sources_from_tasks(tasks):

--- a/quipucords/api/merge_report/tests_async_merge_report.py
+++ b/quipucords/api/merge_report/tests_async_merge_report.py
@@ -23,7 +23,7 @@ def dummy_start():
 class AsyncMergeReports(LoggedUserMixin, TestCase):
     """Tests against the Deployment reports function."""
 
-    # pylint: disable=invalid-name,too-many-public-methods
+    # pylint: disable=too-many-public-methods
     def setUp(self):
         """Create test case setup."""
         management.call_command("flush", "--no-input")

--- a/quipucords/api/merge_report/tests_sync_merge_report.py
+++ b/quipucords/api/merge_report/tests_sync_merge_report.py
@@ -17,7 +17,6 @@ from tests.mixins import LoggedUserMixin
 class SyncMergeReports(LoggedUserMixin, TestCase):
     """Tests merging reports synchronously."""
 
-    # pylint: disable=invalid-name
     def setUp(self):
         """Create test case setup."""
         management.call_command("flush", "--no-input")

--- a/quipucords/api/merge_report/view.py
+++ b/quipucords/api/merge_report/view.py
@@ -77,7 +77,6 @@ def sync_merge_reports(request):
 @permission_classes(perm_classes)
 def async_merge_reports(request, scan_job_id=None):
     """Merge reports asynchronously."""
-    # pylint: disable=invalid-name
     if request.method == "GET":
         return _get_async_merge_report_status(scan_job_id)
 

--- a/quipucords/api/reports/tests_reports.py
+++ b/quipucords/api/reports/tests_reports.py
@@ -24,7 +24,7 @@ from tests.utils import patch_mask_value
 class ReportsTest(LoggedUserMixin, TestCase):
     """Tests against the Reports function."""
 
-    # pylint: disable=invalid-name,too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes
     def setUp(self):
         """Create test case setup."""
         management.call_command("flush", "--no-input")

--- a/quipucords/api/scan/model.py
+++ b/quipucords/api/scan/model.py
@@ -49,7 +49,6 @@ class ExtendedProductSearchOptions(models.Model):
 class DisabledOptionalProductsOptions(models.Model):
     """The disable optional products options of a scan."""
 
-    # pylint: disable=invalid-name
     MODEL_OPT_JBOSS_EAP = False
     EXTRA_VAR_OPT_JBOSS_EAP = not MODEL_OPT_JBOSS_EAP
 

--- a/quipucords/api/scan/serializer.py
+++ b/quipucords/api/scan/serializer.py
@@ -25,11 +25,10 @@ from api.models import (
 )
 from api.scantask.serializer import SourceField
 
-# pylint: disable=invalid-name
 try:
-    json_exception_class = json.decoder.JSONDecodeError
+    JsonExceptionClass = json.decoder.JSONDecodeError
 except AttributeError:
-    json_exception_class = ValueError
+    JsonExceptionClass = ValueError
 
 
 class ExtendedProductSearchOptionsSerializer(NotEmptySerializer):
@@ -72,7 +71,7 @@ class ExtendedProductSearchOptionsSerializer(NotEmptySerializer):
                 raise ValidationError(
                     _(messages.SCAN_OPTIONS_EXTENDED_SEARCH_DIR_NOT_LIST)
                 )
-        except json_exception_class as exception:
+        except JsonExceptionClass as exception:
             raise ValidationError(
                 _(messages.SCAN_OPTIONS_EXTENDED_SEARCH_DIR_NOT_LIST)
             ) from exception

--- a/quipucords/api/scan/tests_scan.py
+++ b/quipucords/api/scan/tests_scan.py
@@ -13,7 +13,7 @@ from api.scan.view import expand_scan
 from scanner.test_util import create_scan_job
 from tests.mixins import LoggedUserMixin
 
-# pylint: disable=unused-argument,invalid-name
+# pylint: disable=unused-argument
 
 
 class ScanTest(LoggedUserMixin, TestCase):

--- a/quipucords/api/scan/view.py
+++ b/quipucords/api/scan/view.py
@@ -33,7 +33,7 @@ from api.user.authentication import QuipucordsExpiringTokenAuthentication
 
 logger = logging.getLogger(__name__)
 
-# pylint: disable=too-many-branches,invalid-name
+# pylint: disable=too-many-branches
 
 SOURCES_KEY = "sources"
 MOST_RECENT = "most_recent"
@@ -74,7 +74,6 @@ perm_classes = (IsAuthenticated,)
 @permission_classes(perm_classes)
 def jobs(request, scan_id=None):
     """Get the jobs of a scan."""
-    # pylint: disable=invalid-name
     if scan_id is not None:
         if not is_int(scan_id):
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/quipucords/api/scanjob/tests_scanjob.py
+++ b/quipucords/api/scanjob/tests_scanjob.py
@@ -1,6 +1,6 @@
 """Test the API application."""
 
-# pylint: disable=unused-argument,invalid-name,too-many-lines
+# pylint: disable=unused-argument,too-many-lines
 
 import json
 from unittest.mock import patch

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -103,7 +103,7 @@ class ScanJobViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     ordering_fields = ("id", "scan_type", "status", "start_time", "end_time")
     ordering = ("id",)
 
-    # pylint: disable=unused-argument, arguments-differ,invalid-name
+    # pylint: disable=unused-argument, arguments-differ
     def retrieve(self, request, pk=None):
         """Get a scan job."""
         if not pk or (pk and not is_int(pk)):
@@ -154,7 +154,7 @@ class ScanJobViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 
         return (ordering_filter, status_filter, source_id_filter)
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,invalid-name
     @action(detail=True, methods=["get"])
     def connection(self, request, pk=None):
         """Get the connection results of a scan job."""

--- a/quipucords/api/scantask/tests_scantask.py
+++ b/quipucords/api/scantask/tests_scantask.py
@@ -155,12 +155,11 @@ class ScanTaskTest(TestCase):
             scan_type=ScanTask.SCAN_TYPE_CONNECT,
             status=ScanTask.PENDING,
         )
-        # pylint: disable=invalid-name
-        MSG = "Test Fail."
+        msg = "Test Fail."
         end_time = datetime.utcnow()
-        task.status_fail(MSG)
+        task.status_fail(msg)
         task.save()
-        self.assertEqual(MSG, task.status_message)
+        self.assertEqual(msg, task.status_message)
         self.assertEqual(task.status, ScanTask.FAILED)
         self.assertEqual(
             end_time.replace(microsecond=0), task.end_time.replace(microsecond=0)
@@ -174,7 +173,6 @@ class ScanTaskTest(TestCase):
             scan_type=ScanTask.SCAN_TYPE_CONNECT,
             status=ScanTask.PENDING,
         )
-        # pylint: disable=invalid-name
         task.save()
         task.increment_stats(
             "foo",
@@ -207,7 +205,6 @@ class ScanTaskTest(TestCase):
             scan_type=ScanTask.SCAN_TYPE_CONNECT,
             status=ScanTask.PENDING,
         )
-        # pylint: disable=invalid-name
         task.save()
         task.increment_stats(
             "foo",

--- a/quipucords/api/source/tests_source.py
+++ b/quipucords/api/source/tests_source.py
@@ -23,7 +23,7 @@ def dummy_start():
     """Create a dummy method for testing."""
 
 
-# pylint: disable=too-many-instance-attributes,invalid-name,R0904,C0302
+# pylint: disable=too-many-instance-attributes,R0904,C0302
 class SourceTest(LoggedUserMixin, TestCase):
     """Test the basic Source infrastructure."""
 

--- a/quipucords/api/status/model.py
+++ b/quipucords/api/status/model.py
@@ -5,7 +5,7 @@ import uuid
 
 from django.db import models, transaction
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 class ServerInformation(models.Model):

--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -30,7 +30,6 @@ ROUTER.register(r"scans", ScanViewSet, basename="scan")
 ROUTER.register(r"jobs", ScanJobViewSet, basename="scanjob")
 ROUTER.register(r"users", UserViewSet, basename="users")
 
-# pylint: disable=invalid-name
 urlpatterns = [
     path("reports/<int:report_id>/details/", details),
     path("reports/<int:report_id>/deployments/", deployments),

--- a/quipucords/api/user/token_view.py
+++ b/quipucords/api/user/token_view.py
@@ -34,5 +34,4 @@ class QuipucordsExpiringAuthToken(ObtainAuthToken):
         return Response({"token": auth_token.key})
 
 
-# pylint: disable=invalid-name
 QuipucordsExpiringAuthTokenView = QuipucordsExpiringAuthToken.as_view()

--- a/quipucords/fingerprinter/jboss_brms.py
+++ b/quipucords/fingerprinter/jboss_brms.py
@@ -8,7 +8,7 @@ from fingerprinter.constants import META_DATA_KEY, PRESENCE_KEY
 from fingerprinter.utils import generate_raw_fact_members, product_entitlement_found
 from utils import default_getter
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 PRODUCT = "JBoss BRMS"
 VERSION_KEY = "version"

--- a/quipucords/fingerprinter/jboss_eap.py
+++ b/quipucords/fingerprinter/jboss_eap.py
@@ -7,7 +7,7 @@ from api.models import Product
 from fingerprinter.constants import META_DATA_KEY
 from fingerprinter.utils import product_entitlement_found
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 NAME = "name"
 PRODUCT = "JBoss EAP"

--- a/quipucords/fingerprinter/jboss_eap.py
+++ b/quipucords/fingerprinter/jboss_eap.py
@@ -336,13 +336,13 @@ def call_or_value(obj, argument):
 PRESENCE_ORDER = [Product.UNKNOWN, Product.ABSENT, Product.POTENTIAL, Product.PRESENT]
 
 
-# pylint: disable=invalid-name
-def presence_ge(a, b):
+def presence_ge(value_a, value_b):
     """Compare two presence values, like >= for numbers.
 
-    :returns: True if a is as or more "sure" of presence than b, False if not.
+    :returns: True if value_a is as or more "sure" of presence than value_b,
+              False if not.
     """
-    return PRESENCE_ORDER.index(a) >= PRESENCE_ORDER.index(b)
+    return PRESENCE_ORDER.index(value_a) >= PRESENCE_ORDER.index(value_b)
 
 
 def version_aware_dedup(versions):

--- a/quipucords/fingerprinter/jboss_fuse.py
+++ b/quipucords/fingerprinter/jboss_fuse.py
@@ -7,7 +7,7 @@ from fingerprinter.constants import META_DATA_KEY, PRESENCE_KEY
 from fingerprinter.utils import generate_raw_fact_members, product_entitlement_found
 from utils import default_getter
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 PRODUCT = "JBoss Fuse"
 VERSION_KEY = "version"

--- a/quipucords/fingerprinter/tests_fingerprint_task.py
+++ b/quipucords/fingerprinter/tests_fingerprint_task.py
@@ -131,7 +131,7 @@ class EngineTest(TestCase):
         self.fp_task_runner = FingerprintTaskRunner(scan_job, self.fp_task)
 
     # pylint: disable=too-many-arguments,too-many-lines
-    # pylint: disable=too-many-locals,too-many-branches,invalid-name
+    # pylint: disable=too-many-locals,too-many-branches
     # pylint: disable=protected-access, W0102
 
     ################################################################
@@ -1335,17 +1335,17 @@ class EngineTest(TestCase):
             NETWORK_SATELLITE_MERGE_KEYS, nfingerprints, sfingerprints
         )
         self.assertEqual(len(result_fingerprints), 1)
-        fp = result_fingerprints[0]
-        fp["date_yum_history"] = "2018-1-7"
-        fp["date_filesystem_create"] = None
-        fp["date_anaconda_log"] = "201837"
-        fp["registration_time"] = "2018-4-7 12:45:02"
-        fp["date_machine_id"] = None
-        self.fp_task_runner._compute_system_creation_time(fp)
+        rfp = result_fingerprints[0]
+        rfp["date_yum_history"] = "2018-1-7"
+        rfp["date_filesystem_create"] = None
+        rfp["date_anaconda_log"] = "201837"
+        rfp["registration_time"] = "2018-4-7 12:45:02"
+        rfp["date_machine_id"] = None
+        self.fp_task_runner._compute_system_creation_time(rfp)
         test_date = datetime.strptime("2018-4-7", "%Y-%m-%d").date()
 
-        self.assertEqual(fp["system_creation_date"], test_date)
-        metadata = fp["metadata"]["system_creation_date"]["raw_fact_key"]
+        self.assertEqual(rfp["system_creation_date"], test_date)
+        metadata = rfp["metadata"]["system_creation_date"]["raw_fact_key"]
         self.assertEqual("registration_time", metadata)
 
     ################################################################

--- a/quipucords/fingerprinter/tests_product_brms.py
+++ b/quipucords/fingerprinter/tests_product_brms.py
@@ -38,7 +38,6 @@ class ProductBRMSTest(TestCase):
         }
         self.assertEqual(product, expected)
 
-    # pylint: disable=C0103
     def test_detect_jboss_brms_potential_sub(self):
         """Test the detect_jboss_brms method."""
         source = {

--- a/quipucords/fingerprinter/tests_product_eap.py
+++ b/quipucords/fingerprinter/tests_product_eap.py
@@ -58,7 +58,6 @@ class ProductEAPTest(TestCase):
         }
         self.assertEqual(product, expected)
 
-    # pylint: disable=C0103
     def test_detect_jboss_eap_potential_common(self):
         """Test the detect_jboss_eap method."""
         source = {

--- a/quipucords/fingerprinter/tests_product_fuse.py
+++ b/quipucords/fingerprinter/tests_product_fuse.py
@@ -39,7 +39,6 @@ class ProductFuseTest(TestCase):
         }
         self.assertEqual(product, expected)
 
-    # pylint: disable=C0103
     def test_detect_jboss_fuse_potential_init(self):
         """Test the detect_jboss_fuse method."""
         source = {

--- a/quipucords/quipucords/wsgi.py
+++ b/quipucords/quipucords/wsgi.py
@@ -13,7 +13,6 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "quipucords.settings")
 
-# pylint: disable=invalid-name
 application = get_wsgi_application()
 
 from . import environment  # noqa: E402 pylint: disable=C0413

--- a/quipucords/scanner/network/processing/brms.py
+++ b/quipucords/scanner/network/processing/brms.py
@@ -7,7 +7,7 @@ import re
 
 from scanner.network.processing import process
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/cpu.py
+++ b/quipucords/scanner/network/processing/cpu.py
@@ -6,7 +6,7 @@ from api.common.util import convert_to_int, is_int
 from scanner.network.processing import process
 from scanner.network.processing.util import get_line
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/date.py
+++ b/quipucords/scanner/network/processing/date.py
@@ -5,7 +5,7 @@ import logging
 from scanner.network.processing import process
 from scanner.network.processing.util import get_line
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/dmi.py
+++ b/quipucords/scanner/network/processing/dmi.py
@@ -3,7 +3,7 @@ import logging
 
 from scanner.network.processing import process
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 class ProcessDmiSystemUuid(process.Processor):

--- a/quipucords/scanner/network/processing/eap.py
+++ b/quipucords/scanner/network/processing/eap.py
@@ -5,7 +5,7 @@ import re
 
 from scanner.network.processing import process, util
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/eap5.py
+++ b/quipucords/scanner/network/processing/eap5.py
@@ -5,7 +5,7 @@ import re
 
 from scanner.network.processing import util
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 class ProcessVersionTxt(util.StdoutSearchProcessor):

--- a/quipucords/scanner/network/processing/fuse.py
+++ b/quipucords/scanner/network/processing/fuse.py
@@ -4,7 +4,7 @@ import logging
 
 from scanner.network.processing import util
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/karaf.py
+++ b/quipucords/scanner/network/processing/karaf.py
@@ -4,7 +4,7 @@ import logging
 
 from scanner.network.processing import process, util
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/redhat_packages.py
+++ b/quipucords/scanner/network/processing/redhat_packages.py
@@ -4,7 +4,7 @@ import logging
 
 from scanner.network.processing import process
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/subman.py
+++ b/quipucords/scanner/network/processing/subman.py
@@ -4,7 +4,7 @@ import logging
 
 from scanner.network.processing import process
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/network/processing/system_purpose.py
+++ b/quipucords/scanner/network/processing/system_purpose.py
@@ -5,7 +5,7 @@ import logging
 
 from scanner.network.processing import process
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 class ProcessSystemPurpose(process.Processor):

--- a/quipucords/scanner/network/processing/test_virt.py
+++ b/quipucords/scanner/network/processing/test_virt.py
@@ -314,7 +314,6 @@ class TestProcessVirtType(unittest.TestCase):
 class TestProcessVirtVirt(unittest.TestCase):
     """Test ProcessVirtVirt."""
 
-    # pylint: disable=invalid-name
     def test_virt_virt_with_virt_type_case(self):
         """Found virt_virt using virt_type fact."""
         dependencies = {

--- a/quipucords/scanner/network/processing/util.py
+++ b/quipucords/scanner/network/processing/util.py
@@ -4,7 +4,7 @@ import logging
 
 from scanner.network.processing import process
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 
 def get_line(lines, line_index=0):

--- a/quipucords/scanner/network/processing/yum.py
+++ b/quipucords/scanner/network/processing/yum.py
@@ -4,7 +4,7 @@ import logging
 
 from scanner.network.processing import process
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 
 # #### Processors ####
 

--- a/quipucords/scanner/openshift/api.py
+++ b/quipucords/scanner/openshift/api.py
@@ -24,14 +24,14 @@ from scanner.openshift.entities import (
 logger = getLogger(__name__)
 
 
-def catch_k8s_exception(fn):  # pylint: disable=invalid-name
+def catch_k8s_exception(func):
     """Capture Kubernetes exception and reraise as OCPError."""
 
-    @wraps(fn)
+    @wraps(func)
     def _decorator(*args, **kwargs):
         _normalize_kwargs(kwargs)
         try:
-            return fn(*args, **kwargs)
+            return func(*args, **kwargs)
         except ApiException as api_exception:
             ocp_error = OCPError.from_api_exception(api_exception)
             raise ocp_error from api_exception


### PR DESCRIPTION
chore: removing the bulk of the invalid-name pylint disable directives.
   
- Updating short variable names to three or more characters.
- Removing the unneeded pylint directives for getLogger and others.

Remaining 8 invalid-name are for for ansible_result/items's rc, setUp test mixin, scanjob view pk and gunicorn. Those can be handled in seprate PRs.