### PR TITLE
Enhance OCP Inspection to query Node metrics

### DIFF
--- a/quipucords/scanner/openshift/inspect.py
+++ b/quipucords/scanner/openshift/inspect.py
@@ -5,6 +5,7 @@ from django.db import transaction
 
 from api.models import RawFact, ScanTask, SystemInspectionResult
 from scanner.exceptions import ScanFailureError
+from scanner.openshift import metrics
 from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.entities import OCPBaseEntity, OCPCluster, OCPError, OCPNode
 from scanner.openshift.runner import OpenShiftTaskRunner
@@ -80,6 +81,10 @@ class InspectTaskRunner(OpenShiftTaskRunner):
                 )
             except OCPError as err:
                 cluster.errors[fact_name] = err
+
+        # Let's add the cluster metrics facts
+        extra_facts.update(metrics.retrieve_cluster_metrics(ocp_client))
+
         return extra_facts
 
     def _check_prerequisites(self):

--- a/quipucords/scanner/openshift/inspect.py
+++ b/quipucords/scanner/openshift/inspect.py
@@ -83,7 +83,13 @@ class InspectTaskRunner(OpenShiftTaskRunner):
                 cluster.errors[fact_name] = err
 
         # Let's add the cluster metrics facts
-        extra_facts.update(metrics.retrieve_cluster_metrics(ocp_client))
+        for fact_name, metric in metrics.OCP_PROMETHEUS_METRICS.items():
+            try:
+                extra_facts[fact_name] = metrics.retrieve_cluster_metrics(
+                    ocp_client, metric
+                )
+            except OCPError as err:
+                cluster.errors[fact_name] = err
 
         return extra_facts
 

--- a/quipucords/scanner/openshift/metrics.py
+++ b/quipucords/scanner/openshift/metrics.py
@@ -1,0 +1,37 @@
+"""OpenShift Prometheus metrics definitions and utilities."""
+
+OCP_PROMETHEUS_METRICS = {
+    "node_metrics": {
+        "attributes": [
+            "instance",
+            "label_node_hyperthread_enabled",
+            "label_node_role_kubernetes_io_master",
+        ],
+        "query": """
+count by(instance,
+         label_node_hyperthread_enabled,
+         label_node_role_kubernetes_io_master)
+(max
+    by(node, instance,
+             label_node_hyperthread_enabled,
+             label_node_role_kubernetes_io_master)
+    (cluster:cpu_core_node_labels)
+)
+""",
+    }
+}
+
+
+def retrieve_cluster_metrics(ocp_client):
+    """Execute Prometheus queries and return the Cluster metrics."""
+    cluster_metrics = {}
+    for name, metric in OCP_PROMETHEUS_METRICS.items():
+        raw_result = ocp_client.metrics_query(metric["query"])
+        result = []
+        for item in raw_result:
+            query_item = {}
+            for attr in metric["attributes"]:
+                query_item[attr] = item.get(attr, None)
+            result.append(query_item)
+        cluster_metrics[name] = result
+    return cluster_metrics

--- a/quipucords/scanner/openshift/metrics.py
+++ b/quipucords/scanner/openshift/metrics.py
@@ -22,16 +22,12 @@ count by(instance,
 }
 
 
-def retrieve_cluster_metrics(ocp_client):
-    """Execute Prometheus queries and return the Cluster metrics."""
-    cluster_metrics = {}
-    for name, metric in OCP_PROMETHEUS_METRICS.items():
-        raw_result = ocp_client.metrics_query(metric["query"])
-        result = []
-        for item in raw_result:
-            query_item = {}
-            for attr in metric["attributes"]:
-                query_item[attr] = item.get(attr, None)
-            result.append(query_item)
-        cluster_metrics[name] = result
-    return cluster_metrics
+def retrieve_cluster_metrics(ocp_client, metric):
+    """Execute a Prometheus query and return the Cluster metrics."""
+    result = []
+    for item in ocp_client.metrics_query(metric["query"]):
+        result_item = {}
+        for attr in metric["attributes"]:
+            result_item[attr] = item.get(attr, None)
+        result.append(result_item)
+    return result

