### PR TITLE
Skip upload container image step on PRs from forks... for real

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Push To quay.io
         # Forks don't have access to secrets and can't complete this step
-        if: ${{ github.repository_owner == 'quipucords' }}
+        if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
         uses: redhat-actions/push-to-registry@v2
         with:
           image: quipucords/quipucords


### PR DESCRIPTION
Apparently 097a2c8f1bfa167caf85d304f1805776739b3d53 doesn't work as I wanted. Let's try again.