### PR TITLE
fix(insights): report correct cloud provider tag

### DIFF
--- a/quipucords/scanner/network/processing/cloud_provider.py
+++ b/quipucords/scanner/network/processing/cloud_provider.py
@@ -3,7 +3,7 @@
 from scanner.network.processing import process
 
 AMAZON = "aws"
-GOOGLE = "google"
+GCP = "gcp"
 AZURE = "azure"
 ALIBABA = "alibaba"
 
@@ -77,7 +77,7 @@ class ProcessCloudProvider(process.Processor):
         if "amazon" in dmi_bios_version.lower():
             return AMAZON
         if "google" in dmi_bios_version.lower():
-            return GOOGLE
+            return GCP
         if "7783-7084-3265-9085-8269-3286-77" in dmi_chassis_asset_tag:
             return AZURE
         if (

--- a/quipucords/tests/scanner/network/processing/test_cloud_provider.py
+++ b/quipucords/tests/scanner/network/processing/test_cloud_provider.py
@@ -112,7 +112,7 @@ class TestProcessCloudProvider(unittest.TestCase):
             cloud_provider.ProcessCloudProvider.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
             ),
-            cloud_provider.GOOGLE,
+            cloud_provider.GCP,
         )
         dependencies["dmi_bios_version"] = "6.0"
         dependencies["dmi_system_manufacturer"] = "Alibaba Cloud"


### PR DESCRIPTION
Inventory UI expects GCP tag instead of GOOGLE and Discovery should use the same value.

Relates to JIRA: DISCOVERY-414
https://issues.redhat.com/browse/DISCOVERY-414