### PR TITLE
fix: `export LANG=C LC_ALL=C;` before all ansible raw commands

### DIFF
--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "check_dependencies"
 
 - name: test if user has sudo cmd
-  raw: echo "user has sudo" 2>/dev/null
+  raw: export LANG=C LC_ALL=C; echo "user has sudo" 2>/dev/null
   register: internal_user_has_sudo_cmd
   become: yes
   ignore_errors: yes
@@ -16,7 +16,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_dmidecode_cmd
-  raw: command -v /usr/sbin/dmidecode
+  raw: export LANG=C LC_ALL=C; command -v /usr/sbin/dmidecode
   register: internal_have_dmidecode_cmd
   become: yes
   ignore_errors: yes
@@ -28,7 +28,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_tune2fs_cmd
-  raw: command -v tune2fs
+  raw: export LANG=C LC_ALL=C; command -v tune2fs
   register: internal_have_tune2fs_cmd
   ignore_errors: yes
 
@@ -38,7 +38,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_yum_cmd
-  raw: command -v yum
+  raw: export LANG=C LC_ALL=C; command -v yum
   register: internal_have_yum_cmd
   ignore_errors: yes
 
@@ -48,7 +48,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_java_cmd
-  raw: command -v java
+  raw: export LANG=C LC_ALL=C; command -v java
   register: internal_have_java_cmd
   ignore_errors: yes
 
@@ -58,7 +58,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_rpm_cmd
-  raw: command -v rpm
+  raw: export LANG=C LC_ALL=C; command -v rpm
   register: internal_have_rpm_cmd
   ignore_errors: yes
 
@@ -68,7 +68,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_subscription_manager_cmd
-  raw: command -v subscription-manager
+  raw: export LANG=C LC_ALL=C; command -v subscription-manager
   register: internal_have_subscription_manager_cmd
   become: yes
   ignore_errors: yes
@@ -80,7 +80,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_virsh_cmd
-  raw: command -v virsh
+  raw: export LANG=C LC_ALL=C; command -v virsh
   register: internal_have_virsh_cmd
   ignore_errors: yes
 
@@ -90,7 +90,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_virt_what_cmd
-  raw: command -v virt-what
+  raw: export LANG=C LC_ALL=C; command -v virt-what
   register: internal_have_virt_what_cmd
   ignore_errors: yes
 
@@ -100,12 +100,12 @@
   ignore_errors: yes
 
 - name: gather internal_have_locate_cmd
-  raw: command -v locate
+  raw: export LANG=C LC_ALL=C; command -v locate
   register: internal_have_locate_cmd
   ignore_errors: yes
 
 - name: test locate command
-  raw: locate echo
+  raw: export LANG=C LC_ALL=C; locate echo
   register: internal_test_locate
   ignore_errors: yes
   when: (internal_have_locate_cmd.get('rc') == 0)
@@ -122,7 +122,7 @@
   when: (internal_have_locate_cmd.get('rc') == 0 and internal_test_locate.get('rc') == 0)
 
 - name: gather internal_have_systemctl_cmd
-  raw: whereis systemctl
+  raw: export LANG=C LC_ALL=C; whereis systemctl
   register: internal_whereis_systemctl_cmd
   ignore_errors: yes
 
@@ -138,7 +138,7 @@
   when: (internal_whereis_systemctl_cmd.get('rc') == 0 and internal_whereis_systemctl_cmd.get('stdout_lines')[-1] != 'systemctl:')
 
 - name: gather internal_whereis_chkconfig_cmd
-  raw: whereis chkconfig
+  raw: export LANG=C LC_ALL=C; whereis chkconfig
   register: internal_whereis_chkconfig_cmd
   ignore_errors: yes
 
@@ -154,7 +154,7 @@
   when: (internal_whereis_chkconfig_cmd.get('rc') == 0 and internal_whereis_chkconfig_cmd.get('stdout_lines')[-1] != 'chkconfig:')
 
 - name: gather internal_whereis_ifconfig_cmd
-  raw: whereis ifconfig
+  raw: export LANG=C LC_ALL=C; whereis ifconfig
   register:  internal_whereis_ifconfig_cmd
   ignore_errors: yes
 
@@ -170,7 +170,7 @@
   when: "internal_whereis_ifconfig_cmd.get('rc') == 0 and internal_whereis_ifconfig_cmd.get('stdout_lines')[-1] != 'ifconfig:'"
 
 - name: gather internal_whereis_ip_cmd
-  raw: command -v /sbin/ip
+  raw: export LANG=C LC_ALL=C; command -v /sbin/ip
   register:  internal_whereis_ip_cmd
   ignore_errors: yes
 
@@ -186,7 +186,7 @@
   when: "internal_whereis_ip_cmd.get('rc') == 0"
 
 - name: gather internal_have_unzip_cmd
-  raw: command -v unzip
+  raw: export LANG=C LC_ALL=C; command -v unzip
   register: internal_have_unzip_cmd
   ignore_errors: yes
 
@@ -196,7 +196,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_rct_cmd
-  raw: command -v rct
+  raw: export LANG=C LC_ALL=C; command -v rct
   register: internal_have_rct_cmd
   ignore_errors: yes
 

--- a/quipucords/scanner/network/runner/roles/cloud_provider/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/cloud_provider/tasks/main.yml
@@ -6,7 +6,7 @@
 
 # Azure cloud facts
 - name: gather dmi.chassis.asset_tag fact
-  raw: /usr/sbin/dmidecode -t chassis 2>/dev/null | grep "Asset Tag"
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t chassis 2>/dev/null | grep "Asset Tag"
   register: internal_dmi_chassis_asset_tag_cmd
   ignore_errors: yes
   become: yes
@@ -24,7 +24,7 @@
 
 # ## Alibaba cloud facts
 - name: gather dmi.system.product_name fact
-  raw: /usr/sbin/dmidecode -t system 2>/dev/null | grep "Product Name"
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t system 2>/dev/null | grep "Product Name"
   register: internal_dmi_system_product_name_cmd
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/cpu/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/cpu/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "cpu"
 
 - name: gather internal_cpu_vendor_id
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^vendor_id\s*' | sed -n -e 's/^.*vendor_id\s*.\s*//p'
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^vendor_id\s*' | sed -n -e 's/^.*vendor_id\s*.\s*//p'
   register: internal_cpu_vendor_id
   ignore_errors: yes
 
@@ -15,7 +15,7 @@
   ignore_errors: yes
 
 - name: gather internal_cpu_model_name
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^model name\s*.' | sed -n -e 's/^.*model name\s*.\s*//p'
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^model name\s*.' | sed -n -e 's/^.*model name\s*.\s*//p'
   register: internal_cpu_model_name
   ignore_errors: yes
 
@@ -25,7 +25,7 @@
   ignore_errors: yes
 
 - name: gather internal_cpu_bogomips fact
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^bogomips\s*.' | sed -n -e 's/^.*bogomips\s*.\s*//p'
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^bogomips\s*.' | sed -n -e 's/^.*bogomips\s*.\s*//p'
   register: internal_cpu_bogomips
   ignore_errors: yes
 
@@ -35,7 +35,7 @@
   ignore_errors: yes
 
 - name: gather internal_cpu_cpu_family fact
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^cpu family\s*.' | sed -n -e 's/^.*cpu family\s*.\s*//p'
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^cpu family\s*.' | sed -n -e 's/^.*cpu family\s*.\s*//p'
   register: internal_cpu_cpu_family
   ignore_errors: yes
 
@@ -45,7 +45,7 @@
   ignore_errors: yes
 
 - name: gather internal_cpu_model_ver fact
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^model\s*:' | sed -n -e 's/^.*model\s*:\s*//p'
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^model\s*:' | sed -n -e 's/^.*model\s*:\s*//p'
   register: internal_cpu_model_ver
   ignore_errors: yes
 
@@ -55,7 +55,7 @@
   ignore_errors: yes
 
 - name: gather cpu.count fact
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^processor\s*.' | wc -l
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^processor\s*.' | wc -l
   register: internal_cpu_count_cmd
   ignore_errors: yes
 
@@ -65,7 +65,7 @@
   ignore_errors: yes
 
 - name: gather cpu.core_per_socket fact
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^cpu cores\s*.' | sed -n -e 's/^.*cpu cores\s*.\s*//p'
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^cpu cores\s*.' | sed -n -e 's/^.*cpu cores\s*.\s*//p'
   register: internal_cpu_core_per_socket_cmd
   ignore_errors: yes
 
@@ -75,7 +75,7 @@
   ignore_errors: yes
 
 - name: gather cpu.siblings fact
-  raw: cat /proc/cpuinfo 2>/dev/null | grep '^siblings\s*.' | sed -n -e 's/^.*siblings\s*.\s*//p'
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep '^siblings\s*.' | sed -n -e 's/^.*siblings\s*.\s*//p'
   register: internal_cpu_siblings_cmd
   ignore_errors: yes
 
@@ -90,7 +90,7 @@
   ignore_errors: yes
 
 - name: gather cpu.socket_count fact
-  raw: /usr/sbin/dmidecode -t 4 | egrep 'Designation|Status'
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t 4 | egrep 'Designation|Status'
   register: internal_cpu_socket_count_dmi_cmd
   become: yes
   ignore_errors: yes
@@ -102,7 +102,7 @@
   ignore_errors: yes
 
 - name: gather cpu.socket_count fact with fallback
-  raw: cat /proc/cpuinfo 2>/dev/null | grep 'physical id' | sort -u | wc -l
+  raw: export LANG=C LC_ALL=C; cat /proc/cpuinfo 2>/dev/null | grep 'physical id' | sort -u | wc -l
   register: internal_cpu_socket_count_cpuinfo_cmd
   ignore_errors: yes
 

