### PR TITLE
chore: addopt bandit static linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ select = [
     "PL",  # Pylint
     "BLE", # flake8-blind-except
     "PTH", # flake8-use-pathlib
+    "S",   # flake8-bandit
 ]
 ignore = [
     "D107",
@@ -112,9 +113,14 @@ known-first-party = [
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401", "D104"]
-"**/test_*.py" = [
+"**test**" = [
     "PLC1901", 
-    "PLR2004"
+    "PLR2004",
+    "S101",
+    "S105",
+    "S106",
+    "S107",
+    "S311",
 ]
 "quipucords/api/migrations/*.py" = ["D100", "D101"]
 

--- a/quipucords/api/management/commands/randomize_db_sequences.py
+++ b/quipucords/api/management/commands/randomize_db_sequences.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         The random id is guaranteed to be > than MAX(model.id)
         """
         max_id = self._get_max_id(model)
-        random_id = random.randint(10000, 20000)
+        random_id = random.randint(10000, 20000)  # noqa: S311
         return random_id + max_id
 
     def _get_max_id(self, model):

--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -1,4 +1,6 @@
 """API messages for translation."""
+# S105 violations here are false positives
+# ruff: noqa: S105
 
 # fact messages
 FC_REQUIRED_ATTRIBUTE = "Required. May not be null or empty."

--- a/quipucords/api/source/serializer.py
+++ b/quipucords/api/source/serializer.py
@@ -513,7 +513,7 @@ class SourceSerializer(NotEmptySerializer):
                 # The number of bits of this octet that we want to
                 # preserve
                 this_octet_bits = prefix_bits - 8 * i
-                assert 0 < this_octet_bits < 8  # noqa: PLR2004
+                SourceSerializer._validate_octet_bits(this_octet_bits)
                 # mask is this_octet_bits 1's followed by (8 -
                 # this_octet_bits) 0's.
                 mask = -1 << (8 - this_octet_bits)
@@ -523,6 +523,11 @@ class SourceSerializer(NotEmptySerializer):
                 ansible_out[i] = f"[{lower_bound}:{upper_bound}]"
 
         return ".".join(ansible_out)
+
+    @staticmethod
+    def _validate_octet_bits(this_octet_bits):
+        if not (0 < this_octet_bits < 8):  # noqa: PLR2004
+            raise ValueError(f"Invalid value for {this_octet_bits=}")
 
     @staticmethod
     def validate_port(port):

--- a/quipucords/quipucords/environment.py
+++ b/quipucords/quipucords/environment.py
@@ -19,7 +19,7 @@ def commit():
     commit_info = os.environ.get("QUIPUCORDS_COMMIT", "").strip()
     if not commit_info:
         commit_info = subprocess.check_output(
-            ["git", "rev-parse", "--verify", "HEAD"]
+            ["git", "rev-parse", "--verify", "HEAD"]  # noqa: S603, S607
         ).strip()
         commit_info = commit_info.decode("utf-8")
     return commit_info

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -229,10 +229,10 @@ MINIMUM_LENGTH_VALIDATOR = (
     "django.contrib.auth.password_validation.MinimumLengthValidator"
 )
 COMMON_PASSWORD_VALIDATOR = (
-    "django.contrib.auth.password_validation.CommonPasswordValidator"
+    "django.contrib.auth.password_validation.CommonPasswordValidator"  # noqa: S105
 )
 NUMERIC_PASSWORD_VALIDATOR = (
-    "django.contrib.auth.password_validation.NumericPasswordValidator"
+    "django.contrib.auth.password_validation.NumericPasswordValidator"  # noqa: S105
 )
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -40,9 +40,10 @@ class CeleryScanManager:
 
     def put(self, scan_job_runner: CeleryBasedScanJobRunner):
         """Process the given CeleryBasedScanJobRunner's job and tasks."""
-        assert isinstance(
-            scan_job_runner, CeleryBasedScanJobRunner
-        ), "CeleryScanManager only accepts CeleryBasedScanJobRunner runners."
+        if not isinstance(scan_job_runner, CeleryBasedScanJobRunner):
+            raise ValueError(
+                "CeleryScanManager only accepts CeleryBasedScanJobRunner runners."
+            )
         scan_job_runner.run()
 
 
@@ -140,10 +141,11 @@ class Manager(Thread):
 
         :param scanner: ScanJobRunner to run.
         """
-        assert isinstance(scanner, ProcessBasedScanJobRunner), (
-            "Non-multiprocessing ScanJobRunner can't be used alongside thread "
-            "based ScanManager."
-        )
+        if not isinstance(scanner, ProcessBasedScanJobRunner):
+            raise ValueError(
+                "Non-multiprocessing ScanJobRunner can't be used alongside thread "
+                "based ScanManager."
+            )
         self.scan_queue.insert(0, scanner)
         self.log_info()
 
@@ -161,7 +163,6 @@ class Manager(Thread):
             and self.current_job_runner.identifier == job_id
             and self.current_job_runner.is_alive()
         ):
-
             # record which job is terminated
             self.terminated_job_runner = self.current_job_runner
             self.current_job_runner = None

--- a/quipucords/scanner/network/processing/ip.py
+++ b/quipucords/scanner/network/processing/ip.py
@@ -23,7 +23,7 @@ import re
 
 from scanner.network.processing import process
 
-EXCLUDE_IPV4_ADDRESSES = {"127.0.0.1", "0.0.0.0"}
+EXCLUDE_IPV4_ADDRESSES = {"127.0.0.1", "0.0.0.0"}  # noqa: S104
 EXCLUDE_MAC_ADDRESSES = {"00:00:00:00:00:00", "ff:ff:ff:ff:ff:ff"}
 MATCH_MAC_ADDRESS = re.compile("^[0-9a-f]{2}(?::[0-9a-f]{2}){5}$")
 

--- a/quipucords/scanner/openshift/api.py
+++ b/quipucords/scanner/openshift/api.py
@@ -211,7 +211,8 @@ class OpenShiftApi:
     def retrieve_cluster(self, **kwargs) -> OCPCluster:
         """Retrieve cluster under OCP host."""
         clusters = self._list_clusters(**kwargs)
-        assert len(clusters) == 1, "More than one cluster in cluster API"
+        if len(clusters) > 1:
+            raise ValueError("More than one cluster in cluster API")
         cluster_entity = self._init_cluster(clusters[0])
         return cluster_entity
 

--- a/quipucords/scanner/openshift/entities.py
+++ b/quipucords/scanner/openshift/entities.py
@@ -56,8 +56,10 @@ class OCPBaseEntity(BaseModel):
             raise NotImplementedError(
                 f"{cls.__name__} MUST implement an attribute '_kind'."
             )
-        assert isinstance(kind, str), "'_kind' attribute should be a str."
-        assert kind not in cls._OCP_ENTITIES, f"Entity with {kind=} already registered."
+        if not isinstance(kind, str):
+            raise RuntimeError("'_kind' attribute should be a str.")
+        if kind in cls._OCP_ENTITIES:
+            raise RuntimeError(f"Entity with {kind=} already registered.")
         return kind
 
 

--- a/quipucords/tests/scanner/openshift/test_api.py
+++ b/quipucords/tests/scanner/openshift/test_api.py
@@ -57,12 +57,13 @@ def dynamic_scope(fixture_name, config):
 
 
 @pytest.fixture(scope=dynamic_scope)
-def discoverer_cache(request, testrun_uid):
+def discoverer_cache(request):
     """OCP dynamic client "discoverer" cache."""
     fname = "ocp-discovery.json"
     if request.config.getoption("--refresh-cassettes"):
         # persist cache file for whole test suite execution
-        _file = Path("/tmp/qpc") / testrun_uid / fname
+        tmp_path_factory = request.getfixturevalue("tmp_path_factory")
+        _file = tmp_path_factory.mktemp("ocp-cache") / fname
         _file.parent.mkdir(parents=True, exist_ok=True)
         yield _file
 

--- a/quipucords/tests/scanner/openshift/test_entities.py
+++ b/quipucords/tests/scanner/openshift/test_entities.py
@@ -107,7 +107,7 @@ class TestOCPBaseEntity:
             name: str
 
         with pytest.raises(
-            AssertionError, match="Entity with kind='test-entity' already registered."
+            RuntimeError, match="Entity with kind='test-entity' already registered."
         ):
 
             class TestClass2(OCPBaseEntity):

--- a/quipucords/utils/debugger.py
+++ b/quipucords/utils/debugger.py
@@ -21,5 +21,5 @@ def start_debugger_if_required():
             logger.exception("debugpy is not installed, can't start debugger.")
             raise SystemExit()
 
-        debugpy.listen(("0.0.0.0", DEBUGPY_PORT))
+        debugpy.listen(("0.0.0.0", DEBUGPY_PORT))  # noqa: S104
         print("⏳ debugpy debugger can now be attached ⏳", flush=True)


### PR DESCRIPTION
Yet another linter enabled in ruff. This time, [bandit](https://pypi.org/project/bandit/).

The inspiration to add this check came from this comment: https://github.com/quipucords/quipucords/pull/2492#discussion_r1345776403