### PR TITLE
chore: bump to version 1.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quipucords"
-version = "1.3.3"
+version = "1.3.4"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 authors = ["Quipucords Dev Team <quipucords@redhat.com>"]
 readme = "README.md"


### PR DESCRIPTION
Picking the recent change from `release/1.3` to `main`:

```
git checkout main
git pull
git checkout -b cherry-pick-1.3-to-main
git cherry-pick aeae70f8
```

It looks like aeae70f8 is the only recent change that exists exclusively in the `release/1.3` branch. Everything else has been ported to or from `main`.