--- a/quipucords/scanner/network/runner/roles/date/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/date/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "date"
 
 - name: gather internal_date_date fact
-  raw: date
+  raw: export LANG=C LC_ALL=C; date
   register: internal_date_date
   ignore_errors: yes
 
@@ -15,7 +15,7 @@
   ignore_errors: yes
 
 - name: gather uptime fact
-  raw: uptime=$(cat /proc/uptime); array=( $uptime); seconds=" +seconds"; formatted_uptime="${array[0]}$seconds"; TZ=utc date --date -"$formatted_uptime" +"%Y-%m-%d %T"
+  raw: export LANG=C LC_ALL=C; uptime=$(cat /proc/uptime); array=( $uptime); seconds=" +seconds"; formatted_uptime="${array[0]}$seconds"; TZ=utc date --date -"$formatted_uptime" +"%Y-%m-%d %T"
   register: internal_uptime_utc_cmd
   ignore_errors: yes
 
@@ -25,7 +25,7 @@
   ignore_errors: yes
 
 - name: gather date.anaconda_log fact
-  raw: ls --full-time /root/anaconda-ks.cfg 2>/dev/null | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
+  raw: export LANG=C LC_ALL=C; ls --full-time /root/anaconda-ks.cfg 2>/dev/null | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
   register: internal_date_anaconda_log_cmd
   become: yes
   ignore_errors: yes
@@ -47,7 +47,7 @@
   when: '"stdout_lines" not in internal_date_anaconda_log_cmd or internal_date_anaconda_log_cmd["stdout_lines"] | length == 0'
 
 - name: gather internal_date_machine_id fact
-  raw: if [ -f /etc/machine-id ] ; then ls --full-time /etc/machine-id 2>/dev/null | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' ; fi
+  raw: export LANG=C LC_ALL=C; if [ -f /etc/machine-id ] ; then ls --full-time /etc/machine-id 2>/dev/null | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' ; fi
   register: internal_date_machine_id
   ignore_errors: yes
 
@@ -57,7 +57,7 @@
   ignore_errors: yes
 
 - name: gather internal_date_filesystem_create fact
-  raw: fs_date=$(tune2fs -l $(mount | egrep '/ type' | grep -o '/dev.* on' | sed -e 's/\on//g') 2>/dev/null | grep 'Filesystem created' | sed 's/Filesystem created:\s*//g'); if [[ $fs_date ]]; then date +'%F' -d "$fs_date"; else echo "" ; fi
+  raw: export LANG=C LC_ALL=C; fs_date=$(tune2fs -l $(mount | egrep '/ type' | grep -o '/dev.* on' | sed -e 's/\on//g') 2>/dev/null | grep 'Filesystem created' | sed 's/Filesystem created:\s*//g'); if [[ $fs_date ]]; then date +'%F' -d "$fs_date"; else echo "" ; fi
   register: internal_date_filesystem_create
   ignore_errors: yes
   when: 'internal_have_tune2fs'
@@ -68,7 +68,7 @@
   ignore_errors: yes
 
 - name: gather internal_date_yum_history fact
-  raw: yum history 2>/dev/null  | tail -n 2 | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
+  raw: export LANG=C LC_ALL=C; yum history 2>/dev/null  | tail -n 2 | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
   register: internal_date_yum_history
   become: yes
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "dmi"
 
 - name: gather dmi.bios-vendor fact
-  raw: /usr/sbin/dmidecode -s bios-vendor 2>/dev/null
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s bios-vendor 2>/dev/null
   register: internal_dmi_bios_vendor_cmd
   ignore_errors: yes
   become: yes
@@ -26,7 +26,7 @@
   when: '"stdout_lines" not in internal_dmi_bios_vendor_cmd'
 
 - name: gather dmi.bios-version fact
-  raw: /usr/sbin/dmidecode -s bios-version 2>/dev/null
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s bios-version 2>/dev/null
   register: internal_dmi_bios_version_cmd
   ignore_errors: yes
   become: yes
@@ -47,7 +47,7 @@
   when: '"stdout_lines" not in internal_dmi_bios_version_cmd'
 
 - name: gather dmi.system-manufacturer fact
-  raw: /usr/sbin/dmidecode 2>/dev/null | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode 2>/dev/null | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
   register: internal_dmi_system_manufacturer_cmd
   ignore_errors: yes
   become: yes
@@ -68,7 +68,7 @@
   when: '"stdout_lines" not in internal_dmi_system_manufacturer_cmd'
 
 - name: gather dmi.processor-family fact
-  raw: /usr/sbin/dmidecode -s processor-family 2>/dev/null
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s processor-family 2>/dev/null
   register: internal_dmi_processor_family_cmd
   ignore_errors: yes
   become: yes
@@ -89,7 +89,7 @@
   when: '"stdout_lines" not in internal_dmi_processor_family_cmd'
 
 - name: gather dmi.system-uuid fact
-  raw: /usr/sbin/dmidecode -s system-uuid 2>/dev/null
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s system-uuid 2>/dev/null
   register: internal_dmi_system_uuid_cmd
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/etc_release/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/etc_release/tasks/main.yml
@@ -27,6 +27,7 @@
 
 - name: check which /etc/*release file exists
   raw: |
+    export LANG=C LC_ALL=C;
     for i in \
       /etc/debian_version \
       {{ internal_distro_standard_release|join(' ') }} \
@@ -47,7 +48,7 @@
     - 'internal_release_found["stdout_lines"][-1]|length > 0'
 
 - name: set internal_release_file_content based on internal_release_file
-  raw: cat {{ internal_release_file }}
+  raw: export LANG=C LC_ALL=C; cat {{ internal_release_file }}
   register: internal_release_file_content
   ignore_errors: yes
   when:
@@ -86,7 +87,7 @@
 # set facts using Linux Standard Base when no other release file was found
 
 - name: set os and version based on /etc/lsb-release output
-  raw: . /etc/lsb-release && echo "$DISTRIB_ID" && echo "$DISTRIB_RELEASE"
+  raw: export LANG=C LC_ALL=C; . /etc/lsb-release && echo "$DISTRIB_ID" && echo "$DISTRIB_RELEASE"
   register: internal_lsb_release
   ignore_errors: yes
   when:
@@ -94,7 +95,7 @@
     - 'internal_release_file == "/etc/lsb-release"'
 
 - name: set os and version using `lsb_release -si -sr`
-  raw: lsb_release -si -sr
+  raw: export LANG=C LC_ALL=C; lsb_release -si -sr
   register: internal_lsb_release
   ignore_errors: yes
   when:
@@ -115,7 +116,7 @@
 # set facts using uname if we still haven't identified the distro
 
 - name: set os and kernel release using `uname -s -r`
-  raw: uname -s -r
+  raw: export LANG=C LC_ALL=C; uname -s -r
   register: internal_uname_version
   ignore_errors: yes
   when: 'etc_release_name == ""'
@@ -133,7 +134,7 @@
 
 # gather etc machine id
 - name: Gather the etc machine id
-  raw: if [ -f /etc/machine-id ]; then cat /etc/machine-id; fi | tr -d '\r' | tr -d '\n'
+  raw: export LANG=C LC_ALL=C; if [ -f /etc/machine-id ]; then cat /etc/machine-id; fi | tr -d '\r' | tr -d '\n'
   register: internal_get_etc_machine_id
   ignore_errors: yes
 

--- a/quipucords/scanner/network/runner/roles/file_contents/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/file_contents/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "file_contents"
 
 - name: gather etc-issue.etc-issue fact
-  raw: if [ -f /etc/issue ] ; then cat /etc/issue 2>/dev/null ; fi
+  raw: export LANG=C LC_ALL=C; if [ -f /etc/issue ] ; then cat /etc/issue 2>/dev/null ; fi
   register: internal_etc_issue_cmd
   ignore_errors: yes
 
@@ -15,7 +15,7 @@
   ignore_errors: yes
 
 - name: gather instnum.instnum fact
-  raw: if [ -f /etc/sysconfig/rhn/install-num ] ; then cat /etc/sysconfig/rhn/install-num 2>/dev/null ; fi
+  raw: export LANG=C LC_ALL=C; if [ -f /etc/sysconfig/rhn/install-num ] ; then cat /etc/sysconfig/rhn/install-num 2>/dev/null ; fi
   register: internal_instnum_cmd
   ignore_errors: yes
 
@@ -25,7 +25,7 @@
   ignore_errors: yes
 
 - name: gather systemid fact
-  raw: if [ -f /etc/sysconfig/rhn/systemid ] ; then cat /etc/sysconfig/rhn/systemid 2>/dev/null ; fi
+  raw: export LANG=C LC_ALL=C; if [ -f /etc/sysconfig/rhn/systemid ] ; then cat /etc/sysconfig/rhn/systemid 2>/dev/null ; fi
   register: internal_systemid_cmd
   ignore_errors: yes
 

--- a/quipucords/scanner/network/runner/roles/ifconfig/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/ifconfig/tasks/main.yml
@@ -5,13 +5,13 @@
     internal_host_started_processing_role: "ifconfig"
 
 - name: gather ifconfig.mac-addresses fact (no sudo)
-  raw: /sbin/ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
+  raw: export LANG=C LC_ALL=C; /sbin/ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
   register: internal_ifconfig_mac_addresses_cmd
   ignore_errors: yes
   when: '(not user_has_sudo) and internal_have_ifconfig'
 
 - name: gather ifconfig.mac-addresses fact (sudo)
-  raw: /sbin/ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
+  raw: export LANG=C LC_ALL=C; /sbin/ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
   register: internal_sudo_ifconfig_mac_addresses_cmd
   ignore_errors: yes
   become: yes
@@ -30,13 +30,13 @@
   when: 'user_has_sudo and "stdout_lines" in internal_sudo_ifconfig_mac_addresses_cmd'
 
 - name: gather ip-address fact (no sudo)
-  raw: if [ -f /sbin/ifconfig ] ; then /sbin/ifconfig -a; else hostname -I 2>/dev/null; fi
+  raw: export LANG=C LC_ALL=C; if [ -f /sbin/ifconfig ] ; then /sbin/ifconfig -a; else hostname -I 2>/dev/null; fi
   register: internal_ifconfig_ip_addresses_cmd
   ignore_errors: yes
   when: '(not user_has_sudo)'
 
 - name: gather ip-address fact (sudo)
-  raw: if [ -f /sbin/ifconfig ] ; then /sbin/ifconfig -a; else hostname -I 2>/dev/null; fi
+  raw: export LANG=C LC_ALL=C; if [ -f /sbin/ifconfig ] ; then /sbin/ifconfig -a; else hostname -I 2>/dev/null; fi
   register: internal_sudo_ifconfig_ip_addresses_cmd
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/insights/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/insights/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "insights"
 
 - name: gather insights.machine-id
-  raw: if [ -f /etc/insights-client/machine-id ] ; then cat /etc/insights-client/machine-id; fi || if [ -f /etc/redhat-access-insights ] ; then cat /etc/redhat-access-insights/machine-id; fi | tr -d '\r' | tr -d '\n'
+  raw: export LANG=C LC_ALL=C; if [ -f /etc/insights-client/machine-id ] ; then cat /etc/insights-client/machine-id; fi || if [ -f /etc/redhat-access-insights ] ; then cat /etc/redhat-access-insights/machine-id; fi | tr -d '\r' | tr -d '\n'
   register: internal_get_insights_client_id
   ignore_errors: yes
 

--- a/quipucords/scanner/network/runner/roles/installed_products/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/installed_products/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "installed_products"
 
 - name: gather internal_installed_products
-  raw: find /etc/pki/product*/ -name '*pem' -exec rct cat-cert --no-content '{}' \; | grep -C2 -E '^\s+ID:'
+  raw: export LANG=C LC_ALL=C; find /etc/pki/product*/ -name '*pem' -exec rct cat-cert --no-content '{}' \; | grep -C2 -E '^\s+ID:'
   register: internal_installed_products
   ignore_errors: yes
   when: 'internal_have_rct'

