### PR TITLE
Add required params to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,13 @@
 @Library("smqe-shared-lib@master") _
 
+properties([
+    parameters([
+        booleanParam(defaultValue: true, name: 'TEST_API'),
+        booleanParam(defaultValue: true, name: 'TEST_CLI'),
+        booleanParam(defaultValue: true, name: 'TEST_UI')
+    ])
+])
+
 node("discovery_ci && fedora") {
     stage("Setup test environment") {
         echo "Setting up Quipucords PR tests"


### PR DESCRIPTION
The new pipeline skips execution if you didn't select any of API, CLI and UI. This is to not waste too much time in badly-configured standalone jobs.

But these params aren't set in PR-triggered runs, either, causing all PR pipelines to quickly finish; what's worse - they would appear as if they were successful.

Let's see if I put this directive in right place.