### PR TITLE
chore: remove setuptools<67 requirement now that kombu has been updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ lock-build-requirements:
 	poetry run pip-compile $(PIP_COMPILE_ARGS) -r --resolver=backtracking --quiet --allow-unsafe --output-file=requirements-build.txt requirements-build.in
 
 search-build-requirements:
-	echo "setuptools<67" >> requirements-build.in # required while kombu is incompatible with it
 	cat requirements*.txt | grep -vE '(^ )|(#)' | awk '{print $$1}' | sed 's/==/ /' | \
 	xargs -P$(PARALLEL_NUM) -n2 poetry run pybuild-deps find-build-deps 2> /dev/null | \
 	sort -u >> requirements-build.in || true

--- a/requirements-build.in
+++ b/requirements-build.in
@@ -19,7 +19,6 @@ setuptools-scm
 setuptools-scm[toml]>=6.2.3
 setuptools;python_version!='3.3'
 setuptools<40.0;python_version=='3.3'
-setuptools<67
 setuptools>=36.2.2
 setuptools>=39.2.0
 setuptools>=40.8.0

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -8,7 +8,7 @@ calver==2022.6.26
     # via -r requirements-build.in
 cffi==1.15.1 ; platform_python_implementation != "PyPy"
     # via -r requirements-build.in
-cython==0.29.36
+cython==3.0.0
     # via -r requirements-build.in
 docutils==0.20.1
     # via -r requirements-build.in
@@ -44,11 +44,11 @@ typing-extensions==4.7.1
     # via
     #   setuptools-rust
     #   setuptools-scm
-wheel==0.40.0
+wheel==0.41.0
     # via -r requirements-build.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==66.1.1 ; python_version != "3.3"
+setuptools==68.0.0 ; python_version != "3.3"
     # via
     #   -r requirements-build.in
     #   setuptools-rust


### PR DESCRIPTION
`git cherry-pick` b8b5f432 to backport https://github.com/quipucords/quipucords/pull/2426 into the 1.3 release branch.