### PR TITLE
DISCOVERY-435: Authorize GitHub requests if token is available

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 .dockerignore
 .egg
 .github
+.github_api_token
 .gitignore
 .pytest_cache
 .tool-versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi9-minimal
+FROM docker.io/redhat/ubi9-minimal
 
 ENV DJANGO_DB_PATH=/var/data/
 ENV DJANGO_DEBUG=False

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN dnf remove ${BUILD_PACKAGES} -y && \
 # Fetch UI code
 COPY Makefile .
 ARG UI_RELEASE="latest"
-RUN make fetch-ui -e QUIPUCORDS_UI_RELEASE=${UI_RELEASE}
+RUN --mount=type=secret,id=gh_api_token make fetch-ui -e QUIPUCORDS_UI_RELEASE=${UI_RELEASE}
 
 # Create /etc/ssl/qpc
 COPY deploy/ssl /etc/ssl/qpc

--- a/Dockerfile.scan-target
+++ b/Dockerfile.scan-target
@@ -1,4 +1,4 @@
-FROM redhat/ubi9-init
+FROM docker.io/redhat/ubi9-init
 
 RUN dnf -y install openssh-server openssl sudo; \
     dnf clean all

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,22 @@ DIRS	= test bin locale src
 PYDIRS	= quipucords
 PIP_COMPILE_ARGS = --no-upgrade
 BINDIR  = bin
-PARALLEL_NUM ?= $(shell python -c 'import multiprocessing as m;print(int(max(m.cpu_count()/2, 2)))')
+PARALLEL_NUM ?= $(shell $(PYTHON) -c 'import multiprocessing as m;print(int(max(m.cpu_count()/2, 2)))')
 TEST_OPTS := -n $(PARALLEL_NUM) -ra -m 'not slow' --timeout=15
 
 QUIPUCORDS_CONTAINER_TAG ?= quipucords
 QUIPUCORDS_UI_PATH ?= ../quipucords-ui
 QUIPUCORDS_UI_RELEASE ?= latest
+
+ifndef DOCKER_HOST
+	PODMAN_SOCKET := $(shell podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}' 2> /dev/null || podman info --format '{{.Host.RemoteSocket.Path}}' 2> /dev/null || echo -n "")
+
+	ifneq ($(PODMAN_SOCKET),)
+		ifneq ($(wildcard $(PODMAN_SOCKET)),)
+			export DOCKER_HOST := unix://$(PODMAN_SOCKET)
+		endif
+	endif
+endif
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"

--- a/quipucords/tests/integration/conftest.py
+++ b/quipucords/tests/integration/conftest.py
@@ -36,7 +36,7 @@ postgres_container = container(
         "POSTGRES_PASSWORD": constants.POSTGRES_PASSWORD,
         "POSTGRES_DB": constants.POSTGRES_DB,
     },
-    image="postgres:12",
+    image="docker.io/library/postgres:12",
     restart_policy={"Name": "on-failure"},
     scope="class",
     timeout=constants.READINESS_TIMEOUT_SECONDS,


### PR DESCRIPTION
Context: On internal Jenkins, `make build-container` may fail because GitHub rate-limits API requests, and a lot of internal traffic appears as a single IP to GitHub.

With this change, we can use GitHub token to authenticate API request during `make build-container`. Jenkins pipeline will use that capability, but it remains optional for everyone else.

The easy way would be to pass environment variable using `podman --env`, but then token will be embedded in final image layer. The correct way is to use docker / podman `--secret` flag. Unfortunately, this flag requires file with secret to exist when running `podman build`, so I have to add new empty file to repo.

Since secrets are not part of built layer, changing secrets file content will not invalidate cached layers. So if you run `make build-container`, change content of `.github_api_token` and run `make build-container` again, you will end up with exactly the same image. You can modify Makefile to run `podman build --no-cache`, or clear locally cached layers through other means.

I have not tested this with real Docker, but `podman` claims compatibility with Docker in this use case. Docker supports some other options that podman does not.