### PR TITLE
fix: Allow git to run in /app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,8 @@ RUN pip install -v -e .
 # Collect static files
 RUN make server-static
 
+# Allow git to run in /app
+RUN git config --file /.gitconfig --add safe.directory /app
+
 EXPOSE 443
 CMD ["/bin/bash", "/deploy/docker_run.sh"]


### PR DESCRIPTION
fix: Allow git to run in /app

With the Exception catch removed while doing a git rev-parse for determining the commit sha for the server version (see https://github.com/quipucords/quipucords/commit/1c415df5bf0b4d5caca93d2d4de36b5ba8cfb805), git fails with the following error while running in OpenShift:

  fatal: detected dubious ownership in repository at '/app'

This pertains to file/directory ownership vs the user running the git command.  The fix to this is to tell git that /app is a safe directory to run git in and proceed normally. The git config adds /app as a safe directory to the user's .gitconfig file.