### PR TITLE
fix: handle when openshift source has no ManagedCluster API (no ACM)

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -336,31 +336,7 @@ LOGGING = {
             "handlers": LOGGING_HANDLERS,
             "level": QUIPUCORDS_LOGGING_LEVEL,
         },
-        "scanner.callback": {
-            "handlers": LOGGING_HANDLERS,
-            "level": QUIPUCORDS_LOGGING_LEVEL,
-        },
-        "scanner.manager": {
-            "handlers": LOGGING_HANDLERS,
-            "level": QUIPUCORDS_LOGGING_LEVEL,
-        },
-        "scanner.job": {
-            "handlers": LOGGING_HANDLERS,
-            "level": QUIPUCORDS_LOGGING_LEVEL,
-        },
-        "scanner.task": {
-            "handlers": LOGGING_HANDLERS,
-            "level": QUIPUCORDS_LOGGING_LEVEL,
-        },
-        "scanner.network": {
-            "handlers": LOGGING_HANDLERS,
-            "level": QUIPUCORDS_LOGGING_LEVEL,
-        },
-        "scanner.vcenter": {
-            "handlers": LOGGING_HANDLERS,
-            "level": QUIPUCORDS_LOGGING_LEVEL,
-        },
-        "scanner.satellite": {
+        "scanner": {
             "handlers": LOGGING_HANDLERS,
             "level": QUIPUCORDS_LOGGING_LEVEL,
         },

--- a/quipucords/scanner/openshift/api.py
+++ b/quipucords/scanner/openshift/api.py
@@ -166,7 +166,7 @@ class OpenShiftApi:
         route_list = self._list_routes(
             namespace="openshift-monitoring",
             field_selector="metadata.name=prometheus-k8s",
-        ).items
+        )
         if len(route_list) != 1:
             logger.warning(
                 "Could not find the OpenShift prometheus-k8s metrics route,"
@@ -178,14 +178,14 @@ class OpenShiftApi:
     def retrieve_nodes(self, **kwargs) -> List[OCPNode]:
         """Retrieve nodes under OCP host."""
         node_list = []
-        for node in self._list_nodes(**kwargs).items:
+        for node in self._list_nodes(**kwargs):
             ocp_node = self._init_ocp_nodes(node)
             node_list.append(ocp_node)
         return node_list
 
     def retrieve_cluster(self, **kwargs) -> OCPCluster:
         """Retrieve cluster under OCP host."""
-        clusters = self._list_clusters(**kwargs).items
+        clusters = self._list_clusters(**kwargs)
         assert len(clusters) == 1, "More than one cluster in cluster API"
         cluster_entity = self._init_cluster(clusters[0])
         return cluster_entity
@@ -194,7 +194,7 @@ class OpenShiftApi:
         """Retrieve metrics on acm managed clusters."""
         acm_metrics = []
         try:
-            for cluster in self._list_managed_clusters(**kwargs).items:
+            for cluster in self._list_managed_clusters(**kwargs):
                 managed_cluster_metrics = self._init_managed_cluster(cluster)
                 acm_metrics.append(managed_cluster_metrics)
         except ResourceNotFoundError:
@@ -208,7 +208,7 @@ class OpenShiftApi:
         """Retrieve OCP Pods."""
         pods_raw = self._list_pods(**kwargs)
         pods_list = []
-        for pod in pods_raw.items:
+        for pod in pods_raw:
             ocp_pod = OCPPod.from_api_object(pod)
             pods_list.append(ocp_pod)
         return pods_list
@@ -232,16 +232,16 @@ class OpenShiftApi:
         """Retrieve cluster and "olm" operators."""
         cluster_operators = [
             ClusterOperator.from_raw_object(operator)
-            for operator in self._list_cluster_operators(**kwargs).items
+            for operator in self._list_cluster_operators(**kwargs)
         ]
         olm_operators = [
             LifecycleOperator.from_raw_object(operator)
-            for operator in self._list_subscriptions(**kwargs).items
+            for operator in self._list_subscriptions(**kwargs)
         ]
         # Use CSV api to enhance olm operators with extra metadata
         csv_map = {
             csv.metadata.name: csv
-            for csv in self._list_cluster_service_versions(**kwargs).items
+            for csv in self._list_cluster_service_versions(**kwargs)
         }
         for operator in olm_operators:
             csv = csv_map[operator.cluster_service_version]
@@ -303,35 +303,35 @@ class OpenShiftApi:
 
     @catch_k8s_exception
     def _list_nodes(self, **kwargs):
-        return self._node_api.get(**kwargs)
+        return self._node_api.get(**kwargs).items
 
     @catch_k8s_exception
     def _list_clusters(self, **kwargs):
-        return self._cluster_api.get(**kwargs)
+        return self._cluster_api.get(**kwargs).items
 
     @catch_k8s_exception
     def _list_pods(self, **kwargs):
-        return self._pod_api.get(**kwargs)
+        return self._pod_api.get(**kwargs).items
 
     @catch_k8s_exception
     def _list_cluster_operators(self, **kwargs):
-        return self._cluster_operator_api.get(**kwargs)
+        return self._cluster_operator_api.get(**kwargs).items
 
     @catch_k8s_exception
     def _list_subscriptions(self, **kwargs):
-        return self._subscription_api.get(**kwargs)
+        return self._subscription_api.get(**kwargs).items
 
     @catch_k8s_exception
     def _list_cluster_service_versions(self, **kwargs):
-        return self._cluster_service_version_api.get(**kwargs)
+        return self._cluster_service_version_api.get(**kwargs).items
 
     @catch_k8s_exception
     def _list_managed_clusters(self, **kwargs):
-        return self._managed_cluster_api.get(**kwargs)
+        return self._managed_cluster_api.get(**kwargs).items
 
     @catch_k8s_exception
     def _list_routes(self, **kwargs):
-        return self._route_api.get(**kwargs)
+        return self._route_api.get(**kwargs).items
 
     def _init_ocp_nodes(self, node) -> OCPNode:
         return OCPNode(

--- a/quipucords/tests/scanner/openshift/test_api.py
+++ b/quipucords/tests/scanner/openshift/test_api.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import httpretty
 import pytest
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
 from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.entities import (
@@ -328,6 +329,16 @@ def test_init_managed_cluster(
 
     acm_metrics = ocp_client.retrieve_acm_metrics()
 
+    assert acm_metrics == expected_metrics
+
+
+def test_retrieve_acm_metrics_when_acm_not_available(ocp_client: OpenShiftApi, mocker):
+    """Test retrieving no metrics when ACM ManagedCluster API is not available."""
+    expected_metrics = []
+    mocker.patch.object(
+        ocp_client, "_list_managed_clusters", side_effect=ResourceNotFoundError
+    )
+    acm_metrics = ocp_client.retrieve_acm_metrics()
     assert acm_metrics == expected_metrics
 
 

--- a/quipucords/tests/scanner/openshift/test_api.py
+++ b/quipucords/tests/scanner/openshift/test_api.py
@@ -151,7 +151,7 @@ def test_route_api(ocp_client: OpenShiftApi):
 @pytest.mark.vcr(VCRCassettes.OCP_ROUTE, VCRCassettes.OCP_DISCOVERER_CACHE)
 def test_list_route(ocp_client: OpenShiftApi):
     """Test retrieve routes method."""
-    list_routes = ocp_client._list_routes().items
+    list_routes = ocp_client._list_routes()
     for route in list_routes:
         assert route["spec"]["host"]
 
@@ -324,7 +324,7 @@ def test_init_managed_cluster(
     mocker.patch.object(
         ocp_client,
         "_list_managed_clusters",
-        return_value=mocker.Mock(items=[mock_managed_cluster]),
+        return_value=[mock_managed_cluster],
     )
 
     acm_metrics = ocp_client.retrieve_acm_metrics()
@@ -364,12 +364,12 @@ def test_olm_operator_construction(ocp_client: OpenShiftApi, mocker, faker):
     mocker.patch.object(
         OpenShiftApi,
         "_list_subscriptions",
-        return_value=mocker.Mock(items=[subscription]),
+        return_value=[subscription],
     )
     mocker.patch.object(
         OpenShiftApi,
         "_list_cluster_service_versions",
-        return_value=mocker.Mock(items=[csv]),
+        return_value=[csv],
     )
 
     operators = ocp_client.retrieve_operators()


### PR DESCRIPTION
This fixes an issue I encountered when trying to scan an OpenShift source where the cluster _does not_ have ACM installed.

Previously, the scan would fail and report an unhandled exception like this in the server logs:

```
ERROR 2023-08-21 15:32:26,947 model 39918 123145369550848 Job 7, Task 2 of 3 (inspect, openshift, shrocp4upi412ovn, elapsed_time: 4s) - Unexpected failure occurred. See context below.
SCAN JOB: ScanJob object (7)
TASK: ScanTask object (14)
SOURCE: Source object (3)
CREDENTIALS: [['Credential object (5)']]
INFO 2023-08-21 15:32:26,948 model 39918 123145369550848 Job 7, Task 2 of 3 (inspect, openshift, shrocp4upi412ovn, elapsed_time: 4s) - FAILURE STATS. Stats: systems_count=7, systems_scanned=6, systems_failed=0, systems_unreachable=0
ERROR 2023-08-21 15:32:26,949 model 39918 123145369550848 Job 7, Task 2 of 3 (inspect, openshift, shrocp4upi412ovn, elapsed_time: 4s) - STATE UPDATE (failed). Additional status information: Unexpected failure occurred. See context below.
SCAN JOB: ScanJob object (7)
TASK: ScanTask object (14)
SOURCE: Source object (3)
CREDENTIALS: [['Credential object (5)']]
ERROR 2023-08-21 15:32:26,949 model 39918 123145369550848 Job 7 (inspect, elapsed_time: 4s) - FATAL ERROR. No matches found for {'api_version': 'cluster.open-cluster-management.io/v1', 'kind': 'ManagedCluster'}
INFO 2023-08-21 15:32:26,972 model 39918 123145369550848 Job 7 (inspect, elapsed_time: 4s) - FAILURE STATS. Stats: systems_count=1, systems_scanned=6, systems_failed=0, systems_unreachable=0, system_fingerprint_count=0
ERROR 2023-08-21 15:32:26,972 model 39918 123145369550848 Job 7 (inspect, elapsed_time: 4s) - STATE UPDATE (failed).  Additional State information: FATAL ERROR. No matches found for {'api_version': 'cluster.open-cluster-management.io/v1', 'kind': 'ManagedCluster'}
Process ProcessBasedScanJobRunner-3:
Traceback (most recent call last):
  File "/Users/brasmith/.pyenv/versions/3.11.3/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/job.py", line 250, in run
    return agnostic_runner.start()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/job.py", line 269, in start
    return self.run()
           ^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/job.py", line 323, in run
    task_status = run_task_runner(runner, self.manager_interrupt)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/job.py", line 123, in run_task_runner
    raise error
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/job.py", line 106, in run_task_runner
    status_message, task_status = runner.run(*run_args)
                                  ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/runner.py", line 78, in run
    return self.execute_task(manager_interrupt)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/openshift/inspect.py", line 43, in execute_task
    extra_cluster_facts = self._extra_cluster_facts(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/openshift/inspect.py", line 78, in _extra_cluster_facts
    extra_facts[fact_name] = api_method(
                             ^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/openshift/api.py", line 195, in retrieve_acm_metrics
    for cluster in self._list_managed_clusters(**kwargs).items:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/openshift/api.py", line 37, in _decorator
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/openshift/api.py", line 323, in _list_managed_clusters
    return self._managed_cluster_api.get(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/.pyenv/versions/3.11.3/lib/python3.11/functools.py", line 1001, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/openshift/api.py", line 293, in _managed_cluster_api
    return self._dynamic_client.resources.get(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.11/lib/python3.11/site-packages/openshift/dynamic/discovery.py", line 186, in get
    raise ResourceNotFoundError('No matches found for {}'.format(kwargs))
kubernetes.dynamic.exceptions.ResourceNotFoundError: No matches found for {'api_version': 'cluster.open-cluster-management.io/v1', 'kind': 'ManagedCluster'}
INFO 2023-08-21 15:32:27,935 model 39838 123145369550848 Job 7 (inspect, elapsed_time: 5s) - SCAN JOB MANAGER: scan job has completed.
```





Relates to JIRA: DISCOVERY-349
https://issues.redhat.com/browse/DISCOVERY-349