### PR TITLE
Change default path for secret, logs and sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ coverage.xml
 *.pot
 
 # Django stuff:
-*.log
 local_settings.py
 logs
 secret.txt
@@ -112,10 +111,6 @@ ENV/
 
 # mypy
 .mypy_cache/
-
-# sqlite
-db.sqlite3
-db.sqlite3-journal
 
 # From ide
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PATH="/opt/venv/bin:${PATH}"
 ENV PRODUCTION=True
 ENV PYTHONPATH=/app/quipucords
 ENV QUIPUCORDS_LOG_LEVEL=INFO
+ENV QPC_LOG_DIRECTORY=/var/log
 
 COPY scripts/dnf /usr/local/bin/dnf
 ARG BUILD_PACKAGES="crypto-policies-scripts gcc postgresql-devel python3.11-devel"

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -25,8 +25,10 @@ logger = logging.getLogger(__name__)
 
 env = environ.Env()
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+# BASE_DIR is ./quipucords/quipucords
 BASE_DIR = Path(__file__).absolute().parent.parent
+# DEFAULT_DATA_DIR is ./var, which is on .gitignore
+DEFAULT_DATA_DIR = BASE_DIR.parent / "var"
 
 PRODUCTION = env.bool("PRODUCTION", False)
 
@@ -55,7 +57,7 @@ def app_secret_key_and_path():
     # We also update the DJANGO_SECRET_PATH file accordingly
     # as it is also used as the Ansible password vault.
     django_secret_path = Path(
-        env.str("DJANGO_SECRET_PATH", str(BASE_DIR / "secret.txt"))
+        env.str("DJANGO_SECRET_PATH", str(DEFAULT_DATA_DIR / "secret.txt"))
     )
 
     django_secret_key = env("DJANGO_SECRET_KEY", default=None)
@@ -189,8 +191,8 @@ if QPC_DBMS not in allowed_db_engines:
 
 if QPC_DBMS == "sqlite":
     # If user enters an invalid QPC_DBMS, use default postgresql
