### PR TITLE
chore: yet another details report renaming PR

### DIFF
--- a/quipucords/api/deployments_report/serializer.py
+++ b/quipucords/api/deployments_report/serializer.py
@@ -10,15 +10,12 @@ from rest_framework.serializers import (
     JSONField,
     ModelSerializer,
     PrimaryKeyRelatedField,
-    UUIDField,
 )
 
 from api.common.serializer import NotEmptySerializer
 from api.models import (
-    DeploymentsReport,
     Entitlement,
     Product,
-    Report,
     SystemFingerprint,
 )
 
@@ -148,25 +145,3 @@ class FingerprintField(PrimaryKeyRelatedField):
         """Create output representation."""
         serializer = SystemFingerprintSerializer(value)
         return serializer.data
-
-
-class DeploymentReportSerializer(NotEmptySerializer):
-    """Serializer for the Fingerprint model."""
-
-    # Scan information
-    report_type = CharField(read_only=True)
-    report_version = CharField(max_length=64, read_only=True)
-    report_platform_id = UUIDField(format="hex_verbose", read_only=True)
-    details_report = PrimaryKeyRelatedField(queryset=Report.objects.all())
-    report_id = IntegerField(read_only=True, source="report.id")
-    cached_fingerprints = JSONField(read_only=True)
-    cached_csv = CharField(read_only=True)
-
-    status = ChoiceField(read_only=True, choices=DeploymentsReport.STATUS_CHOICES)
-    system_fingerprints = FingerprintField(many=True, read_only=True)
-
-    class Meta:
-        """Meta class for DeploymentReportSerializer."""
-
-        model = DeploymentsReport
-        fields = "__all__"

--- a/quipucords/api/details_report/view.py
+++ b/quipucords/api/details_report/view.py
@@ -22,7 +22,7 @@ from api.common.common_report import create_report_version
 from api.common.report_json_gzip_renderer import ReportJsonGzipRenderer
 from api.common.util import is_int
 from api.details_report.csv_renderer import DetailsCSVRenderer
-from api.details_report.util import create_details_report, validate_details_report_json
+from api.details_report.util import create_report, validate_details_report_json
 from api.models import Report, ScanJob, ScanTask
 from api.serializers import DetailsReportSerializer
 from api.user.authentication import QuipucordsExpiringTokenAuthentication
@@ -84,7 +84,7 @@ class DetailsReportsViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
             report_version = create_report_version()
 
         # Create FC model and save data
-        report = create_details_report(create_report_version(), request.data)
+        report = create_report(create_report_version(), request.data)
         scan_job = ScanJob.objects.create(
             scan_type=ScanTask.SCAN_TYPE_FINGERPRINT, report=report
         )

--- a/quipucords/api/reports/view.py
+++ b/quipucords/api/reports/view.py
@@ -35,10 +35,10 @@ def reports(request, report_id):
     """Lookup and return reports."""
     reports_dict = {}
     reports_dict["report_id"] = report_id
-    details_report = get_object_or_404(Report, id=report_id)
+    report = get_object_or_404(Report, id=report_id)
     # add scan job id to allow detection of related logs on GzipRenderer
-    reports_dict["scan_job_id"] = details_report.scanjob.id
-    serializer = DetailsReportSerializer(details_report)
+    reports_dict["scan_job_id"] = report.scanjob.id
+    serializer = DetailsReportSerializer(report)
     json_details = serializer.data
     json_details.pop("cached_csv", None)
     reports_dict["details_json"] = json_details

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -398,7 +398,7 @@ class ScanTask(models.Model):
         using a ScanTask object so others can retrieve them if needed.
 
         :returns: Scan result object for task (either TaskConnectionResult,
-            TaskInspectionResult, or DetailsReport)
+            TaskInspectionResult, or Report)
         """
         if self.scan_type == ScanTask.SCAN_TYPE_INSPECT:
             return self.inspection_result

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -9,7 +9,6 @@ from api.connresult.serializer import (
 )
 from api.credential.serializer import CredentialSerializer
 from api.deployments_report.serializer import (
-    DeploymentReportSerializer,
     SystemFingerprintSerializer,
 )
 from api.details_report.serializer import DetailsReportSerializer

--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -138,20 +138,18 @@ class FingerprintTaskRunner(ScanTaskRunner):
             )
             raise error
 
-    def _process_details_report(  # noqa: PLR0915
-        self, manager_interrupt, details_report
-    ):
+    def _process_details_report(self, manager_interrupt, report):  # noqa: PLR0915
         """Process the details report.
 
         :param manager_interrupt: Signal to indicate job is canceled
