### PR TITLE
fix: strip [extras] from package names before passing to pybuild-deps, stop ignoring errors from pybuild-deps

### DIFF
--- a/requirements-build.in
+++ b/requirements-build.in
@@ -9,6 +9,7 @@ flit_core>=3.3
 flit_core>=3.4,<4
 flit_core>=3.8,<4
 hatchling>=0.25.1
+packaging>=20.0
 pbr
 pbr>=1.8
 poetry-core>=1.0.0
@@ -32,5 +33,6 @@ setuptools>=62.4
 setuptools>=62.4.0
 setuptools_scm
 setuptools_scm[toml]>=3.4.1
+typing_extensions
 wheel
 wheel>=0.28.0

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -20,6 +20,7 @@ hatchling==1.18.0
     # via -r requirements-build.in
 packaging==23.1
     # via
+    #   -r requirements-build.in
     #   hatchling
     #   setuptools-scm
 pathspec==0.11.1
@@ -42,6 +43,7 @@ trove-classifiers==2023.7.6
     # via hatchling
 typing-extensions==4.7.1
     # via
+    #   -r requirements-build.in
     #   setuptools-rust
     #   setuptools-scm
 wheel==0.41.0


### PR DESCRIPTION
`git cherry-pick` bb74f5a9

Back-porting https://github.com/quipucords/quipucords/pull/2429 from `main` to `release/1.3` branch.