### PR TITLE
Skip upload container image step on PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
             quipucords.backend.git_sha=${{ github.sha }}
 
       - name: Push To quay.io
+        # Forks don't have access to secrets and can't complete this step
+        if: ${{ github.repository_owner == 'quipucords' }}
         uses: redhat-actions/push-to-registry@v2
         with:
           image: quipucords/quipucords


### PR DESCRIPTION
Forks don't have access to secrets and can't complete this step.