### PR TITLE
fix: avoid unexpected stdout in network scan Ansible result

### DIFF
--- a/quipucords/scanner/network/processing/cloud_provider.py
+++ b/quipucords/scanner/network/processing/cloud_provider.py
@@ -42,11 +42,9 @@ class ProcessDmiSystemProductName(process.Processor):
         """Pass the output back through."""
         dmi_system_product_name = dependencies.get("internal_dmi_system_product_name")
         if dmi_system_product_name and dmi_system_product_name.get("rc") == 0:
-            result = dmi_system_product_name.get("stdout_lines")
+            result = dmi_system_product_name.get("stdout_lines", [])
             if result:
-                if result[0] == "" and len(result) > 1:  # noqa: PLC1901
-                    return result[1].strip()
-                return result[0].strip()
+                return result[-1].strip()
         return ""
 
 

--- a/quipucords/scanner/network/processing/cpu.py
+++ b/quipucords/scanner/network/processing/cpu.py
@@ -98,7 +98,7 @@ class ProcessCpuSocketCount(process.Processor):
             and cpuinfo_cpu_socket_count.get("rc") == 0
             and cpuinfo_cpu_socket_count.get("stdout_lines")
         ):
-            cpuinfo_count = cpuinfo_cpu_socket_count.get("stdout_lines", [0])[0]
+            cpuinfo_count = cpuinfo_cpu_socket_count.get("stdout_lines", [0])[-1]
             if is_int(cpuinfo_count):
                 if (
                     convert_to_int(cpuinfo_count) != 0

--- a/quipucords/scanner/network/processing/dmi.py
+++ b/quipucords/scanner/network/processing/dmi.py
@@ -16,15 +16,21 @@ class ProcessDmiSystemUuid(process.Processor):
 
     @staticmethod
     def process(output, dependencies):
-        """Pass the output back through."""
+        """
+        Get the DMI system UUID from output if present.
+
+        Get only the last "valid" value from the stdout lines (where "valid" just means
+        it has length <= 36). This seems really lazy and problematic, and we should
+        FIXME this "UUID validation" at some point.
+
+        Note that we are processing the stdout lines in reverse order because a badly
+        configured target system may inject unexpected lines at the start of stdout.
+        """
         dmi_system_uuid = dependencies.get("internal_dmi_system_uuid")
         if dmi_system_uuid and dmi_system_uuid.get("rc") == 0:
-            result = dmi_system_uuid.get("stdout_lines")
-            if result:
-                dmi_system_uuid = result[0]
-                if result[0] == "" and len(result) > 1:  # noqa: PLC1901
-                    dmi_system_uuid = result[1]
-                if len(dmi_system_uuid) <= 36:  # noqa: PLR2004
+            stdout_lines = dmi_system_uuid.get("stdout_lines", [])
+            for dmi_system_uuid in stdout_lines[::-1]:
+                if 0 < len(dmi_system_uuid) <= 36:  # noqa: PLR2004
                     return dmi_system_uuid
                 logger.warning(
                     "dmi_system_uuid is invalid because "

--- a/quipucords/scanner/network/processing/jws.py
+++ b/quipucords/scanner/network/processing/jws.py
@@ -12,10 +12,8 @@ class ProcessJWSInstalledWithRpm(process.Processor):
     @staticmethod
     def process(output, dependencies=None):
         """Determine if jws was installed with rpm. Version 3 and up."""
-        stdout = output.get("stdout_lines", [])
-        if len(stdout) == 1 and "Red Hat JBoss Web Server" in stdout[0]:
-            return True
-        return False
+        stdout_lines = output.get("stdout_lines", [])
+        return bool(stdout_lines and "Red Hat JBoss Web Server" in stdout_lines[-1])
 
 
 class ProcessHasJBossEULA(process.Processor):
@@ -26,8 +24,8 @@ class ProcessHasJBossEULA(process.Processor):
     @staticmethod
     def process(output, dependencies=None):
         """Check if JBossEULA.txt exists in JWS_Home directory."""
-        stdout = output.get("stdout", "false")
-        return stdout == "true"
+        stdout_lines = output.get("stdout_lines", [])
+        return bool(stdout_lines and stdout_lines[-1] == "true")
 
 
 class ProcessTomcatPartOfRedhatProduct(process.Processor):
@@ -38,10 +36,8 @@ class ProcessTomcatPartOfRedhatProduct(process.Processor):
     @staticmethod
     def process(output, dependencies=None):
         """Return either True or False."""
-        result = output.get("stdout_lines", False)
-        if result and result[0] == "True":
-            return True
-        return False
+        stdout_lines = output.get("stdout_lines", [])
+        return bool(stdout_lines and stdout_lines[-1] == "True")
 
 
 class ProcessJWSHasCert(process.Processor):
@@ -53,6 +49,5 @@ class ProcessJWSHasCert(process.Processor):
     @staticmethod
     def process(output, dependencies=None):
         """Return either True or False."""
-        if output.get("stdout_lines", False):
-            return True
-        return False
+        stdout_lines = output.get("stdout_lines", [])
+        return bool(stdout_lines and stdout_lines[-1].endswith(".pem"))

--- a/quipucords/scanner/network/processing/subman.py
+++ b/quipucords/scanner/network/processing/subman.py
@@ -20,8 +20,15 @@ class ProcessSubmanConsumed(process.Processor):
         entitlements_data = []
         entitlements = output.get("stdout_lines", [])
         for entitlement in entitlements:
-            if entitlement:
+            if not entitlement:
+                # Skip emtpy lines.
+                continue
+            try:
                 name, entitlement_id = entitlement.split(" - ")
                 entitlement_dict = {"name": name, "entitlement_id": entitlement_id}
                 entitlements_data.append(entitlement_dict)
+            except ValueError as e:
+                # .split may fail on unexpected outputs in the stdout_lines.
+                # We should log this as an error but keep trying other lines.
+                logger.error(e)
         return entitlements_data

--- a/quipucords/scanner/network/processing/system_purpose.py
+++ b/quipucords/scanner/network/processing/system_purpose.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 
 from scanner.network.processing import process
 
@@ -16,12 +17,19 @@ class ProcessSystemPurpose(process.Processor):
     @staticmethod
     def process(output, dependencies=None):
         """Pass the output back through."""
-        system_purpose_str = output.get("stdout", None)
-        if system_purpose_str:
+        if not (system_purpose_str := output.get("stdout", None)):
+            return None
+        while system_purpose_str:
             try:
                 system_purpose_dict = json.loads(system_purpose_str)
                 return system_purpose_dict
             except json.decoder.JSONDecodeError as error:
                 logger.warning("system_purpose was not valid JSON.  Error: %s", error)
-                return None
+            # We anticipate in some edge cases that unwanted non-JSON outputs may be
+            # included in the stdout stream before the actual JSON output, but we expect
+            # they are on their own lines. So, chop the first line, try, and repeat.
+            # It's a brute-force solution, but this should help in those edge cases!
+            if "\n" not in system_purpose_str:
+                break
+            system_purpose_str = re.sub(r"^.*?\n", "", system_purpose_str)
         return None

--- a/quipucords/scanner/network/processing/util.py
+++ b/quipucords/scanner/network/processing/util.py
@@ -7,17 +7,20 @@ from scanner.network.processing import process
 logger = logging.getLogger(__name__)
 
 
-def get_line(lines, line_index=0):
+def get_line(lines, line_index=-1):
     """Get a line from output.
+
+    By default, get the last line of the output, not the first, since the stdout stream
+    may have been contaminated by unwanted output before our command ran.
 
     :param lines: list of output lines
     :param line_index: The index line to retrieve
     :returns: The specific line or empty string
     """
-    num_lines = len(lines)
-    if num_lines > line_index:
+    try:
         return lines[line_index]
-    return process.NO_DATA
+    except IndexError:
+        return process.NO_DATA
 
 
 class InitLineFinder(process.Processor):

--- a/quipucords/scanner/network/processing/virt.py
+++ b/quipucords/scanner/network/processing/virt.py
@@ -10,6 +10,12 @@ VIRT_TYPE_KVM = "kvm"
 VIRT_TYPE_XEN = "xen"
 
 
+def is_last_stdout_line_y(stdout_lines: list) -> bool:
+    """Return True if the last line of stdout_lines is "Y"."""
+    stdout_lines = [line for line in stdout_lines if line]
+    return bool(stdout_lines and stdout_lines[-1] == "Y")
+
+
 class ProcessVirtXenPrivcmdFound(process.Processor):
     """Process the internal_xen_privcmd_found from virt."""
 
@@ -18,11 +24,7 @@ class ProcessVirtXenPrivcmdFound(process.Processor):
     @staticmethod
     def process(output, dependencies):
         """Process internal_xen_privcmd_found output."""
-        result = output.get("stdout_lines")
-        if isinstance(result, list):
-            result = [line for line in result if line]
-            return bool(result) and result[0] == "Y"
-        return False
+        return is_last_stdout_line_y(output.get("stdout_lines", []))
 
 
 class ProcessVirtKvmFound(process.Processor):
@@ -33,11 +35,7 @@ class ProcessVirtKvmFound(process.Processor):
     @staticmethod
     def process(output, dependencies):
         """Process internal_kvm_found output."""
-        result = output.get("stdout_lines")
-        if isinstance(result, list):
-            result = [line for line in result if line]
-            return bool(result) and result[0] == "Y"
-        return False
+        return is_last_stdout_line_y(output.get("stdout_lines", []))
 
 
 class ProcessVirtXenGuest(process.Processor):
@@ -48,11 +46,9 @@ class ProcessVirtXenGuest(process.Processor):
     @staticmethod
     def process(output, dependencies):
         """Process internal_xen_guest output."""
-        result = output.get("stdout_lines")
-        if isinstance(result, list):
-            result = [line for line in result if line]
-            return bool(result) and is_int(result[0]) and convert_to_int(result[0]) > 0
-        return False
+        result = output.get("stdout_lines", [])
+        result = [line for line in result if line]
+        return bool(result and is_int(result[-1]) and convert_to_int(result[-1]) > 0)
 
 
 class ProcessSystemManufacturer(process.Processor):
@@ -64,12 +60,9 @@ class ProcessSystemManufacturer(process.Processor):
     @staticmethod
     def process(output, dependencies):
         """Process internal_sys_manufacturer output."""
-        result = output.get("stdout_lines")
-        if isinstance(result, list):
-            result = [line for line in result if line]
-            if bool(result):
-                return result[0]
-        return None
+        result = output.get("stdout_lines", [])
+        result = [line for line in result if line]
+        return result[-1] if result else None
 
 
 class ProcessVirtCpuModelNameKvm(process.Processor):
@@ -80,11 +73,7 @@ class ProcessVirtCpuModelNameKvm(process.Processor):
     @staticmethod
     def process(output, dependencies):
         """Process internal_cpu_model_name_kvm output."""
-        result = output.get("stdout_lines")
-        if isinstance(result, list):
-            result = [line for line in result if line]
-            return bool(result) and result[0] == "Y"
-        return False
+        return is_last_stdout_line_y(output.get("stdout_lines", []))
 
 
 class ProcessVirtType(process.Processor):

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -135,7 +135,7 @@
   set_fact:
     internal_have_systemctl: true
   ignore_errors: yes
-  when: (internal_whereis_systemctl_cmd.get('rc') == 0 and internal_whereis_systemctl_cmd.get('stdout_lines') != ['systemctl:'])
+  when: (internal_whereis_systemctl_cmd.get('rc') == 0 and internal_whereis_systemctl_cmd.get('stdout_lines')[-1] != 'systemctl:')
 
 - name: gather internal_whereis_chkconfig_cmd
   raw: whereis chkconfig
@@ -151,7 +151,7 @@
   set_fact:
     internal_have_chkconfig: true
   ignore_errors: yes
-  when: (internal_whereis_chkconfig_cmd.get('rc') == 0 and internal_whereis_chkconfig_cmd.get('stdout_lines') != ['chkconfig:'])
+  when: (internal_whereis_chkconfig_cmd.get('rc') == 0 and internal_whereis_chkconfig_cmd.get('stdout_lines')[-1] != 'chkconfig:')
 
 - name: gather internal_whereis_ifconfig_cmd
   raw: whereis ifconfig
@@ -167,7 +167,7 @@
   set_fact:
     internal_have_ifconfig: true
   ignore_errors: yes
-  when: "internal_whereis_ifconfig_cmd.get('rc') == 0 and internal_whereis_ifconfig_cmd.get('stdout_lines') != ['ifconfig:']"
+  when: "internal_whereis_ifconfig_cmd.get('rc') == 0 and internal_whereis_ifconfig_cmd.get('stdout_lines')[-1] != 'ifconfig:'"
 
 - name: gather internal_whereis_ip_cmd
   raw: command -v /sbin/ip

--- a/quipucords/scanner/network/runner/roles/cpu/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/cpu/tasks/main.yml
@@ -45,7 +45,7 @@
   ignore_errors: yes
 
 - name: gather internal_cpu_model_ver fact
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^model\s*.' | sed -n -e 's/^.*model\s*.\s*//p'
+  raw: cat /proc/cpuinfo 2>/dev/null | grep '^model\s*:' | sed -n -e 's/^.*model\s*:\s*//p'
   register: internal_cpu_model_ver
   ignore_errors: yes
 
@@ -61,7 +61,7 @@
 
 - name: extract or default cpu.count fact
   set_fact:
-    cpu_count: "{{ internal_cpu_count_cmd | json_query('stdout_lines[0]') }}"
+    cpu_count: "{{ internal_cpu_count_cmd | json_query('stdout_lines[-1]') }}"
   ignore_errors: yes
 
 - name: gather cpu.core_per_socket fact
@@ -71,7 +71,7 @@
 
 - name: extract or default cpu.core_per_socket fact
   set_fact:
-    cpu_core_per_socket: "{{ internal_cpu_core_per_socket_cmd | json_query('stdout_lines[0]') }}"
+      cpu_core_per_socket: "{{ internal_cpu_core_per_socket_cmd | json_query('stdout_lines[-1]') }}"
   ignore_errors: yes
 
 - name: gather cpu.siblings fact
@@ -81,7 +81,7 @@
 
 - name: extract or default cpu.siblings fact
   set_fact:
-    cpu_siblings: "{{ internal_cpu_siblings_cmd | json_query('stdout_lines[0]') }}"
+    cpu_siblings: "{{ internal_cpu_siblings_cmd | json_query('stdout_lines[-1]') }}"
   ignore_errors: yes
 
 - name: determine cpu.hyperthreading fact

--- a/quipucords/scanner/network/runner/roles/date/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/date/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: extract result value for uptime
   set_fact:
-    last_booted_at: "{{ internal_uptime_utc_cmd['stdout'] | trim}}"
+    last_booted_at: "{{ internal_uptime_utc_cmd | json_query('stdout_lines[-1]') | trim }}"
   ignore_errors: yes
 
 - name: gather date.anaconda_log fact
@@ -33,15 +33,18 @@
 
 - name: extract result value for date.anaconda_log
   set_fact:
-    date_anaconda_log: "{{ internal_date_anaconda_log_cmd['stdout'] | trim | default('') }}"
+    date_anaconda_log: "{{ internal_date_anaconda_log_cmd['stdout_lines'][-1] | trim | default('') }}"
   ignore_errors: yes
-  when: '"stdout" in internal_date_anaconda_log_cmd'
+  when:
+    - '"stdout_lines" in internal_date_anaconda_log_cmd'
+    - 'internal_date_anaconda_log_cmd["stdout_lines"] | length > 0'
+
 
 - name: handle failure value for date.anaconda_log
   set_fact:
     date_anaconda_log: ""
   ignore_errors: yes
-  when: '"stdout" not in internal_date_anaconda_log_cmd'
+  when: '"stdout_lines" not in internal_date_anaconda_log_cmd or internal_date_anaconda_log_cmd["stdout_lines"] | length == 0'
 
 - name: gather internal_date_machine_id fact
   raw: if [ -f /etc/machine-id ] ; then ls --full-time /etc/machine-id 2>/dev/null | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' ; fi

--- a/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
@@ -13,15 +13,17 @@
 
 - name: extract result value for dmi.bios-vendor
   set_fact:
-    dmi_bios_vendor: "{{  internal_dmi_bios_vendor_cmd['stdout'] | trim if internal_have_dmidecode else '' }}"
+    dmi_bios_vendor: "{{ internal_dmi_bios_vendor_cmd['stdout_lines'][-1] | trim if internal_have_dmidecode else '' }}"
   ignore_errors: yes
-  when: '"stdout" in internal_dmi_bios_vendor_cmd'
+  when:
+    - '"stdout_lines" in internal_dmi_bios_vendor_cmd'
+    - 'internal_dmi_bios_vendor_cmd["stdout_lines"] | length > 0'
 
 - name: handle failure value for dmi.bios-vendor
   set_fact:
     dmi_bios_vendor: ""
   ignore_errors: yes
-  when: '"stdout" not in internal_dmi_bios_vendor_cmd'
+  when: '"stdout_lines" not in internal_dmi_bios_vendor_cmd'
 
 - name: gather dmi.bios-version fact
   raw: /usr/sbin/dmidecode -s bios-version 2>/dev/null
@@ -32,15 +34,17 @@
 
 - name: extract result value for dmi.bios-version
   set_fact:
-    dmi_bios_version: "{{  internal_dmi_bios_version_cmd['stdout'] | trim if internal_have_dmidecode else '' }}"
+    dmi_bios_version: "{{ internal_dmi_bios_version_cmd['stdout_lines'][-1] | trim if internal_have_dmidecode else '' }}"
   ignore_errors: yes
-  when: '"stdout" in internal_dmi_bios_version_cmd'
+  when:
+    - '"stdout_lines" in internal_dmi_bios_version_cmd'
+    - 'internal_dmi_bios_version_cmd["stdout_lines"] | length > 0'
 
 - name: handle failure value for dmi.bios-version
   set_fact:
     dmi_bios_version: ""
   ignore_errors: yes
-  when: '"stdout" not in internal_dmi_bios_version_cmd'
+  when: '"stdout_lines" not in internal_dmi_bios_version_cmd'
 
 - name: gather dmi.system-manufacturer fact
   raw: /usr/sbin/dmidecode 2>/dev/null | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
@@ -51,15 +55,17 @@
 
 - name: extract result value for dmi.system-manufacturer
   set_fact:
-    dmi_system_manufacturer: "{{  internal_dmi_system_manufacturer_cmd['stdout'] | trim if internal_have_dmidecode else '' }}"
+    dmi_system_manufacturer: "{{ internal_dmi_system_manufacturer_cmd['stdout_lines'][-1] | trim if internal_have_dmidecode else '' }}"
   ignore_errors: yes
-  when: '"stdout" in internal_dmi_system_manufacturer_cmd'
+  when:
+    - '"stdout_lines" in internal_dmi_system_manufacturer_cmd'
+    - 'internal_dmi_system_manufacturer_cmd["stdout_lines"] | length > 0'
 
 - name: handle failure value for dmi.system-manufacturer
   set_fact:
     dmi_system_manufacturer: ""
   ignore_errors: yes
-  when: '"stdout" not in internal_dmi_system_manufacturer_cmd'
+  when: '"stdout_lines" not in internal_dmi_system_manufacturer_cmd'
 
 - name: gather dmi.processor-family fact
   raw: /usr/sbin/dmidecode -s processor-family 2>/dev/null
@@ -70,15 +76,17 @@
 
 - name: extract result value for dmi.processor-family
   set_fact:
-    dmi_processor_family: "{{  internal_dmi_processor_family_cmd['stdout'] | trim if internal_have_dmidecode else '' }}"
+    dmi_processor_family: "{{ internal_dmi_processor_family_cmd['stdout_lines'][-1] | trim if internal_have_dmidecode else '' }}"
   ignore_errors: yes
-  when: '"stdout" in internal_dmi_processor_family_cmd'
+  when:
+    - '"stdout_lines" in internal_dmi_processor_family_cmd'
+    - 'internal_dmi_processor_family_cmd["stdout_lines"] | length > 0'
 
 - name: handle failure value for dmi.processor-family
   set_fact:
     dmi_processor_family: ""
   ignore_errors: yes
-  when: '"stdout" not in internal_dmi_processor_family_cmd'
+  when: '"stdout_lines" not in internal_dmi_processor_family_cmd'
 
 - name: gather dmi.system-uuid fact
   raw: /usr/sbin/dmidecode -s system-uuid 2>/dev/null

--- a/quipucords/scanner/network/runner/roles/etc_release/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/etc_release/tasks/main.yml
@@ -38,13 +38,13 @@
   ignore_errors: yes
 
 - name: set internal_release_file when a release file is found
-  set_fact: 
-    internal_release_file: '{{ internal_release_found["stdout_lines"][0] }}'
+  set_fact:
+    internal_release_file: '{{ internal_release_found["stdout_lines"][-1] }}'
   ignore_errors: yes
   when:
     - '"stdout_lines" in internal_release_found'
     - 'internal_release_found["stdout_lines"]|length > 0'
-    - 'internal_release_found["stdout_lines"][0]|length > 0'
+    - 'internal_release_found["stdout_lines"][-1]|length > 0'
 
 - name: set internal_release_file_content based on internal_release_file
   raw: cat {{ internal_release_file }}
@@ -59,8 +59,8 @@
 - name: set etc_release facts for Debian based on internal_release_file_content
   set_fact:
     etc_release_name: "Debian"
-    etc_release_version: "{{ internal_release_file_content['stdout_lines'][0] }}"
-    etc_release_release: "{{ 'Debian ' + internal_release_file_content['stdout_lines'][0] }}"
+    etc_release_version: "{{ internal_release_file_content['stdout_lines'][-1] }}"
+    etc_release_release: "{{ 'Debian ' + internal_release_file_content['stdout_lines'][-1] }}"
   ignore_errors: yes
   when:
     - internal_release_file is defined
@@ -72,16 +72,16 @@
 
 - name: set etc_release facts for typical distros based on internal_release_file_content
   set_fact:
-    etc_release_name: "{{ internal_release_file_content['stdout_lines'][0].split('release')[0].strip() }}"
-    etc_release_version: "{{ internal_release_file_content['stdout_lines'][0].split('release')[1].strip() }}"
-    etc_release_release: "{{ internal_release_file_content['stdout_lines'][0].strip() }}"
+    etc_release_name: "{{ internal_release_file_content['stdout_lines'][-1].split('release')[0].strip() }}"
+    etc_release_version: "{{ internal_release_file_content['stdout_lines'][-1].split('release')[1].strip() }}"
+    etc_release_release: "{{ internal_release_file_content['stdout_lines'][-1].strip() }}"
   ignore_errors: yes
   when:
     - internal_release_file is defined
     - 'internal_release_file in internal_distro_standard_release'
     - '"stdout_lines" in internal_release_file_content'
     - 'internal_release_file_content["stdout_lines"]|length > 0'
-    - '"release" in internal_release_file_content["stdout_lines"][0]'
+    - '"release" in internal_release_file_content["stdout_lines"][-1]'
 
 # set facts using Linux Standard Base when no other release file was found
 
@@ -103,9 +103,9 @@
 
 - name: set etc_release facts based on internal_lsb_release
   set_fact:
-    etc_release_name: '{{ internal_lsb_release["stdout_lines"][0] }}'
-    etc_release_version: '{{ internal_lsb_release["stdout_lines"][1] }}'
-    etc_release_release: '{{ internal_lsb_release["stdout_lines"][0] + " " + internal_lsb_release["stdout_lines"][1] }}'
+    etc_release_name: '{{ internal_lsb_release["stdout_lines"][-2] }}'
+    etc_release_version: '{{ internal_lsb_release["stdout_lines"][-1] }}'
+    etc_release_release: '{{ internal_lsb_release["stdout_lines"][-2] + " " + internal_lsb_release["stdout_lines"][-1] }}'
   ignore_errors: yes
   when:
     - internal_lsb_release is defined
@@ -122,9 +122,9 @@
 
 - name: set etc_release facts based on internal_uname_version
   set_fact:
-    etc_release_name: "{{ internal_uname_version['stdout_lines'][0].split(' ')[:-1]|join(' ') }}"
-    etc_release_version: "{{ internal_uname_version['stdout_lines'][0].split(' ')[-1] }}"
-    etc_release_release: "{{ internal_uname_version['stdout_lines'][0] }}"
+    etc_release_name: "{{ internal_uname_version['stdout_lines'][-1].split(' ')[:-1]|join(' ') }}"
+    etc_release_version: "{{ internal_uname_version['stdout_lines'][-1].split(' ')[-1] }}"
+    etc_release_release: "{{ internal_uname_version['stdout_lines'][-1] }}"
   ignore_errors: yes
   when:
     - internal_uname_version is defined
@@ -139,5 +139,5 @@
 
 - name: extract etc machine id from intern_get_etc_machine_id
   set_fact:
-    etc_machine_id: "{{ internal_get_etc_machine_id.get('stdout') | default('') }}"
+    etc_machine_id: "{{ internal_get_etc_machine_id | json_query('stdout_lines[-1]') }}"
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/memory/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/memory/tasks/main.yml
@@ -21,5 +21,5 @@
 
 - name: Convert memory to bytes
   set_fact:
-    system_memory_bytes: "{{ memory_in_kb.stdout | int * 1024 }}"
+    system_memory_bytes: "{{ memory_in_kb.stdout_lines[-1] | int * 1024 }}"
   when: memory_in_kb.rc == 0

--- a/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
@@ -16,7 +16,7 @@
 # it failed or never ran), then the result will be null.
 - name: set fact whether red hat rpms are installed or not
   set_fact:
-    redhat_packages_gpg_is_redhat: '{{ (internal_redhat_packages_gpg_is_redhat_cmd | json_query("stdout_lines[0]")) == "Y" }}'
+    redhat_packages_gpg_is_redhat: '{{ (internal_redhat_packages_gpg_is_redhat_cmd | json_query("stdout_lines[-1]")) == "Y" }}'
   ignore_errors: yes
 
 - name: gather the number of all installed red hat packages filtered by gpg keys
@@ -27,7 +27,7 @@
 
 - name: set fact of number of installed red hat packages filtered by gpg keys
   set_fact:
-    redhat_packages_gpg_num_rh_packages: '{{ internal_redhat_packages_gpg_num_rh_packages | json_query("stdout_lines[0]") }}'
+    redhat_packages_gpg_num_rh_packages: '{{ internal_redhat_packages_gpg_num_rh_packages | json_query("stdout_lines[-1]") }}'
   ignore_errors: yes
 
 - name: gather total number of installed packages
@@ -38,7 +38,7 @@
 
 - name: set fact of number of all installed rpm packages
   set_fact:
-    redhat_packages_gpg_num_installed_packages: '{{ internal_redhat_packages_all_count | json_query("stdout_lines[0]") }}'
+    redhat_packages_gpg_num_installed_packages: '{{ internal_redhat_packages_all_count | json_query("stdout_lines[-1]") }}'
   ignore_errors: yes
 
 - name: gather the last installed red hat package filtered by gpg keys
@@ -50,7 +50,7 @@
 
 - name: set fact of last installed rh package filtered by gpg key
   set_fact:
-    redhat_packages_gpg_last_installed: '{{ internal_redhat_packages_gpg_last_installed | json_query("stdout_lines[0]") }}'
+    redhat_packages_gpg_last_installed: '{{ internal_redhat_packages_gpg_last_installed | json_query("stdout_lines[-1]") }}'
   ignore_errors: yes
   when:
     internal_have_rpm and redhat_packages_gpg_is_redhat
@@ -64,7 +64,7 @@
 
 - name: set fact of last built rh package filtered by gpg key
   set_fact:
-    redhat_packages_gpg_last_built: '{{ internal_redhat_packages_gpg_last_built | json_query("stdout_lines[0]") }}'
+    redhat_packages_gpg_last_built: '{{ internal_redhat_packages_gpg_last_built | json_query("stdout_lines[-1]") }}'
   ignore_errors: yes
   when:
     internal_have_rpm and redhat_packages_gpg_is_redhat

--- a/quipucords/scanner/network/runner/roles/redhat_release/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/redhat_release/tasks/main.yml
@@ -19,10 +19,10 @@
 
 - name: set redhat_release facts based on internal_redhat_release
   set_fact:
-    redhat_release_name: "{{ internal_redhat_release['stdout_lines'][0] }}"
-    redhat_release_version: "{{ internal_redhat_release['stdout_lines'][1] }}"
-    redhat_release_release: "{{ internal_redhat_release['stdout_lines'][2] }}"
+    redhat_release_name: "{{ internal_redhat_release['stdout_lines'][-3] }}"
+    redhat_release_version: "{{ internal_redhat_release['stdout_lines'][-2] }}"
+    redhat_release_release: "{{ internal_redhat_release['stdout_lines'][-1] }}"
   ignore_errors: yes
   when:
     - "'stdout_lines' in internal_redhat_release"
-    - "internal_redhat_release['stdout_lines']|length == 3"
+    - "internal_redhat_release['stdout_lines']|length >= 3"

--- a/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
@@ -14,9 +14,11 @@
 
 - name: extract result value for subman.cpu.cpu(s)
   set_fact:
-    subman_cpu_cpu: "{{ internal_subman_cpu_cpu_cmd['stdout'] | trim | default(None) }}"
+    subman_cpu_cpu: "{{ internal_subman_cpu_cpu_cmd['stdout_lines'][-1] | trim | default(None) }}"
   ignore_errors: yes
-  when: '"stdout" in internal_subman_cpu_cpu_cmd'
+  when:
+    - '"stdout_lines" in internal_subman_cpu_cpu_cmd'
+    - 'internal_subman_cpu_cpu_cmd["stdout_lines"] | length > 0'
 
 # subman_cpu_core_per_socket fact
 - name: gather subman.cpu.core(s)_per_socket fact
@@ -28,9 +30,11 @@
 
 - name: extract result value for subman.cpu.core(s)_per_socket
   set_fact:
-    subman_cpu_core_per_socket: "{{  internal_subman_cpu_core_per_socket_cmd['stdout'] | trim | default(None) }}"
+    subman_cpu_core_per_socket: "{{  internal_subman_cpu_core_per_socket_cmd['stdout_lines'][-1] | trim | default(None) }}"
   ignore_errors: yes
-  when: '"stdout" in internal_subman_cpu_core_per_socket_cmd'
+  when:
+    - '"stdout_lines" in internal_subman_cpu_core_per_socket_cmd'
+    - 'internal_subman_cpu_core_per_socket_cmd["stdout_lines"] | length > 0'
 
 # subman_cpu_cpu_socket fact
 - name: gather subman.cpu.cpu_socket(s) fact
@@ -42,9 +46,11 @@
 
 - name: extract result value for subman.cpu.cpu_socket(s)
   set_fact:
-    subman_cpu_cpu_socket: "{{  internal_subman_cpu_cpu_socket_cmd['stdout'] | trim | default(None) }}"
+    subman_cpu_cpu_socket: "{{  internal_subman_cpu_cpu_socket_cmd['stdout_lines'][-1] | trim | default(None) }}"
   ignore_errors: yes
-  when: '"stdout" in internal_subman_cpu_cpu_socket_cmd'
+  when:
+    - '"stdout_lines" in internal_subman_cpu_cpu_socket_cmd'
+    - 'internal_subman_cpu_cpu_socket_cmd["stdout_lines"] | length > 0'
 
 # subman_virt_host_type fact
 - name: gather subman.virt.host_type fact
@@ -56,8 +62,10 @@
 
 - name: extract result value for subman.virt.host_type
   set_fact:
-    subman_virt_host_type: "{{  internal_subman_virt_host_type_cmd['stdout'] | trim | default(None) }}"
-  when: '"stdout" in internal_subman_virt_host_type_cmd'
+    subman_virt_host_type: "{{  internal_subman_virt_host_type_cmd['stdout_lines'][-1] | trim | default(None) }}"
+  when:
+    - '"stdout_lines" in internal_subman_virt_host_type_cmd'
+    - 'internal_subman_virt_host_type_cmd["stdout_lines"] | length > 0'
 
 # subman_virt_is_guest fact
 - name: gather subman.virt.is_guest fact
@@ -69,9 +77,12 @@
 
 - name: extract result value for subman.virt.is_guest
   set_fact:
-    subman_virt_is_guest: "{{  internal_subman_virt_is_guest_cmd['stdout'] | string() | trim | default(None) }}"
+    subman_virt_is_guest: "{{  internal_subman_virt_is_guest_cmd['stdout_lines'][-1] | string() | trim | default(None) }}"
   ignore_errors: yes
-  when: '"stdout" in internal_subman_virt_is_guest_cmd'
+  when:
+    - '"stdout_lines" in internal_subman_virt_is_guest_cmd'
+    - 'internal_subman_virt_is_guest_cmd["stdout_lines"] | length > 0'
+
 
 # subman_virt_uuid fact
 - name: gather subman.virt.uuid fact
@@ -83,9 +94,11 @@
 
 - name: extract result value for subman.virt.uuid
   set_fact:
-    subman_virt_uuid: "{{  internal_subman_virt_uuid_cmd['stdout'] | trim | default(None) }}"
+    subman_virt_uuid: "{{  internal_subman_virt_uuid_cmd['stdout_lines'][-1] | trim | default(None) }}"
   ignore_errors: yes
-  when: '"stdout" in internal_subman_virt_uuid_cmd'
+  when:
+    - '"stdout_lines" in internal_subman_virt_uuid_cmd'
+    - 'internal_subman_virt_uuid_cmd["stdout_lines"] | length > 0'
 
 # subman_overall_status fact
 - name: gather subman.overall.status fact
@@ -99,9 +112,11 @@
 
 - name: extract result value for subman.overall.status
   set_fact:
-    subman_overall_status: "{{ internal_subman_overall_status_cmd['stdout'] | string() | trim | default(None) }}"
+    subman_overall_status: "{{ internal_subman_overall_status_cmd['stdout_lines'][-1] | string() | trim | default(None) }}"
   ignore_errors: yes
-  when: '"stdout" in internal_subman_overall_status_cmd'
+  when:
+    - '"stdout_lines" in internal_subman_overall_status_cmd'
+    - 'internal_subman_overall_status_cmd["stdout_lines"] | length > 0'
 
 # subman fact
 - name: gather subman.has_facts_file fact
@@ -112,11 +127,14 @@
 
 - name: add subman.has_facts_file to dictionary
   set_fact:
-    subman: "{{ subman|default({}) | combine({ item: (internal_subman_facts_file_lines['stdout'] | int) > 0 }) }}"
+    subman: "{{ subman|default({}) | combine({ item: (internal_subman_facts_file_lines['stdout_lines'][-1] | int) > 0 }) }}"
   with_items:
   - 'subman.has_facts_file'
   ignore_errors: yes
-  when: 'internal_have_subscription_manager and "stdout" in internal_subman_facts_file_lines'
+  when:
+    - 'internal_have_subscription_manager'
+    - '"stdout_lines" in internal_subman_facts_file_lines'
+    - 'internal_subman_facts_file_lines["stdout_lines"] | length > 0'
 
 # subman_consumed fact
 - name: gather internal_subman_consumed
@@ -144,6 +162,8 @@
 
 - name: extract result value for subscription_manager_id
   set_fact:
-    subscription_manager_id: "{{ internal_subscription_manager_id_cmd['stdout'] | trim | default(None) }}"
+    subscription_manager_id: "{{ internal_subscription_manager_id_cmd['stdout_lines'][-1] | trim | default(None) }}"
   ignore_errors: yes
-  when: '"stdout" in internal_subscription_manager_id_cmd'
+  when:
+    - '"stdout_lines" in internal_subscription_manager_id_cmd'
+    - 'internal_subscription_manager_id_cmd["stdout_lines"] | length > 0'

--- a/quipucords/scanner/network/runner/roles/uname/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/uname/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: add uname.os to dictionary
   set_fact:
-    uname_os: "{{ internal_uname_os | json_query('stdout_lines[0]') | default('') }}"
+    uname_os: "{{ internal_uname_os | json_query('stdout_lines[-1]') | default('') }}"
   ignore_errors: yes
 
 - name: gather internal_uname_hostname fact
@@ -21,7 +21,7 @@
 
 - name: add uname.hostname to dictionary
   set_fact:
-    uname_hostname: "{{ internal_uname_hostname | json_query('stdout_lines[0]') | default('') }}"
+    uname_hostname: "{{ internal_uname_hostname | json_query('stdout_lines[-1]') | default('') }}"
   ignore_errors: yes
 
 - name: gather internal_uname_processor fact
@@ -31,7 +31,7 @@
 
 - name: add uname_processor to dictionary
   set_fact:
-    uname_processor: "{{ internal_uname_processor | json_query('stdout_lines[0]') | default('') }}"
+    uname_processor: "{{ internal_uname_processor | json_query('stdout_lines[-1]') | default('') }}"
   ignore_errors: yes
 
 - name: gather internal_uname_kernel fact
@@ -41,7 +41,7 @@
 
 - name: add uname.kernel to dictionary
   set_fact:
-    uname_kernel: "{{ internal_uname_kernel | json_query('stdout_lines[0]') | default('') }}"
+    uname_kernel: "{{ internal_uname_kernel | json_query('stdout_lines[-1]') | default('') }}"
   ignore_errors: yes
 
 - name: gather internal_uname_all fact
@@ -51,7 +51,7 @@
 
 - name: add uname.all to dictionary
   set_fact:
-    uname_all: "{{ internal_uname_all | json_query('stdout_lines[0]') | default('') }}"
+    uname_all: "{{ internal_uname_all | json_query('stdout_lines[-1]') | default('') }}"
   ignore_errors: yes
 
 - name: gather internal_uname_hardware_platform fact
@@ -61,5 +61,5 @@
 
 - name: add uname.hardware_platform to dictionary
   set_fact:
-    uname_hardware_platform: "{{ internal_uname_hardware_platform | json_query('stdout_lines[0]') | default('') }}"
+    uname_hardware_platform: "{{ internal_uname_hardware_platform | json_query('stdout_lines[-1]') | default('') }}"
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
@@ -78,8 +78,8 @@
   ignore_errors: yes
 
 - name: extract output virt.num_guests fact
-  set_fact: 
-    virt_num_guests: "{{ (virt_num_guests | json_query('stdout_lines[0]')) if internal_have_virsh else None }}"
+  set_fact:
+    virt_num_guests: "{{ virt_num_guests['stdout_lines'][-1] if internal_have_virsh else None }}"
   ignore_errors: yes
 
 - name: gather virt.num_running_guests fact
@@ -89,6 +89,6 @@
   when: 'internal_have_virsh'
 
 - name: extract output virt.num_running_guests fact
-  set_fact: 
-    virt_num_running_guests: "{{ (internal_virt_num_running_guests | json_query('stdout_lines[0]')) if internal_have_virsh else None }}"
+  set_fact:
+    virt_num_running_guests: "{{ internal_virt_num_running_guests['stdout_lines'][-1] if internal_have_virsh else None }}"
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/virt_what/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/virt_what/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "virt_what"
 
 - name: set virt-what.type fact if virt-what not found
-  set_fact: 
+  set_fact:
     virt_what_type: ""
   ignore_errors: yes
   when: 'not internal_have_virt_what'

--- a/quipucords/tests/scanner/network/processing/test_cloud_provider.py
+++ b/quipucords/tests/scanner/network/processing/test_cloud_provider.py
@@ -50,13 +50,19 @@ class TestProcessDmiSystemProductName(unittest.TestCase):
     """Test ProcessDmiSystemProductName."""
 
     def test_success_case(self):
-        """Found dmi system product name."""
+        """
+        Found dmi system product name.
+
+        Please note that the way we handle multiple results may be unintuitive. If
+        Ansible's output includes multiple lines which may mean multiple products,
+        we always return only one of them: the content from the last line.
+        """
         dependencies = {"internal_dmi_system_product_name": ansible_result("a\nb\nc")}
         self.assertEqual(
             cloud_provider.ProcessDmiSystemProductName.process(
                 "QPC_FORCE_POST_PROCESS", dependencies
             ),
-            "a",
+            "c",
         )
         # stdout_lines looks like ['', 'b']
         dependencies["internal_dmi_system_product_name"] = ansible_result("\nb\n")

--- a/quipucords/tests/scanner/network/processing/test_cpu.py
+++ b/quipucords/tests/scanner/network/processing/test_cpu.py
@@ -12,7 +12,7 @@ class TestProcessCpuModelVer(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu model ver."""
-        self.assertEqual(cpu.ProcessCpuModelVer.process(ansible_result("a\nb\nc")), "a")
+        self.assertEqual(cpu.ProcessCpuModelVer.process(ansible_result("a\nb\nc")), "c")
 
     def test_not_found(self):
         """Did not find cpu model ver."""
@@ -27,7 +27,7 @@ class TestProcessCpuCpuFamily(unittest.TestCase):
     def test_success_case(self):
         """Found cpu family."""
         self.assertEqual(
-            cpu.ProcessCpuCpuFamily.process(ansible_result("a\nb\nc")), "a"
+            cpu.ProcessCpuCpuFamily.process(ansible_result("a\nb\nc")), "c"
         )
 
     def test__not_found(self):
@@ -42,7 +42,7 @@ class TestProcessCpuVendorId(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu vendor id."""
-        self.assertEqual(cpu.ProcessCpuVendorId.process(ansible_result("a\nb\nc")), "a")
+        self.assertEqual(cpu.ProcessCpuVendorId.process(ansible_result("a\nb\nc")), "c")
 
     def test__not_found(self):
         """Did not find cpu vendor id."""
@@ -57,7 +57,7 @@ class TestProcessCpuModelName(unittest.TestCase):
     def test_success_case(self):
         """Found cpu model name."""
         self.assertEqual(
-            cpu.ProcessCpuModelName.process(ansible_result("a\nb\nc")), "a"
+            cpu.ProcessCpuModelName.process(ansible_result("a\nb\nc")), "c"
         )
 
     def test__not_found(self):
@@ -72,7 +72,7 @@ class TestProcessCpuBogomips(unittest.TestCase):
 
     def test_success_case(self):
         """Found cpu bogomips."""
-        self.assertEqual(cpu.ProcessCpuBogomips.process(ansible_result("a\nb\nc")), "a")
+        self.assertEqual(cpu.ProcessCpuBogomips.process(ansible_result("a\nb\nc")), "c")
 
     def test__not_found(self):
         """Did not find cpu bogomips."""

--- a/quipucords/tests/scanner/network/processing/test_date.py
+++ b/quipucords/tests/scanner/network/processing/test_date.py
@@ -12,7 +12,7 @@ class TestProcessDateDate(unittest.TestCase):
 
     def test_success_case(self):
         """Found date."""
-        self.assertEqual(date.ProcessDateDate.process(ansible_result("a\nb\nc")), "a")
+        self.assertEqual(date.ProcessDateDate.process(ansible_result("a\nb\nc")), "c")
 
     def test_not_found(self):
         """Did not find date."""
@@ -27,7 +27,7 @@ class ProcessDateFilesystemCreate(unittest.TestCase):
     def test_success_case(self):
         """Found date file system create."""
         self.assertEqual(
-            date.ProcessDateFilesystemCreate.process(ansible_result("a\nb\nc")), "a"
+            date.ProcessDateFilesystemCreate.process(ansible_result("a\nb\nc")), "c"
         )
 
     def test_not_found(self):
@@ -44,7 +44,7 @@ class ProcessDateMachineId(unittest.TestCase):
     def test_success_case(self):
         """Found date machine id."""
         self.assertEqual(
-            date.ProcessDateMachineId.process(ansible_result("a\nb\nc")), "a"
+            date.ProcessDateMachineId.process(ansible_result("a\nb\nc")), "c"
         )
 
     def test_not_found(self):

--- a/quipucords/tests/scanner/network/processing/test_dmi.py
+++ b/quipucords/tests/scanner/network/processing/test_dmi.py
@@ -11,12 +11,18 @@ class TestProcessDmiSystemUuidr(unittest.TestCase):
     """Test ProcessDmiSystemUuid."""
 
     def test_success_case(self):
-        """Test multiple dmi_system_uuid values."""
+        """
+        Test multiple dmi_system_uuid values.
+
+        Please note that the way we handle multiple results may be unintuitive. If
+        Ansible's output includes multiple lines which may mean multiple UUIDs,
+        we always return only one of them: the content from the last line.
+        """
         # stdout_lines looks like ['a', 'b', 'c']
         dependencies = {"internal_dmi_system_uuid": ansible_result("a\nb\nc")}
         self.assertEqual(
             dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies),
-            "a",
+            "c",
         )
         # stdout_lines looks like ['', 'b']
         dependencies["internal_dmi_system_uuid"] = ansible_result("\nb\n")
@@ -31,12 +37,13 @@ class TestProcessDmiSystemUuidr(unittest.TestCase):
 
     def test_invalid_uuid_case(self):
         """Test dmi_system_uuid too long."""
-        # stdout_lines looks like ['a', 'b', 'c']
-        dependencies = {"internal_dmi_system_uuid": ansible_result(f"{'a' * 37}\nb\nc")}
+        # stdout_lines looks like ['a', 'b', 'ccccccccccccccccccccccccccccccccccccc']
+        dependencies = {"internal_dmi_system_uuid": ansible_result(f"a\nb\n{'c' * 37}")}
         self.assertEqual(
-            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies), ""
+            dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies),
+            "b",
         )