--- a/quipucords/scanner/openshift/metrics.py
+++ b/quipucords/scanner/openshift/metrics.py
@@ -5,14 +5,12 @@ OCP_PROMETHEUS_METRICS = {
         "attributes": [
             "instance",
             "label_node_hyperthread_enabled",
-            "label_node_role_kubernetes_io_master",
             "package",
         ],
         "query": """
             group by(
                 instance,
                 label_node_hyperthread_enabled,
-                label_node_role_kubernetes_io_master,
                 package
             )  (cluster:cpu_core_node_labels)
             """,

--- a/quipucords/scanner/openshift/metrics.py
+++ b/quipucords/scanner/openshift/metrics.py
@@ -6,18 +6,16 @@ OCP_PROMETHEUS_METRICS = {
             "instance",
             "label_node_hyperthread_enabled",
             "label_node_role_kubernetes_io_master",
+            "package",
         ],
         "query": """
-count by(instance,
-         label_node_hyperthread_enabled,
-         label_node_role_kubernetes_io_master)
-(max
-    by(node, instance,
-             label_node_hyperthread_enabled,
-             label_node_role_kubernetes_io_master)
-    (cluster:cpu_core_node_labels)
-)
-""",
+            group by(
+                instance,
+                label_node_hyperthread_enabled,
+                label_node_role_kubernetes_io_master,
+                package
+            )  (cluster:cpu_core_node_labels)
+            """,
     }
 }
 

--- a/quipucords/tests/integration/test_openshift_scan.py
+++ b/quipucords/tests/integration/test_openshift_scan.py
@@ -7,6 +7,7 @@ import pytest
 
 from api.inspectresult.model import RawFactEncoder
 from constants import DataSources
+from scanner.openshift import metrics
 from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.entities import (
     ClusterOperator,
@@ -165,6 +166,11 @@ def patched_openshift_client(  # noqa: PLR0913
         OpenShiftApi,
         "retrieve_acm_metrics",
         return_value=expected_acm_metrics,
+    )
+    mocker.patch.object(
+        metrics,
+        "retrieve_cluster_metrics",
+        return_value={},
     )
 
 

--- a/quipucords/tests/integration/test_openshift_scan.py
+++ b/quipucords/tests/integration/test_openshift_scan.py
@@ -7,7 +7,6 @@ import pytest
 
 from api.inspectresult.model import RawFactEncoder
 from constants import DataSources
-from scanner.openshift import metrics
 from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.entities import (
     ClusterOperator,
@@ -166,11 +165,6 @@ def patched_openshift_client(  # noqa: PLR0913
         OpenShiftApi,
         "retrieve_acm_metrics",
         return_value=expected_acm_metrics,
-    )
-    mocker.patch.object(
-        metrics,
-        "retrieve_cluster_metrics",
-        return_value={},
     )
 
 

--- a/quipucords/tests/scanner/openshift/test_inspect.py
+++ b/quipucords/tests/scanner/openshift/test_inspect.py
@@ -95,21 +95,31 @@ def cluster_metrics(faker):
                 "instance": f"master-0.{fake_host_base}",
                 "label_node_hyperthread_enabled": "true",
                 "label_node_role_kubernetes_io_master": "true",
+                "package": "0",
+            },
+            {
+                "instance": f"master-0.{fake_host_base}",
+                "label_node_hyperthread_enabled": "true",
+                "label_node_role_kubernetes_io_master": "true",
+                "package": "1",
             },
             {
                 "instance": f"master-1.{fake_host_base}",
                 "label_node_hyperthread_enabled": "false",
                 "label_node_role_kubernetes_io_master": "true",
+                "package": "0",
             },
             {
                 "instance": f"worker-0.{fake_host_base}",
                 "label_node_hyperthread_enabled": "true",
                 "label_node_role_kubernetes_io_master": None,
+                "package": "0",
             },
             {
                 "instance": f"worker-1.{fake_host_base}",
                 "label_node_hyperthread_enabled": "false",
                 "label_node_role_kubernetes_io_master": None,
+                "package": "0",
             },
         ]
     }

--- a/quipucords/tests/scanner/openshift/test_inspect.py
+++ b/quipucords/tests/scanner/openshift/test_inspect.py
@@ -94,31 +94,26 @@ def cluster_metrics(faker):
             {
                 "instance": f"master-0.{fake_host_base}",
                 "label_node_hyperthread_enabled": "true",
-                "label_node_role_kubernetes_io_master": "true",
                 "package": "0",
             },
             {
                 "instance": f"master-0.{fake_host_base}",
                 "label_node_hyperthread_enabled": "true",
-                "label_node_role_kubernetes_io_master": "true",
                 "package": "1",
             },
             {
                 "instance": f"master-1.{fake_host_base}",
                 "label_node_hyperthread_enabled": "false",
-                "label_node_role_kubernetes_io_master": "true",
                 "package": "0",
             },
             {
                 "instance": f"worker-0.{fake_host_base}",
                 "label_node_hyperthread_enabled": "true",
-                "label_node_role_kubernetes_io_master": None,
                 "package": "0",
             },
             {
                 "instance": f"worker-1.{fake_host_base}",
                 "label_node_hyperthread_enabled": "false",
-                "label_node_role_kubernetes_io_master": None,
                 "package": "0",
             },
         ]


### PR DESCRIPTION
feat(OpenShift): Enhance OCP Inspection to query Node metrics

- With this enhancement, we now fetch whether or not a node is running with hyperthreading enabled or not.
- Metrics facts get added to the "cluster" section in the details report.

Leverages foundational work here: https://github.com/quipucords/quipucords/pull/2438