--- a/quipucords/scanner/network/runner/roles/ip/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/ip/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "ip address show"
 
 - name: gather 'ip address show' fact
-  raw: /sbin/ip address show
+  raw: export LANG=C LC_ALL=C; /sbin/ip address show
   register: internal_ip_address_show_cmd
   ignore_errors: yes
   become: '{{user_has_sudo}}'

--- a/quipucords/scanner/network/runner/roles/jboss_brms/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_brms/tasks/main.yml
@@ -7,7 +7,7 @@
 
 # Use locate to look for business-central, decision-central, and kie-server
 - name: find business-central candidates
-  raw: locate --basename business-central | egrep '.*/business-central(.war)?/?$'
+  raw: export LANG=C LC_ALL=C; locate --basename business-central | egrep '.*/business-central(.war)?/?$'
   register: internal_jboss_brms_business_central_candidates_cmd
   ignore_errors: yes
   become: yes
@@ -25,7 +25,7 @@
   when: 'jboss_brms'
 
 - name: find decision-central candidates
-  raw: locate --basename decision-central | egrep '.*/decision-central(.war)?/?$'
+  raw: export LANG=C LC_ALL=C; locate --basename decision-central | egrep '.*/decision-central(.war)?/?$'
   register: internal_jboss_brms_decision_central_candidates
   ignore_errors: yes
   become: yes
@@ -38,7 +38,7 @@
   when: 'jboss_brms'
 
 - name: find kie-server candidates
-  raw: locate --basename 'kie-server*' | egrep --invert-match '(.*.xml)|(.*.jar)'
+  raw: export LANG=C LC_ALL=C; locate --basename 'kie-server*' | egrep --invert-match '(.*.xml)|(.*.jar)'
   register: internal_jboss_brms_kie_server_candidates_cmd
   ignore_errors: yes
   become: yes
@@ -56,7 +56,7 @@
   when: 'jboss_brms'
 
 - name: search filesystem for kie-server candidates
-  raw: find {{search_directories}} -xdev -name kie*.war 2> /dev/null
+  raw: export LANG=C LC_ALL=C; find {{search_directories}} -xdev -name kie*.war 2> /dev/null
   register: internal_jboss_brms_kie_search_candidates_cmd
   ignore_errors: yes
   become: yes
@@ -99,7 +99,7 @@
   when: 'jboss_brms'
 
 - name: cat MANIFEST.MF files
-  raw: cat '{{ item }}/META-INF/MANIFEST.MF' 2>/dev/null
+  raw: export LANG=C LC_ALL=C; cat '{{ item }}/META-INF/MANIFEST.MF' 2>/dev/null
   register: internal_jboss_brms_manifest_mf
   ignore_errors: yes
   become: yes
@@ -112,7 +112,7 @@
   ignore_errors: yes
 
 - name: look for kie-api files inside candidate directories
-  raw: ls -1 "{{ item }}"/WEB-INF/lib/kie-api* 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -1 "{{ item }}"/WEB-INF/lib/kie-api* 2>/dev/null
   register: internal_jboss_brms_kie_in_business_central
   ignore_errors: yes
   become: yes
@@ -125,7 +125,7 @@
   ignore_errors: yes
 
 - name: look for all kie-api files on the system
-  raw: locate --basename 'kie-api*'
+  raw: export LANG=C LC_ALL=C; locate --basename 'kie-api*'
   register: internal_jboss_brms_locate_kie_api
   ignore_errors: yes
   become: yes
@@ -139,7 +139,7 @@
 # Tasks that do filesystem scans. This will scan linux systems for
 # JBoss BRMS or Drools Installations
 - name: Gather jboss.brms.kie-api-ver
-  raw: find {{search_directories}} -xdev -name kie-api* 2> /dev/null | sort -u
+  raw: export LANG=C LC_ALL=C; find {{search_directories}} -xdev -name kie-api* 2> /dev/null | sort -u
   register: internal_jboss_brms_kie_api_ver
   ignore_errors: yes
   become: yes
@@ -151,7 +151,7 @@
   ignore_errors: yes
 
 - name: Gather jboss.brms.drools-core-ver
-  raw: find {{search_directories}} -xdev -name drools-core* 2> /dev/null | sort -u
+  raw: export LANG=C LC_ALL=C; find {{search_directories}} -xdev -name drools-core* 2> /dev/null | sort -u
   register: internal_jboss_brms_drools_core_ver
   ignore_errors: yes
   become: yes
@@ -163,7 +163,7 @@
   ignore_errors: yes
 
 - name: Gather jboss.brms.kie-war-ver
-  raw: OIFS="$IFS"; IFS=$'\n'; for war in $(find {{search_directories}} -xdev -name kie*.war 2> /dev/null); do if [[ -d  "$war" ]]; then cat "$war"/META-INF/MANIFEST.MF 2> /dev/null | grep Implementation-Version | sed "s/Implementation-Version://g" | sed "s/ //g" | sed 's/\r$//' | sort -u; else fgrep -irsal kie-api "$war" | egrep -o "[0-9]\.[0-9]\.[0-9].*-" | sed "s/-$//g" | sed 's/\r$//' | sort -u; fi; done; IFS="$OIFS"
+  raw: export LANG=C LC_ALL=C; OIFS="$IFS"; IFS=$'\n'; for war in $(find {{search_directories}} -xdev -name kie*.war 2> /dev/null); do if [[ -d  "$war" ]]; then cat "$war"/META-INF/MANIFEST.MF 2> /dev/null | grep Implementation-Version | sed "s/Implementation-Version://g" | sed "s/ //g" | sed 's/\r$//' | sort -u; else fgrep -irsal kie-api "$war" | egrep -o "[0-9]\.[0-9]\.[0-9].*-" | sed "s/-$//g" | sed 's/\r$//' | sort -u; fi; done; IFS="$OIFS"
   register: internal_jboss_brms_kie_war_ver
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
@@ -6,7 +6,7 @@
 
 # Tasks that can locate an EAP_HOME directory
 - name: Gather jboss.eap.running-paths
-  raw: for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*" 2>/dev/null); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
+  raw: export LANG=C LC_ALL=C; for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*" 2>/dev/null); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
   register: internal_jboss_eap_running_paths
   ignore_errors: yes
   become: yes
@@ -18,8 +18,8 @@
   ignore_errors: yes
 
 - name: use locate to look for jboss-modules.jar
-  raw: locate jboss-modules.jar | xargs -n 1 --no-run-if-empty dirname
-  register: internal_jboss_eap_locate_jboss_modules_jar 
+  raw: export LANG=C LC_ALL=C; locate jboss-modules.jar | xargs -n 1 --no-run-if-empty dirname
+  register: internal_jboss_eap_locate_jboss_modules_jar
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and internal_have_locate and jboss_eap'
@@ -30,7 +30,7 @@
   ignore_errors: yes
 
 - name: use find to look for jboss-modules.jar
-  raw: find {{search_directories}} -xdev -type f -name jboss-modules.jar 2> /dev/null | xargs -n 1 --no-run-if-empty dirname | sort -u
+  raw: export LANG=C LC_ALL=C; find {{search_directories}} -xdev -type f -name jboss-modules.jar 2> /dev/null | xargs -n 1 --no-run-if-empty dirname | sort -u
   register: internal_jboss_eap_find_jboss_modules_jar
   ignore_errors: yes
   become: yes
@@ -55,7 +55,7 @@
 # Filters that will help us find true EAP_HOME directories
 
 - name: ls EAP_HOME candidates
