### PR TITLE
Support admin password specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ help:
 	@echo "  swagger-valid                 to run swagger-cli validation"
 	@echo "  setup-postgres                to create a default postgres container"
 	@echo "  server-init                   to run server initializion steps"
+	@echo "  server-set-superuser          to create or update the superuser"
 	@echo "  serve                         to run the server with default db"
 	@echo "  serve-swagger                 to run the openapi/swagger ui for quipucords"
 	@echo "  build-ui                      to build ui and place result in django server"

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ QPC_DBMS=sqlite
 ## Initializing the Server
 
 ```
+export QPC_SERVER_PASSWORD="SuperAdmin1"
 make server-init
 ```
 
-Both of the above commands create a superuser with name `admin` and password of `qpcpassw0rd`.
+Both of the above commands create a superuser with name `admin` and password of `SuperAdmin1`.
 
 ## Running the Server
 Currently, quipucords needs quipucords-ui to run. In order to get it's latest version, run

--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ QPC_DBMS=sqlite
 ## Initializing the Server
 
 ```
-export QPC_SERVER_PASSWORD="SuperAdmin1"
-make server-init
+make server-init QPC_SERVER_PASSWORD="SuperAdmin1"
 ```
 
 Both of the above commands create a superuser with name `admin` and password of `SuperAdmin1`.
