### PR TITLE
1.3 cherry pick 1.3.0 commits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,14 @@
+@Library("smqe-shared-lib@master") _
+
+node("discovery_ci") {
+    stage("Setup test environment") {
+        echo "Setting up Quipucords PR tests"
+        discoveryLib.setupCIEnv()
+    }
+    stage("Run tests") {
+        discoveryLib.runTests()
+    }
+    stage("Archive artifacts") {
+        discoveryLib.archiveArtifacts()
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quipucords"
-version = "1.3.0"
+version = "1.3.1"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 authors = ["Quipucords Dev Team <quipucords@redhat.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quipucords"
-version = "1.2.6"
+version = "1.3.0"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 authors = ["Quipucords Dev Team <quipucords@redhat.com>"]
 readme = "README.md"


### PR DESCRIPTION
git chery-pick these commits from main:

* 82c119ae
* 2b31fa96

Those commits were in the `1.3.0` tag history, but I accidentally missed them when I created the `release/1.3` branch off of `aeafb1d2`.

This PR also bumps the project version because we will be creating a `1.3.1` tag after this PR merges.