### PR TITLE
fix: replace deprecated STATICFILES_STORAGE setting

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -266,7 +266,11 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "client"),
 ]
 
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    }
+}
 
 LOGGING_FORMATTER = env.str("DJANGO_LOG_FORMATTER", "simple")
 DJANGO_LOGGING_LEVEL = env.str("DJANGO_LOG_LEVEL", "INFO")


### PR DESCRIPTION
This change should resolve the following warning emitted during test runs (and also probably at server startup):

    RemovedInDjango51Warning: The STATICFILES_STORAGE setting is deprecated. Use STORAGES instead.
    warnings.warn(STATICFILES_STORAGE_DEPRECATED_MSG, RemovedInDjango51Warning)

The new STORAGES setting is supported by Django 4.2, the version quipuicords is already using. See also:

https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES