### PR TITLE
refactor(insights): remove rh_installed_products

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -1427,9 +1427,6 @@ definitions:
                 "namespace": "qpc",
                 "facts": {
                     "rh_product_certs": [],
-                    "rh_products_installed": [
-                        "RHEL"
-                    ],
                     "last_reported": "2019-08-01T17:21:23.842458",
                     "system_purpose": {
                         "_version": "1",

--- a/quipucords/api/common/entities.py
+++ b/quipucords/api/common/entities.py
@@ -217,30 +217,6 @@ class HostEntity:
                 "Host wasn't properly initialized to list products"
             ) from err
 
-    @property
-    def rh_products_installed(self):
-        """Return the installed products on the system.
-
-        This is a LEGACY fact on HBI and should be replaced with
-        installed_products in the near future.
-        """
-        # installed_products ref: https://github.com/RedHatInsights/insights-host-inventory/blob/986a8323f6d5d94ad721a9746cd50f383dd2594c/swagger/system_profile.spec.yaml#L374-L377  # noqa: E501
-
-        def is_not_none(obj):
-            return obj is not None
-
-        name_to_product = {
-            "JBoss EAP": "EAP",
-            "JBoss Fuse": "FUSE",
-            "JBoss BRMS": "DCSM",
-            "JBoss Web Server": "JWS",
-        }
-        products = [name_to_product.get(product) for product in self.products]
-        products = list(filter(is_not_none, products))
-        if self._fingerprints.is_redhat:
-            products.append("RHEL")
-        return products
-
     def has_canonical_facts(self):
         """Return True if host contains at least one canonical fact."""
         for canonical_fact in CANONICAL_FACTS:

--- a/quipucords/api/insights_report/serializers.py
+++ b/quipucords/api/insights_report/serializers.py
@@ -27,7 +27,6 @@ class FactsSerializer(Serializer):
     last_discovered = fields.DateTimeField()
     qpc_server_version = fields.CharField(default=server_version)
     qpc_server_id = fields.CharField(default=get_server_id)
-    rh_products_installed = fields.ListField(child=fields.CharField())
 
 
 class FactsetSerializer(Serializer):

--- a/quipucords/tests/api/common/test_entities.py
+++ b/quipucords/tests/api/common/test_entities.py
@@ -193,17 +193,15 @@ class TestHostEntity:
             host.products
 
     @pytest.mark.parametrize(
-        "fingerprint,expected_product_names,expected_rh_products_installed",
+        "fingerprint,expected_product_names",
         [
             (
                 pytest.lazy_fixture("fingerprint_wo_products"),
                 set(),
-                [],
             ),
             (
                 pytest.lazy_fixture("fingerprint_with_products"),
                 {"JBoss EAP", "UNKOWN PRODUCT"},
-                ["EAP"],
             ),
         ],
     )
@@ -211,19 +209,10 @@ class TestHostEntity:
         self,
         fingerprint,
         expected_product_names,
-        expected_rh_products_installed,
     ):
-        """Test products/rh_products_installed properties."""
+        """Test products properties."""
         host = self.host_init(fingerprint)
         assert host.products == expected_product_names
-        assert host.rh_products_installed == expected_rh_products_installed
-
-    def test_products_is_rhel(self, fingerprint):
-        """Check if RHEL is added to rh_products_installed when system is rhel."""
-        fingerprint.is_redhat = True
-        fingerprint.save()
-        host = self.host_init(fingerprint)
-        assert "RHEL" in host.rh_products_installed
 
     @pytest.mark.parametrize(
         "cpu_socket_count,vm_host_socket_count,expected_result",


### PR DESCRIPTION
This function was deprecated on hbi side some time ago. Currently, if we want to send instaled_products information we have to do it through system profile.