### PR TITLE
compatibility with rhel 5/6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PYTHONPATH=/app/quipucords
 ENV QUIPUCORDS_LOG_LEVEL=INFO
 
 COPY scripts/dnf /usr/local/bin/dnf
-ARG BUILD_PACKAGES="gcc postgresql-devel python3.11-devel"
+ARG BUILD_PACKAGES="crypto-policies-scripts gcc postgresql-devel python3.11-devel"
 RUN dnf install \
         git \
         glibc-langpack-en \
@@ -32,6 +32,9 @@ RUN dnf install \
         -y &&\
     dnf clean all &&\
     python3.11 -m venv /opt/venv
+
+# set cryptographic policy to a mode compatible with older systems (like RHEL5&6)
+RUN update-crypto-policies --set LEGACY
 
 RUN pip install --upgrade pip wheel
 

--- a/Dockerfile.scan-target
+++ b/Dockerfile.scan-target
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-init
+FROM redhat/ubi9-init
 
 RUN dnf -y install openssh-server openssl sudo; \
     dnf clean all

--- a/quipucords/scanner/network/utils.py
+++ b/quipucords/scanner/network/utils.py
@@ -61,7 +61,19 @@ def _construct_vars(connection_port, credential=None):
     :returns: a dict that can be used as the host variables in an
         Ansible inventory.
     """
-    ansible_vars = {"ansible_port": connection_port}
+    # ssh arguments for compatibility with defaults for older systems (like RHEL 5&6)
+    # (this is only meant to help quipucords running on baremetal since the container
+    # is setup for using a "legacy" configuration for ssh)
+    legacy_ssh_args = (
+        "-o 'KexAlgorithms=diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1'"  # noqa: E501
+        " -o 'HostKeyAlgorithms=+ssh-rsa,ssh-dss'"
+        " -o 'PubkeyAcceptedKeyTypes=+ssh-rsa,ssh-dss'"
+    )
+
+    ansible_vars = {
+        "ansible_port": connection_port,
+        "ansible_ssh_common_args": legacy_ssh_args,
+    }
 
     if credential is not None:
         ansible_dict = _credential_vars(credential)


### PR DESCRIPTION
UBI 9 has stricter criptographic policies for ssh. We need to explicitly set those to "legacy mode" for detection of rhel 5 and 6.