-  raw: ls -1 "{{ item }}" 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -1 "{{ item }}" 2>/dev/null
   register: internal_eap_home_ls
   ignore_errors: yes
   become: yes
@@ -68,7 +68,7 @@
   ignore_errors: yes
 
 - name: get version.txt from EAP_HOME candidates
-  raw: cat '{{ item }}/version.txt' 2>/dev/null
+  raw: export LANG=C LC_ALL=C; cat '{{ item }}/version.txt' 2>/dev/null
   register: internal_eap_home_version_txt
   ignore_errors: yes
   become: yes
@@ -81,7 +81,7 @@
   ignore_errors: yes
 
 - name: get README.txt from EAP_HOME candidates
-  raw: cat '{{ item }}/README.txt' 2>/dev/null
+  raw: export LANG=C LC_ALL=C; cat '{{ item }}/README.txt' 2>/dev/null
   register: internal_eap_home_readme_txt
   ignore_errors: yes
   become: yes
@@ -98,7 +98,7 @@
 # the user has java. We have both to give ourselves more chances to
 # get the data we need.
 - name: get jboss-modules.jar MANIFEST.MF
-  raw: unzip -p "{{ item }}"/jboss-modules.jar META-INF/MANIFEST.MF 2>/dev/null
+  raw: export LANG=C LC_ALL=C; unzip -p "{{ item }}"/jboss-modules.jar META-INF/MANIFEST.MF 2>/dev/null
   register: internal_eap_home_jboss_modules_manifest
   ignore_errors: yes
   become: yes
@@ -111,7 +111,7 @@
   ignore_errors: yes
 
 - name: get jboss-modules.jar version
-  raw: java -jar "{{ item }}"/jboss-modules.jar -version 2>/dev/null
+  raw: export LANG=C LC_ALL=C; java -jar "{{ item }}"/jboss-modules.jar -version 2>/dev/null
   register: internal_eap_home_jboss_modules_version
   ignore_errors: yes
   become: yes
@@ -126,7 +126,7 @@
 # Look for fuse inside EAP_HOME directories
 
 - name: check JBoss bin directory
-  raw: ls -1 "{{ item }}"/bin 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -1 "{{ item }}"/bin 2>/dev/null
   register: internal_eap_home_bin
   ignore_errors: yes
   become: yes
@@ -139,7 +139,7 @@
   ignore_errors: yes
 
 - name: check JBoss layers.conf
-  raw: cat '{{ item }}/modules/layers.conf' 2>/dev/null
+  raw: export LANG=C LC_ALL=C; cat '{{ item }}/modules/layers.conf' 2>/dev/null
   register: internal_eap_home_layers_conf
   ignore_errors: yes
   become: yes
@@ -152,7 +152,7 @@
   ignore_errors: yes
 
 - name: check JBoss modules/system/layers
-  raw: ls -1 "{{ item }}"/modules/system/layers 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -1 "{{ item }}"/modules/system/layers 2>/dev/null
   register: internal_eap_home_layers
   ignore_errors: yes
   become: yes
@@ -167,7 +167,7 @@
 # Tests that can indicate the presence of EAP, but don't let us
 # automatically locate EAP_HOME
 - name: check for common install files and directories
-  raw: test -e "{{ item }}"
+  raw: export LANG=C LC_ALL=C; test -e "{{ item }}"
   register: internal_jboss_eap_common_files
   ignore_errors: yes
   become: yes
@@ -199,7 +199,7 @@
   ignore_errors: yes
 
 - name: gather jboss.processes
-  raw: ps -A -o comm -o args e --columns 10000 | grep java | grep jboss | grep -v "/usr/bin/grep"
+  raw: export LANG=C LC_ALL=C; ps -A -o comm -o args e --columns 10000 | grep java | grep jboss | grep -v "/usr/bin/grep"
   register: internal_jboss_processes
   ignore_errors: yes
   when: 'jboss_eap'
@@ -210,7 +210,7 @@
   ignore_errors: yes
 
 - name: check for jboss packages
-  raw: rpm -qa --qf "%{NAME}|%{VERSION}|%{RELEASE}|%{INSTALLTIME}|%{VENDOR}|%{BUILDTIME}|%{BUILDHOST}|%{SOURCERPM}|%{LICENSE}|%{PACKAGER}|%{INSTALLTIME:date}|%{BUILDTIME:date}\n" | grep -E '(eap7)|(jbossas)' | sort
+  raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{NAME}|%{VERSION}|%{RELEASE}|%{INSTALLTIME}|%{VENDOR}|%{BUILDTIME}|%{BUILDHOST}|%{SOURCERPM}|%{LICENSE}|%{PACKAGER}|%{INSTALLTIME:date}|%{BUILDTIME:date}\n" | grep -E '(eap7)|(jbossas)' | sort
   register: internal_jboss_eap_packages
   ignore_errors: yes
   when: 'jboss_eap'
@@ -221,7 +221,7 @@
   ignore_errors: yes
 
 - name: check for user 'jboss'
-  raw: id -u jboss
+  raw: export LANG=C LC_ALL=C; id -u jboss
   register: internal_jboss_eap_id_jboss
   ignore_errors: yes
   when: 'jboss_eap'
@@ -232,7 +232,7 @@
   ignore_errors: yes
 
 - name: look for jboss systemd service
-  raw: /usr/bin/systemctl list-unit-files --no-pager
+  raw: export LANG=C LC_ALL=C; /usr/bin/systemctl list-unit-files --no-pager
   register: internal_jboss_eap_systemctl_unit_files
   ignore_errors: yes
   become: yes
@@ -244,7 +244,7 @@
   ignore_errors: yes
 
 - name: look for jboss in chkconfig
-  raw: /sbin/chkconfig --list
+  raw: export LANG=C LC_ALL=C; /sbin/chkconfig --list
   register: internal_jboss_eap_chkconfig
   ignore_errors: yes
   become: yes
@@ -257,7 +257,7 @@
 
 # Scan linux systems for JBoss EAP or Wildfly Installations
 - name: Gather jboss.eap.jar-ver
