### PR TITLE
Allow user to override default container tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BINDIR  = bin
 PARALLEL_NUM ?= $(shell python -c 'import multiprocessing as m;print(int(max(m.cpu_count()/2, 2)))')
 TEST_OPTS := -n $(PARALLEL_NUM) -ra -m 'not slow' --timeout=15
 
+QUIPUCORDS_CONTAINER_TAG ?= quipucords
 QUIPUCORDS_UI_PATH ?= ../quipucords-ui
 QUIPUCORDS_UI_RELEASE ?= latest
 
@@ -185,7 +186,7 @@ serve-swagger: $(qpc_on_ui_dir)
 build-container:
 	podman build \
 		--build-arg UI_RELEASE=$(QUIPUCORDS_UI_RELEASE) \
-		-t quipucords .
+		-t $(QUIPUCORDS_CONTAINER_TAG) .
 
 check-db-migrations-needed:
 	$(PYTHON) quipucords/manage.py makemigrations --check


### PR DESCRIPTION
This is part of DISCOVERY-392 .

We want to build container on Jenkins agent. We _could_ modify `get-pipeline-data.py` to assume different container URL when PR is a fork, but that will only complicate a script that is already getting complicated. I think it's better to create a container with a name that already matches what we would have pulled in from quay.

Also, allowing user to set custom container name sounds like a reasonable feature anyway. This allows for easy building of multiple containers locally, or whatever.