### PR TITLE
perf: remove all dunder str methods from models

### DIFF
--- a/quipucords/api/connresult/model.py
+++ b/quipucords/api/connresult/model.py
@@ -13,10 +13,6 @@ from api.source.model import Source
 class JobConnectionResult(models.Model):
     """The results of a connection scan."""
 
-    def __str__(self):
-        """Convert to string."""
-        return f"{{ id:{self.id},task_results:{self.task_results} }}"
-
     class Meta:
         """Metadata for model."""
 
@@ -29,10 +25,6 @@ class TaskConnectionResult(models.Model):
     job_connection_result = models.ForeignKey(
         JobConnectionResult, on_delete=models.CASCADE, related_name="task_results"
     )
-
-    def __str__(self):
-        """Convert to string."""
-        return f"{{ id:{self.id}, systems:{self.systems} }}"
 
     class Meta:
         """Metadata for model."""
@@ -59,18 +51,6 @@ class SystemConnectionResult(models.Model):
     task_connection_result = models.ForeignKey(
         TaskConnectionResult, on_delete=models.CASCADE, related_name="systems"
     )
-
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f" id:{self.id},"
-            f" name:{self.name},"
-            f" status:{self.status},"
-            f" source:{self.source},"
-            f" credential:{self.credential} "
-            "}"
-        )
 
     class Meta:
         """Metadata for model."""

--- a/quipucords/api/deployments_report/model.py
+++ b/quipucords/api/deployments_report/model.py
@@ -40,16 +40,6 @@ class DeploymentsReport(models.Model):
     cached_csv = models.TextField(null=True)
     cached_masked_csv = models.TextField(null=True)
 
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" report_id:{self.report_id},"
-            f" status:{self.status}"
-            "}"
-        )
-
 
 class SystemFingerprint(models.Model):
     """Represents system fingerprint."""
@@ -187,10 +177,6 @@ class SystemFingerprint(models.Model):
         """Retrieve source_types."""
         return {s.get("source_type") for s in self.sources}
 
-    def __str__(self):
-        """Convert to string."""
-        return f"{{id:{self.id}, name:{self.name}}}"
-
 
 class Product(models.Model):
     """Represents a product."""
@@ -215,19 +201,6 @@ class Product(models.Model):
 
     metadata = models.JSONField(unique=False, null=False, default=dict)
 
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" fingerprint:{self.fingerprint.id},"
-            f" name:{self.name},"
-            f" version:{self.version},"
-            f" presence:{self.presence},"
-            f" metadata:{self.metadata} "
-            "}"
-        )
-
 
 class Entitlement(models.Model):
     """Represents a Entitlement."""
@@ -239,15 +212,3 @@ class Entitlement(models.Model):
     entitlement_id = models.CharField(max_length=256, unique=False, null=True)
 
     metadata = models.JSONField(unique=False, null=False, default=dict)
-
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" fingerprint:{self.fingerprint.id},"
-            f" name:{self.name},"
-            f" entitlement_id:{self.entitlement_id},"
-            f" metadata:{self.metadata} "
-            "}"
-        )

--- a/quipucords/api/details_report/model.py
+++ b/quipucords/api/details_report/model.py
@@ -22,13 +22,3 @@ class DetailsReport(models.Model):
     )
     cached_csv = models.TextField(null=True)
     cached_masked_csv = models.TextField(null=True)
-
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f'"id":{self.id},'
-            ' "report_type":"details", '
-            f' "sources":{self.sources}'
-            "}"
-        )

--- a/quipucords/api/inspectresult/model.py
+++ b/quipucords/api/inspectresult/model.py
@@ -16,10 +16,6 @@ from compat.pydantic import BaseModel, PydanticErrorProxy
 class JobInspectionResult(models.Model):
     """The results of a inspection scan."""
 
-    def __str__(self):
-        """Convert to string."""
-        return f"{{ id:{self.id}, task_results:{self.task_results} }}"
-
     class Meta:
         """Metadata for model."""
 
@@ -32,10 +28,6 @@ class TaskInspectionResult(models.Model):
     job_inspection_result = models.ForeignKey(
         JobInspectionResult, on_delete=models.CASCADE, related_name="task_results"
     )
-
-    def __str__(self):
-        """Convert to string."""
-        return f"{{ id:{self.id}, systems:{self.systems} }}"
 
     class Meta:
         """Metadata for model."""
@@ -61,18 +53,6 @@ class SystemInspectionResult(models.Model):
     task_inspection_result = models.ForeignKey(
         TaskInspectionResult, on_delete=models.CASCADE, related_name="systems"
     )