-  raw: FOUND=""; for jar in `find {{search_directories}} -xdev -name 'jboss-modules.jar' 2>/dev/null | grep -v '\.installation/patches'`; do VERSION=$(java -jar ${jar} -version 2> /dev/null | grep version | sed 's/.*version\s//g'); inode=$(stat -c '%i' "${jar}"); fs=$(df  -T "${jar}" | grep "/dev" | sed 's/ .*//'); ctime=$(stat ${jar} | grep 'Change' | grep -oP '[1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]'); if [ ! -z "${VERSION}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $VERSION**$ctime"; else FOUND=${VERSION}'**'${ctime}; fi; fi; done; echo ${FOUND}
+  raw: export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -xdev -name 'jboss-modules.jar' 2>/dev/null | grep -v '\.installation/patches'`; do VERSION=$(java -jar ${jar} -version 2> /dev/null | grep version | sed 's/.*version\s//g'); inode=$(stat -c '%i' "${jar}"); fs=$(df  -T "${jar}" | grep "/dev" | sed 's/ .*//'); ctime=$(stat ${jar} | grep 'Change' | grep -oP '[1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]'); if [ ! -z "${VERSION}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $VERSION**$ctime"; else FOUND=${VERSION}'**'${ctime}; fi; fi; done; echo ${FOUND}
   register: internal_jboss_eap_jar_ver
   ignore_errors: yes
   become: yes
@@ -269,7 +269,7 @@
   ignore_errors: yes
 
 - name: Gather jboss.eap.run-jar-ver
-  raw: FOUND=""; for jar in `find {{search_directories}} -xdev -name 'run.jar' 2>/dev/null`; do VERSION=$(java -jar ${jar} --version 2> /dev/null | grep build  | sed 's/.*[CS]V[NS]Tag.//g' | sed 's/\sdate.*//g'); inode=$(stat -c '%i' "${jar}"); fs=$(df  -T "${jar}" | tail -1 | sed 's/ .*//'); ctime=$(stat ${jar} | grep 'Change' | grep -oP '[1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]'); if [ ! -z "${VERSION}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $VERSION**${ctime}"; else FOUND=${VERSION}'**'${ctime}; fi; fi; done; echo ${FOUND};
+  raw: export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -xdev -name 'run.jar' 2>/dev/null`; do VERSION=$(java -jar ${jar} --version 2> /dev/null | grep build  | sed 's/.*[CS]V[NS]Tag.//g' | sed 's/\sdate.*//g'); inode=$(stat -c '%i' "${jar}"); fs=$(df  -T "${jar}" | tail -1 | sed 's/ .*//'); ctime=$(stat ${jar} | grep 'Change' | grep -oP '[1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]'); if [ ! -z "${VERSION}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $VERSION**${ctime}"; else FOUND=${VERSION}'**'${ctime}; fi; fi; done; echo ${FOUND};
   register: internal_jboss_eap_run_jar_ver
   ignore_errors: yes
   become: yes
@@ -281,7 +281,7 @@
   ignore_errors: yes
 
 - name: check for activemq version on eap
-  raw: ls -1 '{{ item }}/modules/system/layers/fuse/org/apache/activemq/main' 2>/dev/null | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p' | sed 's/\n//'
+  raw: export LANG=C LC_ALL=C; ls -1 '{{ item }}/modules/system/layers/fuse/org/apache/activemq/main' 2>/dev/null | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p' | sed 's/\n//'
   register: internal_jboss_fuse_on_eap_activemq_ver
   ignore_errors: yes
   become: yes
@@ -294,7 +294,7 @@
   ignore_errors: yes
 
 - name: check modules/system/layers/fuse/org/apache/camel/core/main/ for camel version
-  raw: ls -1 '{{ item }}/modules/system/layers/fuse/org/apache/camel/core/main' 2>/dev/null | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; ls -1 '{{ item }}/modules/system/layers/fuse/org/apache/camel/core/main' 2>/dev/null | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_on_eap_camel_ver
   ignore_errors: yes
   become: yes
@@ -307,7 +307,7 @@
   ignore_errors: yes
 
 - name: check modules/system/layers/base/org/apache/cxf/impl/main for cxf-rt version
-  raw: ls -1 '{{ item }}/modules/system/layers/base/org/apache/cxf/impl/main' 2>/dev/null | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; ls -1 '{{ item }}/modules/system/layers/base/org/apache/cxf/impl/main' 2>/dev/null | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_on_eap_cxf_ver
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_eap5/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_eap5/tasks/main.yml
@@ -14,7 +14,7 @@
 # directories. We will gather more information on the candidates to
 # make a determination.
 - name: locate --ignore-case jboss
-  raw: locate JBossEULA.txt | sed -n -e "s/\(.*\)\/jboss-as\/\(.*\)/\1/gp" | uniq
+  raw: export LANG=C LC_ALL=C; locate JBossEULA.txt | sed -n -e "s/\(.*\)\/jboss-as\/\(.*\)/\1/gp" | uniq
   register: internal_jboss_eap5_locate_jboss_homes
   ignore_errors: yes
   become: yes
@@ -27,7 +27,7 @@
 # It removes the extra '=' and ':'-delimited parts and produces
 # candidate EAP_HOME directories.
 - name: gather jboss.eap.processes
-  raw: ps -A -o comm -o args e --columns 10000 | egrep '^java.*(eap|jboss).*' | tr -s ' =:' '\n' | sed -n -e "s/\(.*\)\/jboss-as\/\(.*\)/\1/gp" | uniq
+  raw: export LANG=C LC_ALL=C; ps -A -o comm -o args e --columns 10000 | egrep '^java.*(eap|jboss).*' | tr -s ' =:' '\n' | sed -n -e "s/\(.*\)\/jboss-as\/\(.*\)/\1/gp" | uniq
   register: internal_jboss_eap5_process_jboss_homes
   ignore_errors: yes
   become: yes
@@ -47,7 +47,7 @@
 # Filters that will help us find true EAP_HOME directories
 
 - name: get version.txt from EAP_HOME candidates
-  raw: cat '{{ item }}/version.txt' 2>/dev/null
+  raw: export LANG=C LC_ALL=C; cat '{{ item }}/version.txt' 2>/dev/null
   register: internal_eap5_home_version_txt
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
@@ -59,7 +59,7 @@
   ignore_errors: yes
 
 - name: get readme.html from EAP_HOME candidates
-  raw: cat '{{ item }}/readme.html' 2>/dev/null
+  raw: export LANG=C LC_ALL=C; cat '{{ item }}/readme.html' 2>/dev/null
   register: internal_eap5_home_readme_html
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
@@ -71,7 +71,7 @@
   ignore_errors: yes
 
 - name: ls EAP_HOME/jboss-as
-  raw: ls -1 '{{ item }}/jboss-as' 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -1 '{{ item }}/jboss-as' 2>/dev/null
   register: internal_eap5_home_ls_jboss_as
   ignore_errors: yes
   with_items: "{{ eap5_home_candidates }}"
@@ -83,7 +83,7 @@
   ignore_errors: yes
 
 - name: EAP_HOME/jboss-as/bin/run.jar
-  raw: java -jar '{{ item }}/jboss-as/bin/run.jar' --version
+  raw: export LANG=C LC_ALL=C; java -jar '{{ item }}/jboss-as/bin/run.jar' --version
   register: internal_eap5_home_run_jar_version
   ignore_errors: yes
   become: yes
@@ -98,7 +98,7 @@
 # This is similar to the previous command, but works even when the EAP
 # installation is broken.
 - name: run.jar manifest
-  raw: unzip -p '{{ item }}/jboss-as/bin/run.jar' META-INF/MANIFEST.MF
+  raw: export LANG=C LC_ALL=C; unzip -p '{{ item }}/jboss-as/bin/run.jar' META-INF/MANIFEST.MF
   register: internal_eap5_home_run_jar_manifest
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_fuse/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_fuse/tasks/main.yml
@@ -7,7 +7,7 @@
 
 # This will scan linux systems for JBoss Fuse, ActiveMQ, CXF, Camel or Community  Installations
 - name: Gather jboss.activemq-ver
-  raw: FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*activemq-\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
+  raw: export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*activemq-\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
   register: internal_jboss_activemq_ver
   ignore_errors: yes
   become: yes
@@ -19,7 +19,7 @@
   ignore_errors: yes
 
 - name: Gather jboss.camel-ver
-  raw: FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*camel-core\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
+  raw: export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*camel-core\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
   register: internal_jboss_camel_ver
   ignore_errors: yes
   become: yes
@@ -31,7 +31,7 @@
   ignore_errors: yes
 
 - name: Gather jboss.cxf-ver
-  raw: FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*cxf-rt\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
+  raw: export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*cxf-rt\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
   register: internal_jboss_cxf_ver
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
@@ -27,12 +27,12 @@
   # xargs -n 1 readlink: normalize home directory paths so the
   # 'unique' below really does deduplicate them.
 
-  raw: ps -A -o args | egrep --invert-match '(^sed)|(\| sed)' | sed -n -e 's/.*-Dkaraf.base=\([^[:space:]]*\).*/\1/pg;s/.*-Dkaraf.home=\([^[:space:]]*\).*/\1/pg' | xargs -n 1 --no-run-if-empty readlink --canonicalize
+  raw: export LANG=C LC_ALL=C; ps -A -o args | egrep --invert-match '(^sed)|(\| sed)' | sed -n -e 's/.*-Dkaraf.base=\([^[:space:]]*\).*/\1/pg;s/.*-Dkaraf.home=\([^[:space:]]*\).*/\1/pg' | xargs -n 1 --no-run-if-empty readlink --canonicalize
   register: internal_karaf_running_processes
   ignore_errors: yes
   when: 'jboss_fuse'
 
-- name: set karaf_running_process fact 
+- name: set karaf_running_process fact
   set_fact:
     karaf_running_processes: "{{ internal_karaf_running_processes }}"
   ignore_errors: yes
@@ -44,25 +44,25 @@
   # to get the KARAF_HOME. Just like the last task, we also use
   # realpath to normalize paths.
 
-  raw: locate karaf.jar | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 --no-run-if-empty readlink --canonicalize
+  raw: export LANG=C LC_ALL=C; locate karaf.jar | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 --no-run-if-empty readlink --canonicalize
   register: internal_karaf_locate_karaf_jar
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and internal_have_locate and jboss_fuse'
 
-- name: set karaf_locate_karaf_jar fact 
+- name: set karaf_locate_karaf_jar fact
   set_fact:
     karaf_locate_karaf_jar: "{{ internal_karaf_locate_karaf_jar }}"
   ignore_errors: yes
 
 - name: Use find to look for karaf.jar
-  raw: find {{search_directories}} -xdev -type f -name karaf.jar 2> /dev/null | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 --no-run-if-empty readlink --canonicalize | sort -u
+  raw: export LANG=C LC_ALL=C; find {{search_directories}} -xdev -type f -name karaf.jar 2> /dev/null | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 --no-run-if-empty readlink --canonicalize | sort -u
   register: internal_karaf_find_karaf_jar
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and jboss_fuse_ext'
 
-- name: set karaf_find_karaf_jar fact 
+- name: set karaf_find_karaf_jar fact
   set_fact:
     karaf_find_karaf_jar: "{{ internal_karaf_find_karaf_jar }}"
   ignore_errors: yes
@@ -81,27 +81,27 @@
 # Look for fuse inside KARAF_HOME directories
 
 - name: check bin/fuse
-  raw: ls -1 "{{ item }}"/bin/fuse 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -1 "{{ item }}"/bin/fuse 2>/dev/null
   register: internal_karaf_home_bin_fuse
   ignore_errors: yes
   become: yes
   with_items: "{{ karaf_homes }}"
   when: 'user_has_sudo and jboss_fuse'
 
-- name: set karaf_home_bin_fuse fact 
+- name: set karaf_home_bin_fuse fact
   set_fact:
     karaf_home_bin_fuse: "{{ internal_karaf_home_bin_fuse }}"
   ignore_errors: yes
 
 - name: check system/org/jboss/fuse
-  raw: ls -1 "{{ item }}"/system/org/jboss 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -1 "{{ item }}"/system/org/jboss 2>/dev/null
   register: internal_karaf_home_system_org_jboss
   ignore_errors: yes
   become: yes
   with_items: "{{ karaf_homes }}"
   when: 'user_has_sudo and jboss_fuse'
 
-- name: set karaf_home_system_org_jboss fact 
+- name: set karaf_home_system_org_jboss fact
   set_fact:
     karaf_home_system_org_jboss: "{{ internal_karaf_home_system_org_jboss }}"
   ignore_errors: yes
@@ -110,50 +110,50 @@
 # KARAF_HOME (or even whether it's Fuse-on-Karaf or Fuse-on-EAP).
 
 - name: look for fuse systemd service
-  raw: /usr/bin/systemctl list-unit-files --no-pager
+  raw: export LANG=C LC_ALL=C; /usr/bin/systemctl list-unit-files --no-pager
   register: internal_jboss_fuse_systemctl_unit_files
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and jboss_fuse and internal_have_systemctl'
 
-- name: set jboss_fuse_systemctl_unit_files fact 
+- name: set jboss_fuse_systemctl_unit_files fact
   set_fact:
     jboss_fuse_systemctl_unit_files: "{{ internal_jboss_fuse_systemctl_unit_files }}"
   ignore_errors: yes
 
 - name: look for fuse in chkconfig
-  raw: /sbin/chkconfig --list
+  raw: export LANG=C LC_ALL=C; /sbin/chkconfig --list
   register: internal_jboss_fuse_chkconfig
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and jboss_fuse and internal_have_chkconfig'
 
-- name: set jboss_fuse_chkconfig fact 
+- name: set jboss_fuse_chkconfig fact
   set_fact:
     jboss_fuse_chkconfig: "{{ internal_jboss_fuse_chkconfig }}"
   ignore_errors: yes
 
 - name: Use locate to look for camel-ver
-  raw: locate camel-core | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; locate camel-core | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_camel_ver
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and internal_have_locate and jboss_fuse'
 
-- name: set jboss_fuse_camel_ver fact 
+- name: set jboss_fuse_camel_ver fact
   set_fact:
     jboss_fuse_camel_ver: "{{ internal_jboss_fuse_camel_ver }}"
   ignore_errors: yes
 
 - name: check /system/org/apache/camel/camel-core for camel-ver
-  raw: ls -1 '{{ item }}/system/org/apache/camel/camel-core' 2>/dev/null | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; ls -1 '{{ item }}/system/org/apache/camel/camel-core' 2>/dev/null | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_on_karaf_camel_ver
   ignore_errors: yes
   become: yes
   with_items: "{{ karaf_homes }}"
   when: 'user_has_sudo and jboss_fuse'
 
-- name: set jboss_fuse_on_karaf_camel_ver fact 
+- name: set jboss_fuse_on_karaf_camel_ver fact
   set_fact:
     jboss_fuse_on_karaf_camel_ver: "{{ internal_jboss_fuse_on_karaf_camel_ver }}"
   ignore_errors: yes
@@ -167,26 +167,26 @@
   when: 'jboss_fuse'
 
 - name: Use locate to look for activemq-ver
-  raw: locate activemq | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; locate activemq | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_activemq_ver
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and internal_have_locate and jboss_fuse'
 
-- name: set jboss_fuse_activemq_ver fact 
+- name: set jboss_fuse_activemq_ver fact
   set_fact:
     jboss_fuse_activemq_ver: "{{ internal_jboss_fuse_activemq_ver }}"
   ignore_errors: yes
 
 - name: check /system/org/apache/activemq/activemq-camel for activemq-ver
-  raw: ls -1 '{{ item }}/system/org/apache/activemq/activemq-camel' 2>/dev/null | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; ls -1 '{{ item }}/system/org/apache/activemq/activemq-camel' 2>/dev/null | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_on_karaf_activemq_ver
   ignore_errors: yes
   become: yes
   with_items: "{{ karaf_homes }}"
   when: 'user_has_sudo and jboss_fuse'
 
-- name: set jboss_fuse_on_karaf_activemq_ver fact 
+- name: set jboss_fuse_on_karaf_activemq_ver fact
   set_fact:
     jboss_fuse_on_karaf_activemq_ver: "{{ internal_jboss_fuse_on_karaf_activemq_ver }}"
   ignore_errors: yes
@@ -200,26 +200,26 @@
   when: 'jboss_fuse'
 
 - name: Use locate to look for cxf-rt-ver
-  raw: locate cxf-rt | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; locate cxf-rt | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_cxf_ver
   ignore_errors: yes
   become: yes
   when: 'user_has_sudo and internal_have_locate and jboss_fuse'
 
-- name: set jboss_fuse_cxf_ver fact 
+- name: set jboss_fuse_cxf_ver fact
   set_fact:
     jboss_fuse_cxf_ver: "{{ internal_jboss_fuse_cxf_ver }}"
   ignore_errors: yes
 
 - name: check /system/org/apache/cxf/cxf-rt-bindings-coloc for cxf-rt
-  raw: ls -1 '{{ item }}/system/org/apache/cxf/cxf-rt-bindings-coloc' 2>/dev/null | grep fuse |sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
+  raw: export LANG=C LC_ALL=C; ls -1 '{{ item }}/system/org/apache/cxf/cxf-rt-bindings-coloc' 2>/dev/null | grep fuse |sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
   register: internal_jboss_fuse_on_karaf_cxf_ver
   ignore_errors: yes
   become: yes
   with_items: "{{ karaf_homes }}"
   when: 'user_has_sudo and jboss_fuse'
 
-- name: set jboss_fuse_on_karaf_cxf_ver fact 
+- name: set jboss_fuse_on_karaf_cxf_ver fact
   set_fact:
     jboss_fuse_on_karaf_cxf_ver: "{{ internal_jboss_fuse_on_karaf_cxf_ver }}"
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -7,21 +7,21 @@
 # ----------------------------- FIND JWS_HOME ---------------------------------
 
 - name: search for folder above TOMCAT_HOME listed in tomcat process
-  raw: ps -ef | grep tomcat | grep java |awk -F"catalina.base=" '{split($2,a," ");print FS a[1]}' |  awk 'BEGIN {FS="/";OFS="/";}{ $1=""; $NF="";print}'
+  raw: export LANG=C LC_ALL=C; ps -ef | grep tomcat | grep java |awk -F"catalina.base=" '{split($2,a," ");print FS a[1]}' |  awk 'BEGIN {FS="/";OFS="/";}{ $1=""; $NF="";print}'
   register: internal_jws_find_home_from_tomcat_process
   ignore_errors: yes
   when: 'jboss_ws'
 
 # Only works if locate is installed
 - name: search for folder above tomcat home with locate
-  raw: locate tomcat?/bin/startup.sh | awk -F 'tomcat' '{print $1}' | head -1
+  raw: export LANG=C LC_ALL=C; locate tomcat?/bin/startup.sh | awk -F 'tomcat' '{print $1}' | head -1
   register: internal_jws_find_home_from_tomcat_file
   ignore_errors: yes
   when: 'user_has_sudo and internal_have_locate and jboss_ws'
 
 # If client has not renamed default JWS_HOME folder and followed recommended zip file install instructions, JWS_HOME should be in /opt.
 - name: search for JWS_HOME in search directories
-  raw: find {{search_directories}} -type d 2>/dev/null | egrep '*(ews|jws)*[0-99]\.[0-99]$'
+  raw: export LANG=C LC_ALL=C; find {{search_directories}} -type d 2>/dev/null | egrep '*(ews|jws)*[0-99]\.[0-99]$'
   register: internal_jws_find_home_from_search
   ignore_errors: yes
   when: 'jboss_ws_ext'
@@ -36,7 +36,7 @@
   when: 'jboss_ws'
 
 - name: ls JWS_HOME
-  raw: ls -d1 "{{ item }}" 2>/dev/null
+  raw: export LANG=C LC_ALL=C; ls -d1 "{{ item }}" 2>/dev/null
   register: internal_jws_find_home
   with_items: "{{ jws_home_candidates }}"
   ignore_errors: yes
@@ -56,7 +56,7 @@
 
 # ------------------------------ DETECT JWS/EWS -------------------------------
 - name: check jws presence with yum
-  raw: yum grouplist jws3 jws3plus jws5 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-99]'
+  raw: export LANG=C LC_ALL=C; yum grouplist jws3 jws3plus jws5 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-99]'
   register: internal_jws_installed_with_rpm
   ignore_errors: yes
   when: 'jboss_ws'
