### PR TITLE
Make Jenkins agent labels consistent with internally defined jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library("smqe-shared-lib@master") _
 
-node("discovery_ci") {
+node("discovery_ci && fedora") {
     stage("Setup test environment") {
         echo "Setting up Quipucords PR tests"
         discoveryLib.setupCIEnv()


### PR DESCRIPTION
As we might get RHEL agents in the future (once qpc RPM is available), it might be necessary to be more specific when selecting agent machine - i.e. run something else on RHEL than on Fedora. This change ensures that Fedora job is not mistakenly picked up by RHEL agent.