@@ -134,6 +133,15 @@ If you intend to run on Mac OS, there are several more steps that are required.
     export LDFLAGS="-I$(brew --prefix)/opt/openssl/include -L$(brew --prefix)/opt/openssl/lib"
     poetry install
     ```
+
+## Updating the superuser's password
+
+```
+make server-set-superuser QPC_SERVER_PASSWORD="SuperAdmin2"
+```
+
+The above command updates the `admin` superuser password to `SuperAdmin2`.
+
 
 ## Linting
 To lint changes that are made to the source code, run the following command:

--- a/deploy/entrypoint_web.sh
+++ b/deploy/entrypoint_web.sh
@@ -13,4 +13,8 @@ else
 fi
 
 make server-migrate server-set-superuser -C /app
-gunicorn quipucords.wsgi -c $GUNICORN_CONF
+# We only start the server if both the DB
+# migration succeeds and the superuser is created.
+if [ $? -eq 0 ]; then
+    gunicorn quipucords.wsgi -c $GUNICORN_CONF
+fi

--- a/deploy/rejected_common_passwords.txt
+++ b/deploy/rejected_common_passwords.txt
@@ -1,1 +1,2 @@
 qpcpassw0rd
+dscpassw0rd

--- a/deploy/rejected_common_passwords.txt
+++ b/deploy/rejected_common_passwords.txt
@@ -1,0 +1,1 @@
+qpcpassw0rd

--- a/deploy/setup_user.py
+++ b/deploy/setup_user.py
@@ -1,8 +1,10 @@
 """Setup admin user for quipucords server."""
 
 import os
+import sys
 
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, password_validation
+from django.core.exceptions import ValidationError
 
 from quipucords.user import create_random_password
 
@@ -13,12 +15,28 @@ QPC_SERVER_USER_EMAIL = os.environ.get("QPC_SERVER_USER_EMAIL", "admin@example.c
 QPC_SERVER_PASSWORD = os.environ.get("QPC_SERVER_PASSWORD")
 
 
+def validate_server_password(password):
+    """Validate the server password specified."""
+    # We want to make sure the server password specified passes our password validators.
+    # If validation fails, let's display the errors for the failed validations
+    # and trigger a failure exit.
+    try:
+        password_validation.validate_password(password)
+    except ValidationError as error:
+        print("Invalid server password specified:", file=sys.stderr)
+        for err in error:
+            print(f"- {err}", file=sys.stderr)
+        sys.exit(1)
+
+
 ADMIN_NOT_PRESENT = User.objects.filter(username=QPC_SERVER_USERNAME).count() == 0
 
 if ADMIN_NOT_PRESENT:
     use_random_password = not QPC_SERVER_PASSWORD
     if use_random_password:
         QPC_SERVER_PASSWORD = create_random_password()
+    else:
+        validate_server_password(QPC_SERVER_PASSWORD)
     User.objects.create_superuser(
         QPC_SERVER_USERNAME, QPC_SERVER_USER_EMAIL, QPC_SERVER_PASSWORD
     )
@@ -33,6 +51,7 @@ elif QPC_SERVER_PASSWORD:
     # Note: If the QPC_SERVER_PASSWORD is specified, that may be coming to us
     # from an OpenShift or Kubernetes secret, we need to update the admin password
     # accordingly.
+    validate_server_password(QPC_SERVER_PASSWORD)
     user = User.objects.get(username=QPC_SERVER_USERNAME)
     user.set_password(QPC_SERVER_PASSWORD)
     user.save()

--- a/deploy/setup_user.py
+++ b/deploy/setup_user.py
@@ -4,18 +4,38 @@ import os
 
 from django.contrib.auth import get_user_model
 
+from quipucords.user import create_random_password
+
 User = get_user_model()
 
 QPC_SERVER_USERNAME = os.environ.get("QPC_SERVER_USERNAME", "admin")
 QPC_SERVER_USER_EMAIL = os.environ.get("QPC_SERVER_USER_EMAIL", "admin@example.com")
-QPC_SERVER_PASSWORD = os.environ.get("QPC_SERVER_PASSWORD", "qpcpassw0rd")
+QPC_SERVER_PASSWORD = os.environ.get("QPC_SERVER_PASSWORD")
+
 
 ADMIN_NOT_PRESENT = User.objects.filter(username=QPC_SERVER_USERNAME).count() == 0
 
 if ADMIN_NOT_PRESENT:
+    use_random_password = not QPC_SERVER_PASSWORD
+    if use_random_password:
+        QPC_SERVER_PASSWORD = create_random_password()
     User.objects.create_superuser(
         QPC_SERVER_USERNAME, QPC_SERVER_USER_EMAIL, QPC_SERVER_PASSWORD
     )
-    print(f"Created user {QPC_SERVER_USERNAME}")
+    if use_random_password:
+        print(
+            f"Created user {QPC_SERVER_USERNAME}"
+            f" with random password {QPC_SERVER_PASSWORD}"
+        )
+    else:
+        print(f"Created user {QPC_SERVER_USERNAME}")
+elif QPC_SERVER_PASSWORD:
+    # Note: If the QPC_SERVER_PASSWORD is specified, that may be coming to us
+    # from an OpenShift or Kubernetes secret, we need to update the admin password
+    # accordingly.
+    user = User.objects.get(username=QPC_SERVER_USERNAME)
+    user.set_password(QPC_SERVER_PASSWORD)
+    user.save()
+    print(f"User {QPC_SERVER_USERNAME} already exists, updated password")
 else:
     print(f"User {QPC_SERVER_USERNAME} already exists")

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -221,31 +221,35 @@ elif QPC_DBMS == "postgres":
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
-NAME = "NAME"
-USER_ATTRIBUTE_SIMILARITY_VALIDATOR = (
-    "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-)
-MINIMUM_LENGTH_VALIDATOR = (
-    "django.contrib.auth.password_validation.MinimumLengthValidator"
-)
-COMMON_PASSWORD_VALIDATOR = (
-    "django.contrib.auth.password_validation.CommonPasswordValidator"  # noqa: S105
-)
-NUMERIC_PASSWORD_VALIDATOR = (
-    "django.contrib.auth.password_validation.NumericPasswordValidator"  # noqa: S105
-)
+VALIDATOR_MODULE = "django.contrib.auth.password_validation"
+# Note: User.objects.make_random_password minimum length is 10 vs the default
+#       for the MinimumLengthValidator is 8. let's declare it here for consistency.
+QPC_MINIMUM_PASSWORD_LENGTH = 10
 AUTH_PASSWORD_VALIDATORS = [
     {
-        NAME: USER_ATTRIBUTE_SIMILARITY_VALIDATOR,
+        "NAME": f"{VALIDATOR_MODULE}.UserAttributeSimilarityValidator",
     },
     {
-        NAME: MINIMUM_LENGTH_VALIDATOR,
+        "NAME": f"{VALIDATOR_MODULE}.MinimumLengthValidator",
+        "OPTIONS": {
+            "min_length": QPC_MINIMUM_PASSWORD_LENGTH,
+        },
     },
     {
-        NAME: COMMON_PASSWORD_VALIDATOR,
+        "NAME": f"{VALIDATOR_MODULE}.CommonPasswordValidator",  # noqa: S105
     },
     {
-        NAME: NUMERIC_PASSWORD_VALIDATOR,
+        # Let's reject additional common passwords for Quipucords
+        "NAME": f"{VALIDATOR_MODULE}.CommonPasswordValidator",  # noqa: S105
+        "OPTIONS": {
+            "password_list_path": BASE_DIR
+            / ".."
+            / "deploy"
+            / "rejected_common_passwords.txt"
+        },
+    },
+    {
+        "NAME": f"{VALIDATOR_MODULE}.NumericPasswordValidator",  # noqa: S105
     },
 ]
 

--- a/quipucords/quipucords/user.py
+++ b/quipucords/quipucords/user.py
@@ -1,0 +1,9 @@
+"""Utilities for User management."""
+
+from django.conf import settings
+from django.contrib.auth.models import User
+
+
+def create_random_password():
+    """Create a random password for a User."""
+    return User.objects.make_random_password(settings.QPC_MINIMUM_PASSWORD_LENGTH)

--- a/quipucords/tests/quipucords/test_user.py
+++ b/quipucords/tests/quipucords/test_user.py
@@ -38,10 +38,15 @@ class TestUserPasswordValidators:
         with pytest.raises(ValidationError, match="This password is too common"):
             password_validation.validate_password("hello")
 
-    def test_reject_qpc_common_words(self):
+    def test_reject_qpc_common_words_qpc(self):
         """Test that we reject quipucords common words."""
         with pytest.raises(ValidationError, match="This password is too common"):
             password_validation.validate_password("qpcpassw0rd")
+
+    def test_reject_qpc_common_words_dsc(self):
+        """Test that we reject quipucords common words."""
+        with pytest.raises(ValidationError, match="This password is too common"):
+            password_validation.validate_password("dscpassw0rd")
 
     def test_reject_all_numeric(self):
         """Test that we reject all numeric passwords."""

--- a/quipucords/tests/quipucords/test_user.py
+++ b/quipucords/tests/quipucords/test_user.py
@@ -1,0 +1,60 @@
+"""Test user module."""
+
+import re
+
+import pytest
+from django.contrib.auth import get_user_model, password_validation
+from django.core.exceptions import ValidationError
+
+from quipucords import settings
+from quipucords.user import create_random_password
+
+User = get_user_model()
+
+
+class TestUserRandomPasswords:
+    """Tests to verify user module functions."""
+
+    def test_create_random_password_size(self):
+        """Test user random password is minimum size."""
+        assert len(create_random_password()) == settings.QPC_MINIMUM_PASSWORD_LENGTH
+
+    def test_create_random_password_includes_allowed_characters(self):
+        """Test user random password includes only allowed characters."""
+        random_password = create_random_password()
+        assert re.search("[a-zA-Z0-9]*", random_password).group() == random_password
+
+
+class TestUserPasswordValidators:
+    """Tests the user password validators that we imposed."""
+
+    def test_minimum_size(self):
+        """Test that we impose a minimum size."""
+        with pytest.raises(ValidationError, match="This password is too short"):
+            password_validation.validate_password("hjK4")
+
+    def test_reject_common_words(self):
+        """Test that we reject common words."""
+        with pytest.raises(ValidationError, match="This password is too common"):
+            password_validation.validate_password("hello")
+
+    def test_reject_qpc_common_words(self):
+        """Test that we reject quipucords common words."""
+        with pytest.raises(ValidationError, match="This password is too common"):
+            password_validation.validate_password("qpcpassw0rd")
+
+    def test_reject_all_numeric(self):
+        """Test that we reject all numeric passwords."""
+        with pytest.raises(ValidationError, match="This password is entirely numeric"):
+            password_validation.validate_password("9812319372384")
+
+    @pytest.mark.django_db
+    def test_reject_user_attribute_similarities(self):
+        """Test that we reject passwords that are similar to user attributes."""
+        test_user = User.objects.create_superuser(
+            "test", "test@example.com", "Pass1234User"
+        )
+        with pytest.raises(
+            ValidationError, match="The password is too similar to the username"
+        ):
+            password_validation.validate_password("test", user=test_user)

--- a/quipucords/tests/quipucords/test_user.py
+++ b/quipucords/tests/quipucords/test_user.py
@@ -33,20 +33,11 @@ class TestUserPasswordValidators:
         with pytest.raises(ValidationError, match="This password is too short"):
             password_validation.validate_password("hjK4")
 
-    def test_reject_common_words(self):
+    @pytest.mark.parametrize("password", ["hello", "qpcpassw0rd", "dscpassw0rd"])
+    def test_reject_common_words(self, password):
         """Test that we reject common words."""
         with pytest.raises(ValidationError, match="This password is too common"):
-            password_validation.validate_password("hello")
-
-    def test_reject_qpc_common_words_qpc(self):
-        """Test that we reject quipucords common words."""
-        with pytest.raises(ValidationError, match="This password is too common"):
-            password_validation.validate_password("qpcpassw0rd")
-
-    def test_reject_qpc_common_words_dsc(self):
-        """Test that we reject quipucords common words."""
-        with pytest.raises(ValidationError, match="This password is too common"):
-            password_validation.validate_password("dscpassw0rd")
+            password_validation.validate_password(password)
 
     def test_reject_all_numeric(self):
         """Test that we reject all numeric passwords."""


### PR DESCRIPTION
  - Eliminating the default admin password and relying on the users to specify their default via the environment variable QPC_SERVER_PASSWORD (which also supports the OpenShift/Kubernetes secret declared ones).
  - If not specified, we generate a random password for the user and provide it to them upon creation.
  - When the secret is specified via QPC_SERVER_PASSWORD (either coming from OpenShift or from bash), we also allow the users to update the admin password
 
During server initialization:

```
$ make server-init QPC_SERVER_PASSWORD="SuperAdmin1"
```

As well as any point in time:

```
$ make set-superuser QPC_SERVER_PASSWORD="NewAdminPassword2"
```

When initially creating the superuser and no QPC_SERVER_PASSWORD is specified, a random password is generated:

```
$ make server-init
/Users/abellotti/Library/Caches/pypoetry/virtualenvs/quipucords-WveDg5-x-py3.11/bin/python quipucords/manage.py migrate --settings quipucords.settings -v 3
Operations to perform:
  Apply all migrations: admin, api, auth, authtoken, contenttypes, sessions
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application auth
...
cat ./deploy/setup_user.py | /Users/abellotti/Library/Caches/pypoetry/virtualenvs/quipucords-WveDg5-x-py3.11/bin/python quipucords/manage.py shell --settings quipucords.settings -v 3
Created user admin with random password W2QGYfUUm6
```

With the last line above showing the newly generated password.


Draft for now, needs:
- [x] more testing
- [x] testing from OpenShift instrumenting definiting QPC_SERVER_PASSWORD from a Secret.
- [x] testing/updating camayoc to make sure a QPC_SERVER_PASSWORD is specified and appropriately updated in the camayoc config.yml
- [x] tests added
- [x] verify with enhanced deployer https://github.com/quipucords/quipucords-deployer/pull/22

This PR resolves: https://issues.redhat.com/browse/DISCOVERY-409

A separate issue and PR(s) would be needed for supporting the user password updates via the API (and as a follow-up via the Qpc CLI and finally the quipucords-ui).