-    DEV_DB = BASE_DIR / "db.sqlite3"
-    PROD_DB = Path(env.str("DJANGO_DB_PATH", str(BASE_DIR))) / "db.sqlite3"
+    DEV_DB = DEFAULT_DATA_DIR / "db.sqlite3"
+    PROD_DB = Path(env.str("DJANGO_DB_PATH", str(DEFAULT_DATA_DIR))) / "db.sqlite3"
     DB_PATH = PROD_DB if PRODUCTION else DEV_DB
     DATABASES = {
         "default": {
@@ -283,10 +285,8 @@ LOGGING_HANDLERS = env.list("DJANGO_LOG_HANDLERS", default=["console"])
 VERBOSE_FORMATTING = (
     "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
 )
-
-LOG_DIRECTORY = Path(env.str("LOG_DIRECTORY", str(BASE_DIR)))
-DEFAULT_LOG_FILE = LOG_DIRECTORY / "app.log"
-LOGGING_FILE = Path(env.str("DJANGO_LOG_FILE", str(DEFAULT_LOG_FILE)))
+LOG_DIRECTORY = Path(env.str("QPC_LOG_DIRECTORY", str(DEFAULT_DATA_DIR / "logs")))
+LOGGING_FILE = Path(env.str("DJANGO_LOG_FILE", str(LOG_DIRECTORY / "app.log")))
 
 LOGGING = {
     "version": 1,
@@ -359,6 +359,8 @@ LOGGING = {
 
 # Reverse default behavior to avoid host key checking
 os.environ.setdefault("ANSIBLE_HOST_KEY_CHECKING", "False")
+# Reverse default behavior for better readability in log files
+os.environ.setdefault("ANSIBLE_NOCOLOR", "False")
 
 QPC_EXCLUDE_INTERNAL_FACTS = env.bool("QPC_EXCLUDE_INTERNAL_FACTS", False)
 QPC_TOKEN_EXPIRE_HOURS = env.int("QPC_TOKEN_EXPIRE_HOURS", 24)

--- a/quipucords/tests/quipucords/test_settings.py
+++ b/quipucords/tests/quipucords/test_settings.py
@@ -1,17 +1,13 @@
 """Test settings module."""
 
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-import faker
+import pytest
 from django.conf import settings as django_settings
-from django.test import TestCase
 
 from quipucords import settings
 from quipucords.settings import app_secret_key_and_path
-
-_faker = faker.Faker()
 
 
 def read_secret_key(secret_file):
@@ -19,69 +15,77 @@ def read_secret_key(secret_file):
     return secret_file.read_text(encoding="utf-8").strip()
 
 
-class SecretKeyTests(TestCase):
+@pytest.fixture
+def secret_key(faker):
+    """Return a random secret key for testing."""
+    return faker.password(length=64)
+
+
+class TestSecretKey:
     """Tests to verify SECRET_KEY and DJANGO_SECRET_PATH are properly defined."""
 
-    def setUp(self):
-        """Initialize common variables for the tests."""
-        self.test_key = _faker.password(length=64)
-
-    def test_django_secret_key(self):
+    def test_django_secret_key(self, secret_key, tmp_path, mocker):
         """Test DJANGO_SECRET_KEY is honored."""
-        with tempfile.NamedTemporaryFile("w+") as secret_file:
-            with patch.dict(
-                settings.os.environ,
-                {
-                    "DJANGO_SECRET_PATH": secret_file.name,
-                    "DJANGO_SECRET_KEY": self.test_key,
-                },
-                clear=True,
-            ):
-                secret_key, django_secret_path = app_secret_key_and_path()
-                self.assertEqual(secret_key, self.test_key)
-                self.assertEqual(str(django_secret_path), secret_file.name)
-                self.assertEqual(read_secret_key(django_secret_path), self.test_key)
+        secret_file = tmp_path / "secret"
+        mocker.patch.dict(
+            settings.os.environ,
+            {
+                "DJANGO_SECRET_PATH": str(secret_file),
+                "DJANGO_SECRET_KEY": secret_key,
+            },
+            clear=True,
+        )
 
-    def test_django_secret_path(self):
+        django_secret, django_secret_path = app_secret_key_and_path()
+        assert django_secret == secret_key
+        assert django_secret_path == secret_file
+        assert read_secret_key(django_secret_path) == secret_key
+
+    def test_django_secret_path(self, tmp_path, secret_key, mocker):
         """Test DJANGO_SECRET_PATH is honored."""
-        with tempfile.NamedTemporaryFile("w+") as secret_file:
-            secret_file.write(self.test_key)
-            secret_file.flush()
-            with patch.dict(
-                settings.os.environ,
-                {"DJANGO_SECRET_PATH": secret_file.name},
-                clear=True,
-            ):
-                secret_key, django_secret_path = app_secret_key_and_path()
-                self.assertEqual(secret_key, self.test_key)
-                self.assertEqual(str(django_secret_path), secret_file.name)
-                self.assertEqual(read_secret_key(django_secret_path), self.test_key)
+        secret_file = tmp_path / "secret"
+        secret_file.write_text(secret_key)
+        mocker.patch.dict(
+            settings.os.environ,
+            {
+                "DJANGO_SECRET_PATH": str(secret_file),
+                "DJANGO_SECRET_KEY": secret_key,
+            },
+            clear=True,
+        )
 
-    def test_base_secret_key(self):
+        django_secret, django_secret_path = app_secret_key_and_path()
+        assert django_secret == secret_key
+        assert django_secret_path == secret_file
+        assert read_secret_key(django_secret_path) == secret_key
+
+    def test_base_secret_key(self, mocker):
         """Test base secret file is read and honored."""
         base_secret_path = Path(str(django_settings.DEFAULT_DATA_DIR / "secret.txt"))
-        with patch.dict(settings.os.environ, {}, clear=True):
-            if base_secret_path.exists():
-                base_secret_key = base_secret_path.read_text(encoding="utf-8").strip()
-                secret_key, django_secret_path = app_secret_key_and_path()
-                self.assertEqual(secret_key, base_secret_key)
-                self.assertEqual(base_secret_path, django_secret_path)
-                self.assertEqual(read_secret_key(base_secret_path), base_secret_key)
+        mocker.patch.dict(settings.os.environ, {}, clear=True)
+        if base_secret_path.exists():
+            base_secret_key = read_secret_key(base_secret_path)
+            django_secret, django_secret_path = app_secret_key_and_path()
+            assert django_secret == base_secret_key
+            assert base_secret_path == django_secret_path
+            assert read_secret_key(base_secret_path) == base_secret_key
 
     @patch("quipucords.settings.create_random_key")
     @patch("quipucords.settings.Path.exists")
-    def test_default_random_key(self, mock_path_exists, mock_create_random_key):
+    def test_default_random_key(  # noqa: PLR0913
+        self, mock_path_exists, mock_create_random_key, tmp_path, mocker, secret_key
+    ):
         """Test default random key generated if no secrets are specified."""
-        with tempfile.NamedTemporaryFile("w+") as secret_file:
-            with patch.dict(
-                settings.os.environ,
-                {"DJANGO_SECRET_PATH": secret_file.name},
-                clear=True,
-            ):
-                mock_path_exists.return_value = False
-                mock_create_random_key.return_value = self.test_key
-                secret_key, django_secret_path = app_secret_key_and_path()
-                self.assertEqual(secret_key, self.test_key)
-                self.assertEqual(str(django_secret_path), secret_file.name)
-                self.assertEqual(read_secret_key(django_secret_path), self.test_key)
-                mock_create_random_key.assert_called()
+        mock_path_exists.return_value = False
+        mock_create_random_key.return_value = secret_key
+        secret_file = tmp_path / "secret"
+        mocker.patch.dict(
+            settings.os.environ,
+            {"DJANGO_SECRET_PATH": str(secret_file)},
+            clear=True,
+        )
+        django_secret, django_secret_path = app_secret_key_and_path()
+        assert django_secret == secret_key
+        assert django_secret_path == secret_file
+        assert read_secret_key(django_secret_path) == secret_key
+        mock_create_random_key.assert_called()

--- a/quipucords/tests/quipucords/test_settings.py
+++ b/quipucords/tests/quipucords/test_settings.py
@@ -59,7 +59,7 @@ class SecretKeyTests(TestCase):
 
     def test_base_secret_key(self):
         """Test base secret file is read and honored."""
-        base_secret_path = Path(str(django_settings.BASE_DIR / "secret.txt"))
+        base_secret_path = Path(str(django_settings.DEFAULT_DATA_DIR / "secret.txt"))
         with patch.dict(settings.os.environ, {}, clear=True):
             if base_secret_path.exists():
                 base_secret_key = base_secret_path.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
Initially secret, app.log, and sqlite files were being saved (by default) to quipucords/quipucords. That's... unwise, as this path is reserved for source code and a "vanilla" development environment would not have the env vars customizing the path to save this files set.