### PR TITLE
1.3 cherry pick and update to 1.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,7 @@ jobs:
             quipucords.backend.git_sha=${{ github.sha }}
 
       - name: Push To quay.io
-        # Forks don't have access to secrets and can't complete this step
-        if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
+        # Forks that do not set these secrets and may fail this step.
         uses: redhat-actions/push-to-registry@v2
         with:
           image: quipucords/quipucords

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ env:
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
   EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=3d' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/quipucords' }}
+  REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 
 jobs:
   build:
@@ -28,7 +30,7 @@ jobs:
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: quipucords/quipucords
+          image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.STABLE_TAG }} ${{ env.STABLE_TAG == 'main' && 'latest' || '' }}
           containerfiles: |
             ./Dockerfile
@@ -37,11 +39,11 @@ jobs:
             quipucords.backend.git_sha=${{ github.sha }}
 
       - name: Push To quay.io
-        # Forks that do not set these secrets and may fail this step.
+        # Forks that do not set secrets and override the variables may fail this step.
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: quipucords/quipucords
+          image: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   STABLE_TAG: ${{ github.event_name == 'push' && github.ref_name || format('pr-{0}', github.event.pull_request.number) }}
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
-  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=3d' }}
+  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=5d' }}
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/quipucords' }}
   REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quipucords"
-version = "1.3.0"
+version = "1.3.1"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 authors = ["Quipucords Dev Team <quipucords@redhat.com>"]
 readme = "README.md"


### PR DESCRIPTION
git chery-pick these commits from main:

* ff5f0f09
* 0977427c
* b44d7e58

These commits were originally introduced by https://github.com/quipucords/quipucords/pull/2419, but we want to include them in the 1.3 release branch.

This PR also adds one commit to update the project version to `1.3.1` because we intend to tag `1.3.1` after this PR merges.

Relates to JIRA: DISCOVERY-388
https://issues.redhat.com/browse/DISCOVERY-388