### PR TITLE
test: drop test-integration from github test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
             lint,
             check-db-migrations-needed,
             test-coverage,
-            test-integration,
             test-sudo-list,
           ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Dropping `test-integration` due to the recent mysterious failures that we have not been able to explain or reproduce locally.

I also removed `test-integration` from GitHub's required PR checks on https://github.com/quipucords/quipucords/settings/branch_protection_rules/1091609.

Discussion thread: https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1699382962577379