### PR TITLE
fix(ocp): properly encode potential OCP error entities

### DIFF
--- a/quipucords/api/inspectresult/model.py
+++ b/quipucords/api/inspectresult/model.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 
 from api import messages
 from api.source.model import Source
-from compat.pydantic import BaseModel
+from compat.pydantic import BaseModel, PydanticErrorProxy
 
 
 class JobInspectionResult(models.Model):
@@ -85,7 +85,7 @@ class RawFactEncoder(JSONEncoder):
 
     def default(self, o):
         """Update the default Encoder to handle types beyond just the basic ones."""
-        if isinstance(o, BaseModel):
+        if isinstance(o, (BaseModel, PydanticErrorProxy)):
             return o.dict()
         if isinstance(o, datetime):
             return o.isoformat()

--- a/quipucords/scanner/openshift/inspect.py
+++ b/quipucords/scanner/openshift/inspect.py
@@ -5,6 +5,7 @@ from django.db import transaction
 
 from api.models import RawFact, ScanTask, SystemInspectionResult
 from scanner.exceptions import ScanFailureError
+from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.entities import OCPBaseEntity, OCPCluster, OCPError, OCPNode
 from scanner.openshift.runner import OpenShiftTaskRunner
 
@@ -56,7 +57,9 @@ class InspectTaskRunner(OpenShiftTaskRunner):
             return self.SUCCESS_MESSAGE, ScanTask.COMPLETED
         return self.FAILURE_MESSAGE, ScanTask.FAILED
 
-    def _extra_cluster_facts(self, manager_interrupt, ocp_client, cluster):
+    def _extra_cluster_facts(
+        self, manager_interrupt, ocp_client: OpenShiftApi, cluster
+    ):
         """Retrieve extra cluster facts."""
         fact2method = (
             ("projects", ocp_client.retrieve_projects),


### PR DESCRIPTION
One of the premisses of OCP scanner "extra facts" is that they should not break a scan if an API error is caught. When that happens, an OCPError entity would be collected instead of the extra fact. 

This behavior was broken because OCPErrors were not able to be properly encoded as json.