@@ -68,7 +68,7 @@
 
   # If tomcat was installed with a Redhat product, a 'redhat' string can be found in certain files
 - name: determine if tomcat is installed from upstream or as part of redhat product
-  raw: \[ $(grep -iR redhat "{{ jws_home }}"/tomcat[0-99] 2>/dev/null| wc -l) != 0 \] && echo False || echo True
+  raw: export LANG=C LC_ALL=C; \[ $(grep -iR redhat "{{ jws_home }}"/tomcat[0-99] 2>/dev/null| wc -l) != 0 \] && echo False || echo True
   register: internal_tomcat_is_part_of_redhat_product
   ignore_errors: yes
   when: 'jws_home is defined and jboss_ws'
@@ -79,7 +79,7 @@
   ignore_errors: yes
 
 - name: see if JBossEULA.txt exists
-  raw: if [ -f "{{ jws_home }}"/JBossEULA.txt ]; then FOUND="true"; else FOUND="false"; fi; echo ${FOUND}
+  raw: export LANG=C LC_ALL=C; if [ -f "{{ jws_home }}"/JBossEULA.txt ]; then FOUND="true"; else FOUND="false"; fi; echo ${FOUND}
   register: internal_jws_has_eula_txt_file
   ignore_errors: yes
   when: 'jws_home is defined and jboss_ws'
@@ -90,7 +90,7 @@
   ignore_errors: yes
 
 - name: check for jws cert
-  raw: ls /etc/pki/product/185.pem /etc/pki/product-default/185.pem 2>/dev/null | sort -u 
+  raw: export LANG=C LC_ALL=C; ls /etc/pki/product/185.pem /etc/pki/product-default/185.pem 2>/dev/null | sort -u
   register: internal_jws_has_cert
   ignore_errors: yes
   when: 'jboss_ws'
@@ -105,6 +105,7 @@
   # Ver 2.0.1 and below have a unique combination of httpd and tomcat versions
 - name: find JWS version 2 and below
   raw: >
+      export LANG=C LC_ALL=C;
       (echo -n $(."{{ jws_home }}"/httpd/sbin/httpd -v | grep Apache);
       echo $(."{{ jws_home }}"/tomcat*/bin/version.sh
       | grep "Server version"))
@@ -115,7 +116,7 @@
 
   # Ver 3.x.x mentioned in id tags in “TOMCAT_HOME/webapps/docs/changelog.html”
 - name: find JWS version 3.x.x
