### PR TITLE
refactor: remove unnecessary exposed port for celery worker container in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,6 @@ services:
       - .:/app:ro
       - ./deploy:/deploy:ro
       - ./var/sshkeys/:/sshkeys:ro
-    ports:
-      - "56789:5678"
     environment:
       ANSIBLE_LOG_LEVEL: 3
       NETWORK_CONNECT_JOB_TIMEOUT: 6


### PR DESCRIPTION
Thank you @mirekdlugosz for spotting this!

I spun up a new set of containers with docker-compose, confirmed that the Celery config was enabled, created a network source, and performed a network scan (this uses the Celery workers), waited for it to complete successfully, and downloaded and reviewed the reports. As far as I can tell, everything worked normally without the exposed port.