### PR TITLE
fix: strip [extras] from package names before passing to pybuild-deps, stop ignoring errors from pybuild-deps

### DIFF
--- a/requirements-build.in
+++ b/requirements-build.in
@@ -9,6 +9,7 @@ flit_core>=3.3
 flit_core>=3.4,<4
 flit_core>=3.8,<4
 hatchling>=0.25.1
+packaging>=20.0
 pbr
 pbr>=1.8
 poetry-core>=1.0.0
@@ -32,5 +33,6 @@ setuptools>=62.4
 setuptools>=62.4.0
 setuptools_scm
 setuptools_scm[toml]>=3.4.1
+typing_extensions
 wheel
 wheel>=0.28.0

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -12,7 +12,7 @@ cython==3.0.0
     # via -r requirements-build.in
 docutils==0.20.1
     # via -r requirements-build.in
-editables==0.4
+editables==0.5
     # via hatchling
 flit-core==3.9.0
     # via -r requirements-build.in
@@ -20,6 +20,7 @@ hatchling==1.18.0
     # via -r requirements-build.in
 packaging==23.1
     # via
+    #   -r requirements-build.in
     #   hatchling
     #   setuptools-scm
 pathspec==0.11.1
@@ -42,6 +43,7 @@ trove-classifiers==2023.7.6
     # via hatchling
 typing-extensions==4.7.1
     # via
+    #   -r requirements-build.in
     #   setuptools-rust
     #   setuptools-scm
 wheel==0.41.0


### PR DESCRIPTION
I also ran `make lock-requirements` immediately after updating the command, and that resulted in a couple minor updates to the generated requirements files.

This mirrors a similar change we just made in `qpc` here: https://github.com/quipucords/qpc/pull/266#discussion_r1276400827