### PR TITLE
fix: remove deprecated USE_L10N setting

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -252,8 +252,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = False
 
 


### PR DESCRIPTION
This change should resolve the following warning emitted during test runs (and also probably at server startup):

    RemovedInDjango50Warning: The USE_L10N setting is deprecated. Starting
    with Django 5.0, localized formatting of data will always be enabled.
    For example Django will display numbers and dates using the format of
    the current locale.
    warnings.warn(USE_L10N_DEPRECATED_MSG, RemovedInDjango50Warning)

This setting is already enabled by default in Django 4.2, the version quipuicords is already using. See also:

https://docs.djangoproject.com/en/4.2/topics/i18n/formatting/