### PR TITLE
feat: add optional QPC_URLLIB3_DISABLE_WARNINGS to disable warning noise

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -100,6 +100,16 @@ SECRET_KEY, DJANGO_SECRET_PATH = app_secret_key_and_path()
 # TODO FIXME Remove this dangerous default.
 DEBUG = env.bool("DJANGO_DEBUG", True)
 
+if env.bool("QPC_URLLIB3_DISABLE_WARNINGS", False):
+    # Optionally disable noisy urllib3 warnings.
+    # Some scan target systems may have invalid or self-signed certs that the user does
+    # not intend to fix, and they may optionally configure its source not to verify the
+    # cert, but that makes urllib3 produce very noisy warnings that can drown out other
+    # more meaningful log messages.
+    import urllib3
+
+    urllib3.disable_warnings()
+
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOST_LIST", default=["*"])
 
 # Application definition


### PR DESCRIPTION
I'm getting real tired of seeing walls of these messages flood my local logs as I am developing and scanning sources...

```
  warnings.warn(
/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.11/lib/python3.11/site-packages/urllib3/connectionpool.py:1095: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-name.internal-example.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.11/lib/python3.11/site-packages/urllib3/connectionpool.py:1095: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-name.internal-example.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.11/lib/python3.11/site-packages/urllib3/connectionpool.py:1095: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-name.internal-example.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.11/lib/python3.11/site-packages/urllib3/connectionpool.py:1095: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-name.internal-example.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
```
😑 

Yes, _I know_ this is insecure, but this is an internal host with a cert that I don't control but I also don't have its CA. I have consciously and knowingly _disabled_ verification for requests to that host. I accept the risk.

So, I have added an environment variable `QPC_URLLIB3_DISABLE_WARNINGS` to silence this noise. ~~As a safeguard, it can only activate if `PRODUCTION` is `False`.~~ Update: After discussing in Slack ([here](https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1693337240847939?thread_ts=1693337044.633099&cid=C02QSNF1UKE)), we decided to allow anyone anywhere to set this, including production environments.

I confirmed locally by putting `QPC_URLLIB3_DISABLE_WARNINGS=True` in my `.env`, restarting the server, and running a scan. No noise. Then I flipped the setting, restarted, and scanned. Noise has returned.