### PR TITLE
Port 1.4 changes to main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quipucords"
-version = "1.4.3"
+version = "1.4.4"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 authors = ["Quipucords Dev Team <quipucords@redhat.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quipucords"
-version = "1.4.2"
+version = "1.4.3"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 authors = ["Quipucords Dev Team <quipucords@redhat.com>"]
 readme = "README.md"


### PR DESCRIPTION
Pulling these commits in from the `release/1.4` branch.

* f9c80cb3
* 177c0673
* 6c7fee6b

I used `cherry-pick` because the branches have diverged enough that `rebase` attempts to duplicate commits that were originally made in `main` but also ported to `release/1.4`.