### PR TITLE
update instructions for building quipucords containers from source and running in podman

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -122,6 +122,8 @@ So, you should proceed with this option _only_ if you really know what you are d
 
 2. Build the UI in the quipucords directory. See [quipucords-ui installation instructions](https://github.com/quipucords/quipucords-ui) for additional setup information. You must have NodeJS and yarn installed.
 
+   Even though the quipucords `Dockerfile` has instructions to fetch the latest UI assets from GitHub, this step requires you to rebuild the assets locally on your host because the `docker-compose.yml` file instructs the container to mount your host's code into `/app`, and that mounted directory effectively overwrites the existing UI assets that were in the container image.
+
    On Linux:
    ```
    cd quipucords


### PR DESCRIPTION
The intent of this update is simply to modernize and correct errors with the existing documentation. Yes, we will eventually drop compose in favor of something else, and we should consider exposing more of the recently added environment variables, but neither of those is within the scope of this update. I'm simply preserving existing functionality and expectations and making sure the instructions actually work for new users.

Throughout and after making these updates, I have been periodically destroying and rebuilding images and containers (following the updated instructions) to confirm they actually work. Disclaimer: I'm on an Intel (x86-64) Mac, and I cannot currently confirm that the instructions work for Linux or other CPU architectures. I left the Linux-specific instructions largely intact, though, and expect that if they worked before, they should still work after this edit.