-  raw: awk -F 'id=' '/JWS/ {print substr($2,16,9)}' "{{ jws_home }}"/tomcat?/webapps/docs/changelog.html 2>/dev/null | grep JWS | head -n1
+  raw: export LANG=C LC_ALL=C; awk -F 'id=' '/JWS/ {print substr($2,16,9)}' "{{ jws_home }}"/tomcat?/webapps/docs/changelog.html 2>/dev/null | grep JWS | head -n1
   register: internal_jws_version_3
   ignore_errors: yes
   when: 'jws_home is defined and jboss_ws'
@@ -125,7 +126,7 @@
   # Ver 5.x.x has version.txt in JWS_HOME when installed with zip file
   # Provides exact version
 - name: find JWS version
-  raw: cat "{{ jws_home }}"/version.txt  2>/dev/null| grep "Red Hat JBoss Web Server"
+  raw: export LANG=C LC_ALL=C; cat "{{ jws_home }}"/version.txt  2>/dev/null| grep "Red Hat JBoss Web Server"
   register: internal_jws_version_5_txtfile
   ignore_errors: yes
   when: 'jws_home is defined and jboss_ws'
@@ -133,7 +134,7 @@
   # Ver 5.x.x has a jws5-tomcat.service unit installed.
   # Only provides major version (5).
 - name: find JWS version 5
-  raw: systemctl status jws5-tomcat.service 2>/dev/null | grep "Apache Tomcat Web" | grep -o jws5
+  raw: export LANG=C LC_ALL=C; systemctl status jws5-tomcat.service 2>/dev/null | grep "Apache Tomcat Web" | grep -o jws5
   register: internal_jws_version_5_systemctl
   ignore_errors: yes
   when: 'internal_have_systemctl and jboss_ws'

--- a/quipucords/scanner/network/runner/roles/memory/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/memory/tasks/main.yml
@@ -7,6 +7,7 @@
 
 - name: Get memory in kb
   raw: |
+    export LANG=C LC_ALL=C;
     set -o pipefail
     cat /proc/meminfo |
     grep MemTotal |

--- a/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "redhat_packages"
 
 - name: check to see if any red hat rpms are installed