-
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f" id:{self.id},"
-            f" name:{self.name},"
-            f" status:{self.status},"
-            f" facts:{self.facts},"
-            f" source:{self.source} "
-            "}"
-        )
 
     class Meta:
         """Metadata for model."""
@@ -102,10 +82,6 @@ class RawFact(models.Model):
     system_inspection_result = models.ForeignKey(
         SystemInspectionResult, on_delete=models.CASCADE, related_name="facts"
     )
-
-    def __str__(self):
-        """Convert to string."""
-        return f"{{ id:{self.id}, name:{self.name}, value:{self.value} }}"
 
     class Meta:
         """Metadata for model."""

--- a/quipucords/api/scan/model.py
+++ b/quipucords/api/scan/model.py
@@ -28,19 +28,6 @@ class ExtendedProductSearchOptions(models.Model):
     jboss_ws = models.BooleanField(null=False, default=EXT_JBOSS_WS)
     search_directories = models.JSONField(null=True)
 
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" jboss_eap: {self.jboss_eap},"
-            f" jboss_fuse: {self.jboss_fuse},"
-            f" jboss_brms: {self.jboss_brms},"
-            f" jboss_ws: {self.jboss_ws},"
-            f" search_directories: {self.get_search_directories()}"
-            "}"
-        )
-
     def get_search_directories(self):
         """Load JSON search directory."""
         return self.search_directories or []
@@ -66,18 +53,6 @@ class DisabledOptionalProductsOptions(models.Model):
     jboss_brms = models.BooleanField(null=False, default=MODEL_OPT_JBOSS_BRMS)
     jboss_ws = models.BooleanField(null=False, default=MODEL_OPT_JBOSS_WS)
 
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" jboss_eap: {self.jboss_eap},"
-            f" jboss_fuse: {self.jboss_fuse},"
-            f" jboss_brms: {self.jboss_brms},"
-            f" jboss_ws: {self.jboss_ws}"
-            "}"
-        )
-
 
 class ScanOptions(models.Model):
     """The scan options allows configuration of a scan."""
@@ -100,17 +75,6 @@ class ScanOptions(models.Model):
     enabled_extended_product_search = models.OneToOneField(
         ExtendedProductSearchOptions, on_delete=models.CASCADE, null=True
     )
-
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" max_concurrency: {self.max_concurrency},"
-            f" disabled_optional_products: {self.disabled_optional_products},"
-            f" enabled_extended_product_search: {self.enabled_extended_product_search}"
-            "}"
-        )
 
     @staticmethod
     def get_default_forks():
@@ -202,18 +166,6 @@ class Scan(models.Model):
     most_recent_scanjob = models.ForeignKey(
         "api.ScanJob", null=True, on_delete=models.SET_NULL, related_name="+"
     )
-
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" name:{self.name},"
-            f" sources:{self.sources},"
-            f" scan_type:{self.scan_type},"
-            f" options: {self.options}"
-            "}"
-        )
 
     class Meta:
         """Metadata for model."""

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -70,23 +70,6 @@ class ScanJob(models.Model):
         DetailsReport, null=True, on_delete=models.CASCADE
     )
 
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" scan:{self.scan_id},"
-            f" scan_type:{self.scan_type},"
-            f" status:{self.status},"
-            f" options: {self.options_id},"
-            f" report_id: {self.report_id},"
-            f" start_time: {self.start_time},"
-            f" end_time: {self.end_time},"
-            f" connection_results: {self.connection_results_id},"
-            f" inspection_results: {self.inspection_results_id}"
-            "}"
-        )
-
     class Meta:
         """Metadata for model."""
 

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -436,3 +436,17 @@ class ScanTask(models.Model):
         elif self.scan_type == ScanTask.SCAN_TYPE_FINGERPRINT:
             return self.details_report
         return None
+
+    def log_raw_facts(self, log_level=logging.INFO):
+        """Log raw facts stored on details report."""
+        if not self.details_report:
+            self.log_message(
+                "Missing details report - Impossible to log raw facts.",
+                log_level=max(logging.ERROR, log_level),
+            )
+            return
+        # Using a pure logger to avoid the extra context information added
+        # by log_message method.
+        logger.log(log_level, f"{'raw facts':-^50}")
+        logger.log(log_level, self.details_report.sources)
+        logger.log(log_level, "-" * 50)

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -101,28 +101,6 @@ class ScanTask(models.Model):
         if hasattr(self, "scan_job_task_count"):
             del self.scan_job_task_count
 
