### PR TITLE
facts namespace should be qpc

### DIFF
--- a/quipucords/api/insights_report/serializers.py
+++ b/quipucords/api/insights_report/serializers.py
@@ -129,9 +129,12 @@ class YupanaHostSerializer(NotEmptyMixin, Serializer):
         }
         # this differ from actual HBI format due to yupana constraints
         # yupana will format this accordingly
-        # https://github.com/quipucords/yupana/blob/961b376ff80f835203097c43bbf6239a1bc6afbc/yupana/processor/report_slice_processor.py#L226-L252
+        # https://github.com/quipucords/yupana/blob/961b376ff80f835203097c43bbf6239a1bc6afbc/yupana/processor/report_slice_processor.py#L226-L252  # noqa: E501
+        # ---
+        # namespace SHOULD be qpc, because rhsm-subscriptions look specifically for it
+        # in its queries (like https://github.com/RedHatInsights/rhsm-subscriptions/blob/706979cd1a44e76bec00ff237bf8727fa7df0dd6/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java#L93-L138) # noqa: E501
         return [
-            {"namespace": data_collector, "key": key, "value": value}
+            {"namespace": "qpc", "key": key, "value": value}
             for key, value in tags.items()
         ]
 

--- a/quipucords/quipucords/environment.py
+++ b/quipucords/quipucords/environment.py
@@ -33,7 +33,7 @@ def commit():
 @cache
 def server_version():
     """Return server version."""
-    return f"{infer_version()}.{commit()}"
+    return f"{infer_version()}+{commit()}"
 
 
 def platform_info():

--- a/quipucords/quipucords/tests_environment.py
+++ b/quipucords/quipucords/tests_environment.py
@@ -82,7 +82,7 @@ def test_server_fallback_version(package_version):
     else:
         mock_kwargs = {"return_value": package_version}
 
-    expected = f"0.0.0.{environment.commit()}"
+    expected = f"0.0.0+{environment.commit()}"
 
     with patch.object(release, "version", **mock_kwargs):
         assert expected == environment.server_version()


### PR DESCRIPTION
Swatch expects tags namespace to be "qpc", as exemplified in this query: https://github.com/RedHatInsights/rhsm-subscriptions/blob/706979cd1a44e76bec00ff237bf8727fa7df0dd6/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java#L93-L138

Also backport fix #2372 