-  raw: if [ $(rpm -qa --qf "%{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | wc -l) -gt 0 ]; then echo "Y"; else echo "N"; fi
+  raw: export LANG=C LC_ALL=C; if [ $(rpm -qa --qf "%{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | wc -l) -gt 0 ]; then echo "Y"; else echo "N"; fi
   register: internal_redhat_packages_gpg_is_redhat_cmd
   ignore_errors: yes
   when: internal_have_rpm
@@ -20,7 +20,7 @@
   ignore_errors: yes
 
 - name: gather the number of all installed red hat packages filtered by gpg keys
-  raw: rpm -qa --qf "%{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig}\n" 2> /dev/null | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | wc -l
+  raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig}\n" 2> /dev/null | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | wc -l
   register: internal_redhat_packages_gpg_num_rh_packages
   ignore_errors: yes
   when: internal_have_rpm
@@ -31,7 +31,7 @@
   ignore_errors: yes
 
 - name: gather total number of installed packages
-  raw: rpm -qa | wc -l
+  raw: export LANG=C LC_ALL=C; rpm -qa | wc -l
   register: internal_redhat_packages_all_count
   ignore_errors: yes
   when: internal_have_rpm
@@ -42,7 +42,7 @@
   ignore_errors: yes
 
 - name: gather the last installed red hat package filtered by gpg keys
-  raw: rpm -qa --qf "%{INSTALLTIME} %{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig} |%{NAME}-%{VERSION} Installed:%{INSTALLTIME:date}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | sort -nr | head -n 1 | cut -d"|" -f2
+  raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{INSTALLTIME} %{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig} |%{NAME}-%{VERSION} Installed:%{INSTALLTIME:date}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | sort -nr | head -n 1 | cut -d"|" -f2
   register: internal_redhat_packages_gpg_last_installed
   ignore_errors: yes
   when:
@@ -56,7 +56,7 @@
     internal_have_rpm and redhat_packages_gpg_is_redhat
 
 - name: gather the last built red hat package filtered by gpg keys
-  raw: rpm -qa --qf "%{BUILDTIME} %{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig} |%{NAME}-%{VERSION} Built:%{BUILDTIME:date}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | sort -nr | head -n 1 | cut -d"|" -f2
+  raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{BUILDTIME} %{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig} |%{NAME}-%{VERSION} Built:%{BUILDTIME:date}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | sort -nr | head -n 1 | cut -d"|" -f2
   register: internal_redhat_packages_gpg_last_built
   ignore_errors: yes
   when:
@@ -70,7 +70,7 @@
     internal_have_rpm and redhat_packages_gpg_is_redhat
 
 - name: gather redhat-packages.certs fact
-  raw: ls /etc/pki/product/ /etc/pki/product-default/ 2> /dev/null |grep '.pem' | sort -u | tr '\n' ';'
+  raw: export LANG=C LC_ALL=C; ls /etc/pki/product/ /etc/pki/product-default/ 2> /dev/null |grep '.pem' | sort -u | tr '\n' ';'
   register: internal_redhat_packages_certs
   ignore_errors: yes
 
@@ -80,7 +80,7 @@
   ignore_errors: yes
 
 - name: gather enabled repositories
-  raw: yum repolist enabled 2> /dev/null
+  raw: export LANG=C LC_ALL=C; yum repolist enabled 2> /dev/null
   register: internal_yum_enabled_repolist
   become: yes
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/redhat_release/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/redhat_release/tasks/main.yml
@@ -12,7 +12,7 @@
   ignore_errors: yes
 
 - name: gather internal_redhat_release fact
-  raw: rpm -q --queryformat "%{NAME}\n%{VERSION}\n%{RELEASE}\n" --whatprovides redhat-release
+  raw: export LANG=C LC_ALL=C; rpm -q --queryformat "%{NAME}\n%{VERSION}\n%{RELEASE}\n" --whatprovides redhat-release
   register: internal_redhat_release
   ignore_errors: yes
   when: 'internal_have_rpm'

--- a/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
@@ -6,7 +6,7 @@
 
 # subman_cpu_cpu fact
 - name: gather subman.cpu.cpu(s) fact
-  raw: subscription-manager facts --list | grep '^cpu.cpu(s).' | sed -n -e 's/^.*cpu.cpu(s).\s*//p'
+  raw: export LANG=C LC_ALL=C; subscription-manager facts --list | grep '^cpu.cpu(s).' | sed -n -e 's/^.*cpu.cpu(s).\s*//p'
   register: internal_subman_cpu_cpu_cmd
   ignore_errors: yes
   become: yes
@@ -22,7 +22,7 @@
 
 # subman_cpu_core_per_socket fact
 - name: gather subman.cpu.core(s)_per_socket fact
-  raw: subscription-manager facts --list | grep '^cpu.core(s)_per_socket.' | sed -n -e 's/^.*cpu.core(s)_per_socket.\s*//p'
+  raw: export LANG=C LC_ALL=C; subscription-manager facts --list | grep '^cpu.core(s)_per_socket.' | sed -n -e 's/^.*cpu.core(s)_per_socket.\s*//p'
   register: internal_subman_cpu_core_per_socket_cmd
   ignore_errors: yes
   become: yes
@@ -38,7 +38,7 @@
 
 # subman_cpu_cpu_socket fact
 - name: gather subman.cpu.cpu_socket(s) fact
-  raw: subscription-manager facts --list | grep '^cpu.cpu_socket(s).' | sed -n -e 's/^.*cpu.cpu_socket(s).\s*//p'
+  raw: export LANG=C LC_ALL=C; subscription-manager facts --list | grep '^cpu.cpu_socket(s).' | sed -n -e 's/^.*cpu.cpu_socket(s).\s*//p'
   register: internal_subman_cpu_cpu_socket_cmd
   ignore_errors: yes
   become: yes
@@ -54,7 +54,7 @@
 
 # subman_virt_host_type fact
 - name: gather subman.virt.host_type fact
-  raw: subscription-manager facts --list | grep '^virt.host_type.' | sed -n -e 's/^.*virt.host_type.\s*//p'
+  raw: export LANG=C LC_ALL=C; subscription-manager facts --list | grep '^virt.host_type.' | sed -n -e 's/^.*virt.host_type.\s*//p'
   register: internal_subman_virt_host_type_cmd
   ignore_errors: yes
   become: yes
@@ -69,7 +69,7 @@
 
 # subman_virt_is_guest fact
 - name: gather subman.virt.is_guest fact
-  raw: subscription-manager facts --list | grep '^virt.is_guest.' | sed -n -e 's/^.*virt.is_guest.\s*//p'
+  raw: export LANG=C LC_ALL=C; subscription-manager facts --list | grep '^virt.is_guest.' | sed -n -e 's/^.*virt.is_guest.\s*//p'
   register: internal_subman_virt_is_guest_cmd
   ignore_errors: yes
   become: yes
@@ -86,7 +86,7 @@
 
 # subman_virt_uuid fact
 - name: gather subman.virt.uuid fact
-  raw: subscription-manager facts --list 2>/dev/null | grep '^virt.uuid.' | sed -n -e 's/^.*virt.uuid.\s*//p'
+  raw: export LANG=C LC_ALL=C; subscription-manager facts --list 2>/dev/null | grep '^virt.uuid.' | sed -n -e 's/^.*virt.uuid.\s*//p'
   register: internal_subman_virt_uuid_cmd
   ignore_errors: yes
   become: yes
@@ -102,7 +102,7 @@
 
 # subman_overall_status fact
 - name: gather subman.overall.status fact
-  raw: LANG=C subscription-manager status | grep -e 'Overall Status:'| cut -d ":" -f2
+  raw: export LANG=C LC_ALL=C; subscription-manager status | grep -e 'Overall Status:'| cut -d ":" -f2
   register: internal_subman_overall_status_cmd
   ignore_errors: yes
   become: yes
@@ -120,7 +120,7 @@
 
 # subman fact
 - name: gather subman.has_facts_file fact
-  raw: ls /etc/rhsm/facts 2>/dev/null | grep .facts | wc -l
+  raw: export LANG=C LC_ALL=C; ls /etc/rhsm/facts 2>/dev/null | grep .facts | wc -l
   register: internal_subman_facts_file_lines
   ignore_errors: yes
   when: 'internal_have_subscription_manager'
@@ -138,7 +138,7 @@
 
 # subman_consumed fact
 - name: gather internal_subman_consumed
-  raw: subscription-manager list --consumed 2>/dev/null | grep -e '^SKU' -e '^Subscription Name' | sed -n -e 's/SKU\s*.\s*//p' -e 's/Subscription Name\s*.\s*//p' | awk '{ ORS = (NR%2 ? " - " {{":"}} RS) } 1'
+  raw: export LANG=C LC_ALL=C; subscription-manager list --consumed 2>/dev/null | grep -e '^SKU' -e '^Subscription Name' | sed -n -e 's/SKU\s*.\s*//p' -e 's/Subscription Name\s*.\s*//p' | awk '{ ORS = (NR%2 ? " - " {{":"}} RS) } 1'
   register: internal_subman_consumed
   ignore_errors: yes
   become: yes
@@ -152,7 +152,8 @@
 #  subscription_manager_id fact
 - name: gather subscription_manager_id fact
   raw: |
-    subscription-manager identity 2>/dev/null | 
+    export LANG=C LC_ALL=C;
+    subscription-manager identity 2>/dev/null |
     grep 'system identity:' |
     sed 's/system identity:\s*//'
   register: internal_subscription_manager_id_cmd

--- a/quipucords/scanner/network/runner/roles/system_purpose/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/system_purpose/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "system_purpose"
 
 - name: gather internal_system_purpose_json
-  raw: if [ -f /etc/rhsm/syspurpose/syspurpose.json ] ; then cat /etc/rhsm/syspurpose/syspurpose.json 2>/dev/null; fi
+  raw: export LANG=C LC_ALL=C; if [ -f /etc/rhsm/syspurpose/syspurpose.json ] ; then cat /etc/rhsm/syspurpose/syspurpose.json 2>/dev/null; fi
   register: internal_system_purpose_json
   ignore_errors: yes
 

--- a/quipucords/scanner/network/runner/roles/uname/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/uname/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "uname"
 
 - name: gather internal_uname_os fact
-  raw: uname -s
+  raw: export LANG=C LC_ALL=C; uname -s
   register: internal_uname_os
   ignore_errors: yes
 
@@ -15,7 +15,7 @@
   ignore_errors: yes
 
 - name: gather internal_uname_hostname fact
-  raw: uname -n
+  raw: export LANG=C LC_ALL=C; uname -n
   register: internal_uname_hostname
   ignore_errors: yes
 
@@ -25,7 +25,7 @@
   ignore_errors: yes
 
 - name: gather internal_uname_processor fact
-  raw: uname -p
+  raw: export LANG=C LC_ALL=C; uname -p
   register: internal_uname_processor
   ignore_errors: yes
 
@@ -35,7 +35,7 @@
   ignore_errors: yes
 
 - name: gather internal_uname_kernel fact
-  raw: uname -r
+  raw: export LANG=C LC_ALL=C; uname -r
   register: internal_uname_kernel
   ignore_errors: yes
 
@@ -45,7 +45,7 @@
   ignore_errors: yes
 
 - name: gather internal_uname_all fact
-  raw: uname -a
+  raw: export LANG=C LC_ALL=C; uname -a
   register: internal_uname_all
   ignore_errors: yes
 
@@ -55,7 +55,7 @@
   ignore_errors: yes
 
 - name: gather internal_uname_hardware_platform fact
-  raw: uname -i
+  raw: export LANG=C LC_ALL=C; uname -i
   register: internal_uname_hardware_platform
   ignore_errors: yes
 

--- a/quipucords/scanner/network/runner/roles/user_data/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/user_data/tasks/main.yml
@@ -6,7 +6,7 @@
 
 # Facts to gather last 25 logins
 - name: gather user_login_history data fact
-  raw: last -25
+  raw: export LANG=C LC_ALL=C; last -25
   register: internal_user_login_history_cmd
   ignore_errors: yes
   become: yes
@@ -23,7 +23,7 @@
 
 # Facts to determine number of users
 - name: gather etc/passwd data fact
-  raw: cat /etc/passwd
+  raw: export LANG=C LC_ALL=C; cat /etc/passwd
   register: internal_system_user_count_cmd
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "virt"
 
 - name: check if privcmd exists
-  raw: if [ -e /proc/xen/privcmd ]; then echo "Y"; else echo "N"; fi
+  raw: export LANG=C LC_ALL=C; if [ -e /proc/xen/privcmd ]; then echo "Y"; else echo "N"; fi
   register: internal_xen_privcmd_found_cmd
   ignore_errors: yes
 
@@ -15,7 +15,7 @@
   ignore_errors: yes
 
 - name: check if kvm exists
-  raw: if [ -e /dev/kvm ]; then echo "Y"; else echo "N"; fi
+  raw: export LANG=C LC_ALL=C; if [ -e /dev/kvm ]; then echo "Y"; else echo "N"; fi
   register: internal_kvm_found_cmd
   ignore_errors: yes
 
@@ -25,7 +25,7 @@
   ignore_errors: yes
 
 - name: check for xen guests
-  raw: ps aux | grep xend | grep -v grep | wc -l
+  raw: export LANG=C LC_ALL=C; ps aux | grep xend | grep -v grep | wc -l
   register: internal_xen_guest_cmd
   ignore_errors: yes
 
@@ -35,7 +35,7 @@
   ignore_errors: yes
 
 - name: set system manufacturer
-  raw: /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
+  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
   register: internal_sys_manufacturer_cmd
   become: yes
   ignore_errors: yes
@@ -47,7 +47,7 @@
   ignore_errors: yes
 
 - name: check cpu model name for QEMU
-  raw: model_name=$(cat /proc/cpuinfo 2>/dev/null | grep '^model name\s*:' | sed -n -e 's/^.*model name\s*:\s//p'); if [[ $model_name == *QEMU ]]; then echo "Y"; else echo "N"; fi
+  raw: export LANG=C LC_ALL=C; model_name=$(cat /proc/cpuinfo 2>/dev/null | grep '^model name\s*:' | sed -n -e 's/^.*model name\s*:\s//p'); if [[ $model_name == *QEMU ]]; then echo "Y"; else echo "N"; fi
   register: internal_cpu_model_name_kvm_cmd
   ignore_errors: yes
 
@@ -67,7 +67,7 @@
   ignore_errors: yes
 
 - name: gather internal_virt_num_guests fact
-  raw: virsh -c qemu:///system --readonly list --all | wc -l
+  raw: export LANG=C LC_ALL=C; virsh -c qemu:///system --readonly list --all | wc -l
   register: internal_virt_num_guests
   ignore_errors: yes
   when: 'internal_have_virsh'
@@ -83,7 +83,7 @@
   ignore_errors: yes
 
 - name: gather virt.num_running_guests fact
-  raw: virsh -c qemu:///system --readonly list --uuid | wc -l
+  raw: export LANG=C LC_ALL=C; virsh -c qemu:///system --readonly list --uuid | wc -l
   register: internal_virt_num_running_guests
   ignore_errors: yes
   when: 'internal_have_virsh'

--- a/quipucords/scanner/network/runner/roles/virt_what/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/virt_what/tasks/main.yml
@@ -11,7 +11,7 @@
   when: 'not internal_have_virt_what'
 
 - name: execute virt-what
-  raw: virt-what;echo $?
+  raw: export LANG=C LC_ALL=C; virt-what;echo $?
   register: internal_virt_what_output
   ignore_errors: yes
   become: yes


### PR DESCRIPTION
This should help make commands use a consistent locale since we can't trust the system default and we can't reliably set locale on the SSH connection.

Relates to JIRA: DISCOVERY-244
https://issues.redhat.com/browse/DISCOVERY-244

---

It feels ugly, but I confirmed locally it works. 🤷 

Note that I'm using `export` as a separate command instead of prefixing individual program commands with variables. I chose this approach because in _some_ of our `raw` commands, we execute _multiple_ programs, and each of them might need their own copy of these variables. By simply exporting to the environment at the start of each `raw`, we cover _all_ of its commands, and we have a single consistent pattern applied everywhere.

How did I test this? I started a RHEL9 EC2 instance, and I performed the following changes to it before starting a network scan. I think this is all the relevant commands I ran; this was a messy manual process as I was experimenting to make a "badly configured" target system.

```
sudo dnf install glibc-langpack-es
sudo localectl set-locale LANG=es_US
sudo dnf remove glibc-langpack-en
sudo vim /etc/profile.d/lang.sh
:%s/C.UTF-8/es_US/
:%s/en_US.UTF-8/es_US/
:%s/en_US.UTF-8/es_US/
:x
sudo reboot
```

After the VM restarted, I SSHed back into it and confirmed that `es_US` was the default locale.
```
$ id -u jboss
id: �jboss�: no existe ese usuario
```

I also checked `/etc/ssh/sshd_config` to see if connections were allowed to set `LANG` or `LC_*` variables, and it did not. You should check your `/etc/ssh/sshd_config`, remove or comment out anything like `AcceptEnv LANG LC_*`, then `sudo service sshd restart`, and reconnect any SSH sessions.