-    def __str__(self):
-        """Convert to string."""
-        return (
-            "{"
-            f"id:{self.id},"
-            f" job:{self.job_id},"
-            f" scan_type:{self.scan_type},"
-            f" status:{self.status},"
-            f" source:{self.source_id},"
-            f" sequence_number:{self.sequence_number},"
-            f" systems_count: {self.systems_count},"
-            f" systems_scanned: {self.systems_scanned},"
-            f" systems_failed: {self.systems_failed},"
-            f" systems_unreachable: {self.systems_unreachable},"
-            f" start_time: {self.start_time}"
-            f" end_time: {self.end_time},"
-            f" connection_result: {self.connection_result_id},"
-            f" inspection_result: {self.inspection_result_id},"
-            f" details_report: {self.details_report_id}"
-            "}"
-        )
-
     class Meta:
         """Metadata for model."""
 

--- a/quipucords/api/status/model.py
+++ b/quipucords/api/status/model.py
@@ -13,10 +13,6 @@ class ServerInformation(models.Model):
 
     global_identifier = models.CharField(max_length=36, null=False)
 
-    def __str__(self):
-        """Convert to string."""
-        return f"{{id:{self.id}, global_identifier:{self.global_identifier}}}"
-
     @staticmethod
     @transaction.atomic
     def create_or_retrieve_server_id():

--- a/quipucords/scanner/tasks.py
+++ b/quipucords/scanner/tasks.py
@@ -97,9 +97,7 @@ def _fingerprint(scan_task_id: int) -> tuple[bool, int, str]:
         scan_task.log_message(
             f"Task {scan_task.sequence_number} failed.", log_level=logging.ERROR
         )
-        scan_task.log_message(
-            f"Details failed to fingerprint: {details_report}", log_level=logging.ERROR
-        )
+        scan_task.log_raw_facts(log_level=logging.ERROR)
 
     return success, scan_task_id, task_status
 

--- a/quipucords/tests/api/scantask/test_model.py
+++ b/quipucords/tests/api/scantask/test_model.py
@@ -1,0 +1,60 @@
+"""Test ScanTask model."""
+
+import logging
+
+import pytest
+
+from api.models import DetailsReport, ScanTask
+from tests.factories import ScanTaskFactory
+
+
+@pytest.mark.django_db
+class TestLoggingRawFacts:
+    """Test ScanTask.log_raw_facts method."""
+
+    def test_greenpath(self, caplog):
+        """Test logging_raw_facts method "greenpath"."""
+        details_report = DetailsReport(sources=[{"mamao": "papaia"}])
+        details_report.save()
+        scan_task: ScanTask = ScanTaskFactory(details_report=details_report)
+        caplog.clear()
+        scan_task.log_raw_facts()
+        assert [rec.message for rec in caplog.records] == [
+            "--------------------raw facts---------------------",
+            "[{'mamao': 'papaia'}]",
+            "--------------------------------------------------",
+        ]
+
+    @pytest.mark.parametrize("log_level", (logging.INFO, logging.ERROR))
+    def test_log_level(self, caplog, log_level):
+        """Test logging_raw_facts method "greenpath"."""
+        details_report = DetailsReport()
+        details_report.save()
+        scan_task: ScanTask = ScanTaskFactory(details_report=details_report)
+        caplog.clear()
+        scan_task.log_raw_facts(log_level=log_level)
+        assert [rec.levelno for rec in caplog.records] == [log_level] * 3
+
+    def test_logging_raw_facts_no_details_report(self, caplog):
+        """Test logging_raw_facts method for a ScanTask w/o details report."""
+        scan_task: ScanTask = ScanTaskFactory()
+        caplog.set_level(logging.ERROR)
+        scan_task.log_raw_facts()
+        assert "Missing details report - Impossible to log raw facts." in caplog.text
+
+    @pytest.mark.parametrize(
+        "set_level,expected_level",
+        [
+            (logging.INFO, logging.ERROR),
+            (logging.CRITICAL, logging.CRITICAL),
+            (logging.ERROR, logging.ERROR),
+        ],
+    )
+    def test_log_level_on_error(self, caplog, set_level, expected_level, mocker):
+        """Test if the log level is set correctly on error (mininum lvl is ERROR)."""
+        scan_task: ScanTask = ScanTaskFactory()
+        caplog.clear()
+        scan_task.log_raw_facts(log_level=set_level)
+        assert caplog.record_tuples == [
+            ("api.scantask.model", expected_level, mocker.ANY)
+        ]


### PR DESCRIPTION
some `__str__` methods are making calls to related models, which can quickly cascade into a nasty N+1 problem.

We don't need all this info in `__str__` anyways, just remove it and log explicitly when required.

relates to JIRA: DISCOVERY-220