### PR TITLE
chore: sort environment variables when logging.

### DIFF
--- a/quipucords/quipucords/environment.py
+++ b/quipucords/quipucords/environment.py
@@ -99,7 +99,7 @@ def log_all_environment_variables():
         env_list.append(env)
     mark = "-" * 20
     logger.info("%s BEGIN ENVIRONMENT VARIABLES %s", mark, mark)
-    logger.info("\n".join(env_list))
+    logger.info("\n".join(sorted(env_list)))
     logger.info("%s END ENVIRONMENT VARIABLES %s", mark, mark)
 
 


### PR DESCRIPTION
- When user selects to dump the environment variables via the boolean QPC_LOG_ALL_ENV_VARS_AT_STARTUP at start-up, let's sort them as it is tedious to find a variable by name otherwise.