### PR TITLE
fix: skip test_openshift_source_update since it does not make sense

### DIFF
--- a/quipucords/tests/api/source/test_serializer.py
+++ b/quipucords/tests/api/source/test_serializer.py
@@ -108,7 +108,7 @@ def test_openshift_source_default_port(openshift_cred_id):
     assert serializer.validated_data["port"] == 6443
 
 
-@pytest.mark.xpass("hosts ('5.4.3.2.1') is clearly invalid in this case")
+@pytest.mark.xfail(reason="hosts ('5.4.3.2.1') is clearly invalid in this case")
 @pytest.mark.django_db
 def test_openshift_source_update(openshift_source, openshift_cred_id):
     """Test if serializer updates fields correctly."""

--- a/quipucords/tests/api/source/test_serializer.py
+++ b/quipucords/tests/api/source/test_serializer.py
@@ -108,7 +108,10 @@ def test_openshift_source_default_port(openshift_cred_id):
     assert serializer.validated_data["port"] == 6443
 
 
-@pytest.mark.xfail(reason="hosts ('5.4.3.2.1') is clearly invalid in this case")
+@pytest.mark.skip(
+    "The code being tested is broken. '5.4.3.2.1' should not be a valid host address. "
+    "See also: https://issues.redhat.com/browse/DISCOVERY-352"
+)
 @pytest.mark.django_db
 def test_openshift_source_update(openshift_source, openshift_cred_id):
     """Test if serializer updates fields correctly."""


### PR DESCRIPTION
This change should resolve the following warning emitted during test runs:

    PytestUnknownMarkWarning: Unknown pytest.mark.xpass - is this a typo?
    You can register custom marks to avoid this warning - for details,
    see https://docs.pytest.org/en/stable/how-to/mark.html

2023-06-05 update: Instead of `xfail`, we decided simply to use `skip` on this test because we agree there is no value in attempting to run it. Another issue exists here to reconsider and fix the underlying implementation: https://issues.redhat.com/browse/DISCOVERY-352