-        :param details_report: DetailsReport that was saved
+        :param report: Report that was saved
         :param scan_task: Task that is running this merge
         :returns: Status message and status
         """
         self.scan_task.log_message("START DEDUPLICATION")
 
         # Invoke ENGINE to create fingerprints from facts
-        fingerprints_list = self._process_sources(details_report)
+        fingerprints_list = self._process_sources(report)
 
         self.scan_task.log_message("END DEDUPLICATION")
 
@@ -160,7 +158,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
         self.scan_task.log_message("START FINGERPRINT PERSISTENCE")
         status_count = 0
         total_count = len(fingerprints_list)
-        deployment_report = details_report.deployment_report
+        deployment_report = report.deployment_report
         date_field = DateField()
         final_fingerprint_list = []
 
@@ -221,7 +219,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
                     log_level=logging.ERROR,
                 )
             self.scan_task.log_message(
-                f"Fingerprints (report id={details_report.id}): {fingerprint_dict}",
+                f"Fingerprints (report id={report.id}): {fingerprint_dict}",
                 log_level=logging.DEBUG,
             )
 
@@ -281,15 +279,15 @@ class FingerprintTaskRunner(ScanTaskRunner):
             log_level=log_level,
         )
 
-    def _process_sources(self, details_report):
+    def _process_sources(self, report):
         """Process facts and convert to fingerprints.
 
