### PR TITLE
fix: handle uncommon case when we find an operator not listed in service versions

### DIFF
--- a/quipucords/scanner/openshift/api.py
+++ b/quipucords/scanner/openshift/api.py
@@ -262,8 +262,14 @@ class OpenShiftApi:
             for csv in self._list_cluster_service_versions(**kwargs)
         }
         for operator in olm_operators:
-            csv = csv_map[operator.cluster_service_version]
-            operator.display_name = csv.spec.displayName
+            try:
+                csv = csv_map[operator.cluster_service_version]
+                operator.display_name = csv.spec.displayName
+            except KeyError:
+                # This can happen in rare cases when we find an operator that wasn't
+                # listed in the cluster service versions. I'm not sure how this can
+                # happen, but we have actually seen it on a shared OpenShift server.
+                operator.display_name = operator.name
 
         return cluster_operators + olm_operators
 

--- a/quipucords/scanner/openshift/api.py
+++ b/quipucords/scanner/openshift/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from functools import cached_property, wraps
 from logging import getLogger
@@ -262,14 +263,15 @@ class OpenShiftApi:
             for csv in self._list_cluster_service_versions(**kwargs)
         }
         for operator in olm_operators:
-            try:
+            # We suppress KeyError below because sometimes we find an operator that
+            # wasn't listed in the cluster service versions. I'm not sure how this can
+            # happen, but we have actually seen it on a shared OpenShift server.
+            # See related: https://github.com/quipucords/quipucords/pull/2447
+            # In that case, `operator.display_name` keeps its default `None` which
+            # we prefer over choosing some other value.
+            with contextlib.suppress(KeyError):
                 csv = csv_map[operator.cluster_service_version]
                 operator.display_name = csv.spec.displayName
-            except KeyError:
-                # This can happen in rare cases when we find an operator that wasn't
-                # listed in the cluster service versions. I'm not sure how this can
-                # happen, but we have actually seen it on a shared OpenShift server.
-                operator.display_name = operator.name
 
         return cluster_operators + olm_operators
 


### PR DESCRIPTION
This should handle an uncommon (maybe?) situation wherein we find an operator from the subscriptions API that was not also found in the cluster service versions API.

Specifically, I encountered this problem when attempting to scan an internal shared cluster (`shrocp4upi49`). The inspection crashed out with an unhandled `KeyError` due to finding an operator named `amq-streams` but our keys from the CSV API were:

```
container-security-operator.v3.8.8
devworkspace-operator.v0.19.1-0.1682321189.p
elasticsearch-operator.5.5.11
jaeger-operator.v1.42.0-5
kiali-operator.v1.57.7
openshift-gitops-operator.v1.6.7
openshift-pipelines-operator-rh.v1.7.3
quay-operator.v3.8.8
servicemeshoperator.v2.3.3
web-terminal.v1.4.0
amq-broker-operator.v7.11.1-opr-2
gitlab-runner-operator.v1.12.0
cluster-logging.5.5.11
packageserver
datagrid-operator.v8.4.5
```

Note that the scan _did_ successfully find many other operators that were in that list. Only this one `amq-streams` was found that _was not_ in the list.

It is unclear to me how the operator was installed or how the server is managed. So, I do not know how to reproduce this issue independently.

It looks like we only cross-reference this list to get a more "user friendly" display name for the operators that we find. My change here is to simply reuse the operator's own name (in this case `amq-streams`) as a fallback when we cannot find a match from the CSV API response. Following this change, a new scan against this troublesome OpenShift server succeeded, and the only difference I could find is that the downloaded `details.json` used "amq-streams" as the operator's display name instead of a more user-friendly name (e.g. "Red Hat Quay", "GitLab Runner", "OpenShift Elasticsearch Operator").

update: Instead of copying the name to display_name, we decided to leave display_name blank. I manually confirmed that this works as expected and puts `"display_name":null` in the `details.json`.