### PR TITLE
test: randomize db sequences

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,18 @@ from urllib.parse import urljoin
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core import management
 from django.test import override_settings
+
+
+@pytest.fixture(scope="session")
+def django_db_setup(django_db_setup, django_db_blocker):
+    """Force db sequences to use random numbers."""
+    with django_db_blocker.unblock():
+        # randomize db sequences to avoid ID coincidences causing
+        # false positive tests, avoid hardcoded IDs, and attempt
+        # to simulate a real world-like scenario.
+        management.call_command("randomize_db_sequences")
 
 
 @pytest.fixture(autouse=True)

--- a/quipucords/api/management/commands/randomize_db_sequences.py
+++ b/quipucords/api/management/commands/randomize_db_sequences.py
@@ -1,0 +1,50 @@
+"""Randomize database sequences."""
+
+import random
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    """Django management command for randomizing db sequences."""
+
+    help = "Randomize database sequences"
+
+    def handle(self, *args, **options):
+        """Execute the logic for this command."""
+        # shamelessly inspired on https://pytest-django.readthedocs.io/en/latest/database.html#randomize-database-sequences
+        query_map = {
+            "sqlite": (
+                "UPDATE sqlite_sequence SET seq = {random_id} "
+                "WHERE name = '{table_name}';"
+            ),
+            "postgresql": (
+                "ALTER SEQUENCE {table_name}_id_seq RESTART WITH {random_id};"
+            ),
+        }
+        query = query_map[connection.vendor]
+
+        with connection.cursor() as cursor:
+            for model_name in apps.all_models["api"]:
+                model = apps.get_model("api", model_name)
+                random_id = self._get_random_id(model)
+                table_name = model._meta.db_table
+                cursor.execute(query.format(random_id=random_id, table_name=table_name))
+
+    def _get_random_id(self, model):
+        """
+        Get a random id for a given model.
+
+        The random id is guaranteed to be > than MAX(model.id)
+        """
+        max_id = self._get_max_id(model)
+        random_id = random.randint(10000, 20000)
+        return random_id + max_id
+
+    def _get_max_id(self, model):
+        value_dict = model.objects.order_by("-id").values("id").first()
+        if value_dict:
+            return value_dict["id"]
+        return 0


### PR DESCRIPTION
Randomizing database sequences to:
1. Force tests to not hardcode ids
2. Avoid false positive tests passing only because models had coinciding ids
3. Attempt to simulate a more real world like scenario

In the future this fixture could be an util used to highlight and help debugging the UI issues with incorrect ids being used.