-        :param details_report: DetailsReport containing raw facts
+        :param details_report: Report containing raw facts
         :returns: list of fingerprints for all systems (all scans)
         """
         # fingerprints per source type
         fingerprint_map = {datasource: [] for datasource in DataSources.values}
-        source_list = details_report.sources
+        source_list = report.sources
         total_source_count = len(source_list)
         self.scan_task.log_message(f"{total_source_count} sources to process")
         source_count = 0

--- a/quipucords/scanner/tasks.py
+++ b/quipucords/scanner/tasks.py
@@ -7,7 +7,7 @@ from api.scanjob.model import ScanJob
 from api.scantask.model import ScanTask
 from fingerprinter.runner import FingerprintTaskRunner
 from scanner.get_scanner import get_scanner
-from scanner.job import create_details_report_for_scan_job, run_task_runner
+from scanner.job import create_report_for_scan_job, run_task_runner
 from scanner.runner import ScanTaskRunner
 
 logger = logging.getLogger(__name__)
@@ -60,7 +60,7 @@ def fingerprint(scan_task_id: int) -> tuple[bool, int, str]:
 
 
 def _fingerprint(scan_task_id: int) -> tuple[bool, int, str]:
-    """Create and assign the DetailsReport, and update the related ScanJob status.
+    """Create and assign the Report, and update the related ScanJob status.
 
     This task should run once after all inspection tasks have collected and stored
     Facts for all Sources associated with the given ScanTask's ScanJob. This logic
@@ -73,7 +73,7 @@ def _fingerprint(scan_task_id: int) -> tuple[bool, int, str]:
     scan_job = scan_task.job
 
     if not (report := scan_job.report):
-        report, error_message = create_details_report_for_scan_job(scan_job)
+        report, error_message = create_report_for_scan_job(scan_job)
         if not report:
             scan_job.status_fail(error_message)
             return False, scan_task_id, ScanTask.FAILED

--- a/quipucords/tests/api/deployments_report/test_deployments_report.py
+++ b/quipucords/tests/api/deployments_report/test_deployments_report.py
@@ -73,7 +73,7 @@ class DeploymentReportTest(LoggedUserMixin, TestCase):
         return response.json()
 
     def generate_fingerprints(self, os_name="RHEL", os_versions=None):
-        """Create a DetailsReport for test."""
+        """Create a Report and DeploymentsReport for test."""
         facts = []
         fc_json = {
             "report_type": "details",
@@ -116,8 +116,8 @@ class DeploymentReportTest(LoggedUserMixin, TestCase):
                 "virt_what_type": "vt",
             }
             facts.append(fact_json)
-        details_report = self.create_details_report_expect_201(fc_json)
-        return details_report
+        report = self.create_details_report_expect_201(fc_json)
+        return report
 
     def test_get_details_report_group_report(self):
         """Get a specific group count report."""
@@ -148,7 +148,7 @@ class DeploymentReportTest(LoggedUserMixin, TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_bad_deployment_report(self):
-        """Test case where DetailsReport exists but no fingerprint."""
+        """Test case where Report exists but no fingerprint."""
         url = "/api/v1/reports/1/deployments/"
 
         # Create a system fingerprint via collection receiver

--- a/quipucords/tests/api/details_report/test_details_report.py
+++ b/quipucords/tests/api/details_report/test_details_report.py
@@ -175,9 +175,9 @@ class DetailReportTest(LoggedUserMixin, TestCase):
         self.assertEqual(csv_result, expected)
 
         # Clear cache
-        details_report = Report.objects.get(id=response_json["report_id"])
-        details_report.cached_csv = None
-        details_report.save()
+        report = Report.objects.get(id=response_json["report_id"])
+        report.cached_csv = None
+        report.save()
 
         # Remove sources
         test_json = copy.deepcopy(response_json)
@@ -193,9 +193,9 @@ class DetailReportTest(LoggedUserMixin, TestCase):
         self.assertEqual(csv_result, expected)
 
         # Clear cache
-        details_report = Report.objects.get(id=response_json["report_id"])
-        details_report.cached_csv = None
-        details_report.save()
+        report = Report.objects.get(id=response_json["report_id"])
+        report.cached_csv = None
+        report.save()
 
         # Remove sources
         test_json = copy.deepcopy(response_json)
@@ -211,9 +211,9 @@ class DetailReportTest(LoggedUserMixin, TestCase):
         self.assertEqual(csv_result, expected)
 
         # Clear cache
-        details_report = Report.objects.get(id=response_json["report_id"])
-        details_report.cached_csv = None
-        details_report.save()
+        report = Report.objects.get(id=response_json["report_id"])
+        report.cached_csv = None
+        report.save()
 
         # Remove facts
         test_json = copy.deepcopy(response_json)

--- a/quipucords/tests/api/details_report/test_sync_report_creation.py
+++ b/quipucords/tests/api/details_report/test_sync_report_creation.py
@@ -14,7 +14,7 @@ from tests.mixins import LoggedUserMixin
 
 
 class DetailsReportTest(LoggedUserMixin, TestCase):
-    """Tests against the DetailsReport model and view set."""
+    """Tests against the Report model and view set."""
 
     def setUp(self):
         """Create test case setup."""

--- a/quipucords/tests/api/reports/test_reports.py
+++ b/quipucords/tests/api/reports/test_reports.py
@@ -75,7 +75,7 @@ class ReportsTest(LoggedUserMixin, TestCase):
         return details_json
 
     def generate_fingerprints(self, os_name="RHEL", os_versions=None):
-        """Create a DetailsReport for test."""
+        """Create a Report for testing."""
         facts = []
         fc_json = {
             "report_type": "details",

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -119,7 +119,7 @@ class DeploymentReportFactory(DjangoModelFactory):
 
 
 class ReportFactory(DjangoModelFactory):
-    """Factory for DetailsReport."""
+    """Factory for Report."""
 
     deployment_report = factory.SubFactory(DeploymentReportFactory, report=None)
     scanjob = factory.RelatedFactory(

--- a/quipucords/tests/fingerprinter/test_fingerprint_process_sources.py
+++ b/quipucords/tests/fingerprinter/test_fingerprint_process_sources.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__file__)
 
 
 @pytest.fixture
-def details_report(mocker):
-    """Details report patched to contain all possible source types."""
+def report(mocker):
+    """Report patched to contain all possible source types."""
     report = mocker.MagicMock(spec=Report)
     report.sources = [
         {
@@ -135,12 +135,12 @@ def expected_messages():
 
 
 def test_process_sources(
-    task_runner: FingerprintTaskRunner, expected_messages, details_report, caplog
+    task_runner: FingerprintTaskRunner, expected_messages, report, caplog
 ):
     """Test FingerprintTaskRunner._process_sources counting mechanism."""
     caplog.set_level(logging.INFO)
 
-    fingerprints = task_runner._process_sources(details_report)  # noqa: W0212
+    fingerprints = task_runner._process_sources(report)  # noqa: W0212
     non_merged_fingerprints = [1, 2, 2]
     # ocp/ansible fingerprints wont be part of deduplication/merging process
     assert fingerprints == [1, 2] + 2 * non_merged_fingerprints

--- a/quipucords/tests/fingerprinter/test_fingerprint_task.py
+++ b/quipucords/tests/fingerprinter/test_fingerprint_task.py
@@ -188,7 +188,7 @@ def _create_network_details_report_json(  # noqa: PLR0913, PLR0912, PLR0915, C90
     architecture="x86_64",
     user_has_sudo=True,
 ):
-    """Create an in memory DetailsReport for tests."""
+    """Create an in memory details report for tests."""
     fact = network_template()
     if source_name:
         fact["source_name"] = source_name
@@ -288,7 +288,7 @@ def _create_vcenter_details_report_json(  # noqa: PLR0913, PLR0912, C901
     architecture="x86_64",
     is_redhat=True,
 ):
-    """Create an in memory DetailsReport for tests."""
+    """Create an in memory details report for tests."""
     fact = vcenter_template()
     if source_name:
         fact["source_name"] = source_name
@@ -356,7 +356,7 @@ def _create_satellite_details_report_json(  # noqa: PLR0913, PLR0912, C901
     architecture="x86_64",
     is_redhat=True,
 ):
-    """Create an in memory DetailsReport for tests."""
+    """Create an in memory details report for tests."""
     fact = satellite_template()
     if source_name:
         fact["source_name"] = source_name
@@ -1508,13 +1508,13 @@ def test_process_details_report_failed(fingerprint_task_runner):
     """Test processing a details report no valid fps."""
     fact_collection = {}
     deployments_report = DeploymentsReport()
-    details_report = Report(deployment_report=deployments_report)
+    report = Report(deployment_report=deployments_report)
     with patch(
         "fingerprinter.runner.FingerprintTaskRunner._process_sources",
         return_value=fact_collection,
     ):
         status_message, status = fingerprint_task_runner._process_details_report(
-            "", details_report
+            "", report
         )
         assert "failed" in status_message.lower()
         assert status == "failed"
@@ -1533,13 +1533,13 @@ def test_process_details_report_success(fingerprint_task_runner):
     }
     deployments_report = DeploymentsReport(id=1)
     deployments_report.save()
-    details_report = Report(id=1, deployment_report=deployments_report)
+    report = Report(id=1, deployment_report=deployments_report)
     with patch(
         "fingerprinter.runner.FingerprintTaskRunner._process_sources",
         return_value=[fact_collection],
     ):
         status_message, status = fingerprint_task_runner._process_details_report(
-            "", details_report
+            "", report
         )
     assert "success" in status_message.lower()
     assert status == "completed"
@@ -1555,7 +1555,7 @@ def test_process_details_report_exception(fingerprint_task_runner):
     }
     deployments_report = DeploymentsReport(id=1)
     deployments_report.save()
-    details_report = Report(id=1, deployment_report=deployments_report)
+    report = Report(id=1, deployment_report=deployments_report)
     with patch(
         "fingerprinter.runner.FingerprintTaskRunner._process_sources",
         return_value=[fact_collection],
@@ -1564,7 +1564,7 @@ def test_process_details_report_exception(fingerprint_task_runner):
         side_effect=DataError,
     ):
         status_message, status = fingerprint_task_runner._process_details_report(
-            "", details_report
+            "", report
         )
         assert "failed" in status_message.lower()
         assert status == "failed"

--- a/quipucords/tests/test_factories.py
+++ b/quipucords/tests/test_factories.py
@@ -103,8 +103,8 @@ class TestSourceFactory:
 
 
 @pytest.mark.django_db
-class TestDetailsFactory:
-    """Test DetailsReportFactory."""
+class TestReportFactory:
+    """Test ReportFactory."""
 
     @pytest.mark.parametrize("source_type", DataSources.values)
     def test_source_generation(self, source_type):


### PR DESCRIPTION
Finishes mass renaming details_report -> report. The only references to details report that persist in the codebase should now be referring to the actual report (you know, the file, the json response...), not the model.

Relates to JIRA: DISCOVERY-226