-        # stdout_lines looks like ['', 'b']
+        # stdout_lines looks like ['', 'b', '']
         dependencies["internal_dmi_system_uuid"] = ansible_result(f"\n{'b' * 37}\n")
         self.assertEqual(
             dmi.ProcessDmiSystemUuid.process("QPC_FORCE_POST_PROCESS", dependencies), ""

--- a/quipucords/tests/scanner/network/processing/test_system_purpose.py
+++ b/quipucords/tests/scanner/network/processing/test_system_purpose.py
@@ -56,3 +56,32 @@ class TestProcessSystemPurpose(unittest.TestCase):
             system_purpose.ProcessSystemPurpose.process(ansible_result(input_data)),
             expected,
         )
+
+    def test_unexpected_stout_lines_before_actual_json(self):
+        """Test handling unexpected lines in stdout before the actual JSON."""
+        input_data = """
+            Nobody expects the Spanish Inquisition.
+            Have at thee!
+            {
+                "_version": "1",
+                "role": "server",
+                "addons": [
+                    "ibm"
+                ],
+                "service_level_agreement": "self-support",
+                "usage_type": "dev"
+            }
+            """
+
+        expected = {
+            "_version": "1",
+            "role": "server",
+            "addons": ["ibm"],
+            "service_level_agreement": "self-support",
+            "usage_type": "dev",
+        }
+
+        self.assertEqual(
+            system_purpose.ProcessSystemPurpose.process(ansible_result(input_data)),
+            expected,
+        )


### PR DESCRIPTION
This changes some processing to read the last line of stdout instead of the first or to process stdout lines in reverse order. This should avoid some problems where a badly configured target system emits unexpected lines to stdout upon establishing the ssh connection.

Relates to JIRA: DISCOVERY-407
https://issues.redhat.com/browse/DISCOVERY-407