### PR TITLE
chore(style): prefer pathlib over os.path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ select = [
     "W",   # pycodestyle
     "PL",  # Pylint
     "BLE", # flake8-blind-except
+    "PTH", # flake8-use-pathlib
 ]
 ignore = [
     "D203", 

--- a/quipucords/api/common/common_report.py
+++ b/quipucords/api/common/common_report.py
@@ -1,11 +1,10 @@
 """Util for common report operations."""
-
 import io
 import json
 import logging
-import os
 import tarfile
 import time
+from pathlib import Path
 
 from rest_framework.renderers import JSONRenderer
 
@@ -53,10 +52,11 @@ def extract_tar_gz(file_like_obj):
         if not isinstance(file_like_obj, (bytes, bytearray)):
             return None
         tar_name = f"/tmp/api_tmp_{time.strftime('%Y%m%d_%H%M%S')}.tar.gz"
-        with open(tar_name, "wb") as out_file:
+        path_to_tar = Path(tar_name)
+        with path_to_tar.open("wb") as out_file:
             out_file.write(file_like_obj)
         tar = tarfile.open(tar_name)
-        os.remove(tar_name)
+        path_to_tar.unlink()
 
     file_data_list = []
     files = tar.getmembers()

--- a/quipucords/api/common/util.py
+++ b/quipucords/api/common/util.py
@@ -1,7 +1,7 @@
 """Util for common operations."""
 
 import logging
-import os
+from pathlib import Path
 
 from django.utils.translation import gettext as _
 from rest_framework.serializers import ValidationError
@@ -147,7 +147,7 @@ def check_path_validity(path_list):
     """
     invalid_paths = []
     for a_path in path_list:
-        if not os.path.isabs(a_path):
+        if not Path(a_path).is_absolute():
             invalid_paths.append(a_path)
     return invalid_paths
 

--- a/quipucords/api/credential/serializer.py
+++ b/quipucords/api/credential/serializer.py
@@ -2,6 +2,7 @@
 
 import os
 from collections import defaultdict
+from pathlib import Path
 
 from django.utils.translation import gettext as _
 from rest_framework.serializers import ValidationError, empty
@@ -15,10 +16,8 @@ from constants import ENCRYPTED_DATA_MASK, DataSources
 def expand_filepath(filepath):
     """Expand the ssh_keyfile filepath if necessary."""
     if filepath is not None:
-        expanded = os.path.abspath(
-            os.path.normpath(os.path.expanduser(os.path.expandvars(filepath)))
-        )
-        return expanded
+        expanded = Path(os.path.expandvars(filepath)).expanduser().absolute()
+        return str(expanded)
     return filepath
 
 
@@ -213,7 +212,7 @@ class NetworkCredentialSerializer(CredentialSerializer):
         if ssh_keyfile is None:
             return None
         keyfile = expand_filepath(ssh_keyfile)
-        if not os.path.isfile(keyfile):
+        if not Path(keyfile).is_file():
             raise ValidationError(_(messages.HC_KEY_INVALID % ssh_keyfile))
         return keyfile
 

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -179,8 +179,8 @@ if QPC_DBMS not in allowed_db_engines:
 
 if QPC_DBMS == "sqlite":
     # If user enters an invalid QPC_DBMS, use default postgresql
-    DEV_DB = os.path.join(BASE_DIR, "db.sqlite3")
-    PROD_DB = os.path.join(env.str("DJANGO_DB_PATH", str(BASE_DIR)), "db.sqlite3")
+    DEV_DB = BASE_DIR / "db.sqlite3"
+    PROD_DB = Path(env.str("DJANGO_DB_PATH", str(BASE_DIR))) / "db.sqlite3"
     DB_PATH = PROD_DB if PRODUCTION else DEV_DB
     DATABASES = {
         "default": {
@@ -253,13 +253,11 @@ USE_TZ = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 STATIC_URL = "/client/"
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "client"),
-]
+STATICFILES_DIRS = [BASE_DIR / "client"]
 
 STORAGES = {
     "staticfiles": {

--- a/quipucords/scanner/network/connect.py
+++ b/quipucords/scanner/network/connect.py
@@ -1,6 +1,5 @@
 """ScanTask used for network connection discovery."""
 import logging
-import os.path
 from multiprocessing import Value
 
 import ansible_runner
@@ -272,9 +271,7 @@ def _connect(  # noqa: PLR0913, PLR0912, PLR0915
             "variable_host": group_name,
             "ansible_ssh_timeout": settings.QPC_SSH_CONNECT_TIMEOUT,
         }
-        playbook_path = os.path.join(
-            settings.BASE_DIR, "scanner/network/runner/connect.yml"
-        )
+        playbook_path = str(settings.BASE_DIR / "scanner/network/runner/connect.yml")
         cmdline_list = []
         vault_file_path = f"--vault-password-file={settings.DJANGO_SECRET_PATH}"
         cmdline_list.append(vault_file_path)

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -1,6 +1,5 @@
 """ScanTask used for network connection discovery."""
 import logging
-import os.path
 
 import ansible_runner
 from ansible_runner.exceptions import AnsibleRunnerException
@@ -212,8 +211,8 @@ class InspectTaskRunner(ScanTaskRunner):
                 "job_timeout": int(settings.NETWORK_INSPECT_JOB_TIMEOUT),
                 "pexpect_timeout": 5,
             }
-            playbook_path = os.path.join(
-                settings.BASE_DIR, "scanner/network/runner/inspect.yml"
+            playbook_path = str(
+                settings.BASE_DIR / "scanner/network/runner/inspect.yml"
             )
             extra_vars["variable_host"] = group_name
             cmdline_list = []

--- a/quipucords/tests/api/test_vault.py
+++ b/quipucords/tests/api/test_vault.py
@@ -1,5 +1,7 @@
 """Test the API application."""
 
+from pathlib import Path
+
 import yaml
 from django.test import TestCase
 
@@ -33,10 +35,10 @@ class VaultTest(TestCase):
                 },
             }
         }
-        temp_yaml = vault.write_to_yaml(data)
-        self.assertTrue("yaml" in temp_yaml)
+        temp_yaml = Path(vault.write_to_yaml(data))
+        assert temp_yaml.name.endswith(".yaml")
 
-        with open(temp_yaml, "r", encoding="utf-8") as temp_file:
+        with temp_yaml.open("r", encoding="utf-8") as temp_file:
             encrypted = temp_file.read()
             decrypted = vault.decrypt_data_as_unicode(encrypted)
             obj = yaml.load(decrypted, Loader=yaml.SafeLoader)

--- a/quipucords/tests/scanner/network/test_network_inspect.py
+++ b/quipucords/tests/scanner/network/test_network_inspect.py
@@ -1,6 +1,6 @@
 """Test the inspect scanner capabilities."""
-import os.path
 from multiprocessing import Value
+from pathlib import Path
 from unittest.mock import ANY, Mock, patch
 
 import pytest
@@ -157,7 +157,7 @@ class TestNetworkInspectScanner:
             "ansible_ssh_private_key_file"
         ]
         assert is_gen_ssh_keyfile(ssh_keyfile)
-        os.remove(ssh_keyfile)
+        Path(ssh_keyfile).unlink()
 
     def test_scan_inventory_with_ssh_key_delete(self, source_ssh, host_ssh_list):
         """Test ansible inventory dictionary with ssh_key are deleted."""
@@ -169,9 +169,9 @@ class TestNetworkInspectScanner:
         ssh_keyfile = inventory_dict["all"]["children"]["group_0"]["hosts"]["1.2.3.5"][
             "ansible_ssh_private_key_file"
         ]
-        assert os.path.exists(ssh_keyfile)
+        assert Path(ssh_keyfile).exists()
         delete_ssh_keyfiles(inventory_dict)
-        assert os.path.exists(ssh_keyfile) is False
+        assert not Path(ssh_keyfile).exists()
 
     def test_scan_inventory_grouping(self):
         """Test construct ansible inventory dictionary."""
@@ -269,9 +269,7 @@ class TestNetworkInspectScanner:
     def test_ssh_crash(self):
         """Simulate an ssh crash."""
         scanner = InspectTaskRunner(self.scan_job, self.scan_task)
-        path = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "test_util/crash.py")
-        )
+        path = Path(__file__).absolute().parent / "test_util/crash.py"
 
         _, result = scanner._inspect_scan(
             Value("i", ScanJob.JOB_RUN),
@@ -284,9 +282,7 @@ class TestNetworkInspectScanner:
     def test_ssh_hang(self):
         """Simulate an ssh hang."""
         scanner = InspectTaskRunner(self.scan_job, self.scan_task)
-        path = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "test_util/hang.py")
-        )
+        path = Path(__file__).absolute().parent / "test_util/hang.py"
 
         scanner._inspect_scan(
             Value("i", ScanJob.JOB_RUN),

--- a/scripts/test_generate_sudo_list.py
+++ b/scripts/test_generate_sudo_list.py
@@ -1,4 +1,5 @@
 """Tests for generate sudo list script."""
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -80,10 +81,8 @@ def return_playbook_path(
     role_dir = path / "roles" / "roles1" / "tasks"
     role_dir.mkdir(parents=True, exist_ok=True)
 
-    main_yml_path = role_dir / "main.yml"
-    with open(main_yml_path, "w") as f:
-        f.write(playbook)
-
+    main_yml_path = Path(role_dir / "main.yml")
+    main_yml_path.write_text(playbook)
     yield path
 
 
@@ -136,7 +135,7 @@ def test_file_creation(tmp_path, generated_document_mock):
     assert file_path.exists()
     expected = ["sudo command 1\n", "sudo command 2"]
 
-    with open(file_path, "r") as f:
+    with file_path.open("r") as f:
         lines = f.readlines()
     assert lines == expected
     file_path.unlink()


### PR DESCRIPTION
and enable a ruff checker to ensure we keep true to the one and only way to handle paths in python.

ALL PRAISE pathlib.Path.