### PR TITLE
push to registry regardless of fork, use more variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,7 @@ jobs:
             quipucords.backend.git_sha=${{ github.sha }}
 
       - name: Push To quay.io
-        # Forks don't have access to secrets and can't complete this step
-        if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
+        # Forks that do not set these secrets and may fail this step.
         uses: redhat-actions/push-to-registry@v2
         with:
           image: quipucords/quipucords

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ env:
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
   EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=3d' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/quipucords' }}
+  REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 
 jobs:
   build:
@@ -28,7 +30,7 @@ jobs:
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: quipucords/quipucords
+          image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.STABLE_TAG }} ${{ env.STABLE_TAG == 'main' && 'latest' || '' }}
           containerfiles: |
             ./Dockerfile
@@ -37,11 +39,11 @@ jobs:
             quipucords.backend.git_sha=${{ github.sha }}
 
       - name: Push To quay.io
-        # Forks that do not set these secrets and may fail this step.
+        # Forks that do not set secrets and override the variables may fail this step.
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: quipucords/quipucords
+          image: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   STABLE_TAG: ${{ github.event_name == 'push' && github.ref_name || format('pr-{0}', github.event.pull_request.number) }}
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
-  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=3d' }}
+  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=5d' }}
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/quipucords' }}
   REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 


### PR DESCRIPTION
Do not skip pushing to the registry when the original repo appears to be a fork; this job now always attempts to push when it reaches this step. This means the job may fail if a forked repo does not correctly configure its variables and secrets.

`IMAGE_NAME` and `REGISTRY` are now optional variables that forks may set in their GitHub project settings to override to use another registry or image name.

To verify that the variables works as expected, I opened an identical PR in my up-to-date fork (https://github.com/infinitewarp/quipucords/pull/1).

* The first time the build job ran, I did not have any custom variables or secrets set. As expected, the build job failed (https://github.com/infinitewarp/quipucords/actions/runs/5615107995/job/15214675647?pr=1). The build job used the default `quipucords/quipucords` image name and `quay.io` registry, but it could not push because I did not set secrets.
    ```
    Combining image name "quipucords/quipucords" and registry "quay.io" to form registry path "quay.io/quipucords/quipucords"
    ...
    ⏳ Pushing "quipucords/quipucords:pr-1" to "quay.io/quipucords/quipucords:pr-1" respectively
    ...
    Error: writing blob: initiating layer upload to /v2/quipucords/quipucords/blobs/uploads/ in quay.io: unauthorized: access to the requested resource is not authorized
    ```
* I then set custom variables and secrets in my fork's project settings. I amended the commit and force pushed to trigger new jobs to run. The new build job succeeded (https://github.com/infinitewarp/quipucords/actions/runs/5615194475/job/15214942406?pr=1) and used my fork's variables and secrets to push to my own registry image.
    ````
    Combining image name "***/potato" and registry "quay.io" to form registry path "quay.io/***/potato"
    ...
    ⏳ Pushing "***/potato:pr-1" to "quay.io/***/potato:pr-1" respectively as "***"
    ...
    ✅ Successfully pushed "***/potato:pr-1" to "quay.io/***/potato:pr-1"
    ````

The image pushed by my fork can be found here until it expires in 3 days:
* https://quay.io/repository/infinitewarp/potato?tab=tags 
* `podman pull quay.io/infinitewarp/potato:pr-1`

Relates to JIRA: DISCOVERY-388
https://issues.redhat.com/browse/DISCOVERY-388