### PR TITLE
fix: handle uncommon case when we find an operator not listed in service versions

### DIFF
--- a/quipucords/scanner/openshift/api.py
+++ b/quipucords/scanner/openshift/api.py
@@ -193,8 +193,14 @@ class OpenShiftApi:
             for csv in self._list_cluster_service_versions(**kwargs).items
         }
         for operator in olm_operators:
-            csv = csv_map[operator.cluster_service_version]
-            operator.display_name = csv.spec.displayName
+            try:
+                csv = csv_map[operator.cluster_service_version]
+                operator.display_name = csv.spec.displayName
+            except KeyError:
+                # This can happen in rare cases when we find an operator that wasn't
+                # listed in the cluster service versions. I'm not sure how this can
+                # happen, but we have actually seen it on a shared OpenShift server.
+                operator.display_name = operator.name
 
         return cluster_operators + olm_operators
 


### PR DESCRIPTION
This is a backport of https://github.com/quipucords/quipucords/pull/2447 from main to the `release/1.3` branch

```
git cherry-pick 1f89a5b4f0ba03d07bfdf37ddd86316ea1b4e135
git cherry-pick 731ea3245490c2bd43a829a9c5aae01fe4431541
```