### PR TITLE
refact(tests): remove unused cred_for_upload variable from tests.

### DIFF
--- a/quipucords/tests/api/scan/test_scan.py
+++ b/quipucords/tests/api/scan/test_scan.py
@@ -28,8 +28,6 @@ class ScanTest(LoggedUserMixin, TestCase):
             become_password=None,
             ssh_keyfile=None,
         )
-        self.cred_for_upload = self.cred.id
-
         self.source = Source(name="source1", source_type="network", port=22)
         self.source.save()
 
@@ -645,8 +643,6 @@ class TestScanList(LoggedUserMixin, TestCase):
             become_password=None,
             ssh_keyfile=None,
         )
-        self.cred_for_upload = self.cred.id
-
         self.source = Source.objects.create(
             name="source1", source_type="network", port=22
         )

--- a/quipucords/tests/api/scanjob/test_scanjob.py
+++ b/quipucords/tests/api/scanjob/test_scanjob.py
@@ -51,8 +51,6 @@ class ScanJobTest(LoggedUserMixin, TestCase):
             become_password=None,
             ssh_keyfile=None,
         )
-        self.cred_for_upload = self.cred.id
-
         self.source = Source(name="source1", source_type="network", port=22)
         self.source.save()
         self.source.credentials.add(self.cred)

--- a/quipucords/tests/api/scantask/test_scantask.py
+++ b/quipucords/tests/api/scantask/test_scantask.py
@@ -28,8 +28,6 @@ class ScanTaskTest(TestCase):
             become_password=None,
             ssh_keyfile=None,
         )
-        self.cred_for_upload = self.cred.id
-
         self.source = Source.objects.create(
             name="source1", source_type="network", port=22
         )


### PR DESCRIPTION
Removing unused variable cred_for_upload in quipucords api tests.