### PR TITLE
feat: randomize sequences after migrating database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ server-makemigrations:
 server-migrate:
 	$(PYTHON) quipucords/manage.py migrate --settings quipucords.settings -v 3
 
+server-randomize-sequences:
+	$(PYTHON) quipucords/manage.py randomize_db_sequences --settings quipucords.settings
+
 celery-worker:
 	$(PYTHON) -m celery --app quipucords --workdir quipucords worker
 


### PR DESCRIPTION
Thanks to @bruno-fs for making this possible with quipucords/pull/2481! 🎉 

I want this in the make target so I don't need an extra step for it in my sandbox DB rebuild routine…

```
dropdb -U qpc qpc \
&& createdb -U qpc qpc \
&& poetry install \
&& make server-migrate \
&& poetry run python ./quipucords/manage.py randomize_db_sequences \
&& make server-set-superuser serve
```

Since the makefile is chiefly for us developers/maintainers anyway, I think we should *always* be running the sequence randomizer to ensure we don't miss any unfortunate ID collisions. (I'm looking at you, report IDs…)

Now my local command is simply:

```
dropdb -U qpc qpc \
&& createdb -U qpc qpc \
&& poetry install \
&& make server-migrate server-randomize-sequences server-set-superuser serve
```