### PR TITLE
Don't fail workflow if we can't push to quay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,4 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
+        continue-on-error: true


### PR DESCRIPTION
Pushing to quay only works reliably if PR is created from branch in main repo, not fork.

However, users *may* configure their fork in a way that will make push step succeed.

Jenkins detects PR was created from fork and will build container image locally before running Camayoc.

To support all possible use-cases, instead of using brittle conditionals, let's just mark a push step as allowed failure. Standard PRs from branches should continue to work as they did, and forks with custom setup have a chance to succeed, while others won't prevent merge.