### PR TITLE
feat: Add support for bulk deleting credentials

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -234,6 +234,35 @@ paths:
           description: "Not authorized"
         404:
           description: "Credential not found"
+  /credentials/bulk_delete/:
+    post:
+      tags:
+        - "Credential"
+      summary: "Bulk delete credentials"
+      description: "Bulk delete credentials by ids"
+      operationId: "bulkDeleteCredentials"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of Credential Ids to delete"
+        required: true
+        schema:
+          $ref: "#/definitions/CredentialIds"
+      responses:
+        200:
+          description: "Credentials deleted"
+        400:
+          description: "Invalid input"
+        401:
+          description: "Not authorized"
+        404:
+          description: "Credential not found"
+        422:
+          description: "Unprocessable Entity"
   /sources/:
     post:
       tags:
@@ -1318,6 +1347,18 @@ definitions:
             items:
               $ref: "#/definitions/CredentialOut"
             description: "The paginated credentials"
+  CredentialIds:
+    type: "object"
+    required:
+      - ids
+    properties:
+      ids:
+        type: "array"
+        items:
+          type: "integer"
+          format: "int64"
+        example: [141,165,222]
+        description: "The list of credentials ids"
   DeletionError:
     type: "object"
     required:

--- a/quipucords/api/common/util.py
+++ b/quipucords/api/common/util.py
@@ -188,3 +188,8 @@ def expand_scanjob_with_times(scanjob, connect_only=False):  # noqa: PLR0912, C9
                 status_details[task_key] = task.status_message
 
     return job_json
+
+
+def ids_to_str(id_list):
+    """Convert a list of ids to a comma seperated string of sorted ids."""
+    return ",".join([str(i) for i in sorted(id_list)])

--- a/quipucords/api/exceptions.py
+++ b/quipucords/api/exceptions.py
@@ -1,7 +1,16 @@
 """Quipucords API exceptions."""
 
+from django.utils.translation import gettext_lazy as _
 from rest_framework import status
 from rest_framework.exceptions import APIException
+
+
+class UnprocessableEntity(APIException):
+    """APIException for status code 422 - Unprocessable Entity."""
+
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    default_detail = _("Unprocessable Entity.")
+    default_code = "unprocessable_entity"
 
 
 class FailedDependencyError(APIException):

--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -38,9 +38,13 @@ HC_NO_KEY_W_PASS = (
 )
 HC_NAME_ALREADY_EXISTS = "Host credential with name=%s already exists"
 CRED_TYPE_REQUIRED_CREATED = "cred_type is required for credential creation"
+CRED_ID_DOES_NOT_EXIST = "Credential id=%s does not exist."
 CRED_TYPE_NOT_ALLOWED_UPDATE = "cred_type is invalid for credential update"
 CRED_DELETE_NOT_VALID_W_SOURCES = (
     "Credential cannot be deleted because it is used by 1 or more sources."
+)
+CRED_ID_DELETE_NOT_VALID_W_SOURCES = (
+    "Credential id=%s cannot be deleted because it is used by 1 or more sources."
 )
 UNKNOWN_CRED_TYPE = "Credential type invalid."
 FIELD_NOT_ALLOWED_FOR_DATA_SOURCE = "Field not allowed for '%s' credential."

--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -38,13 +38,14 @@ HC_NO_KEY_W_PASS = (
 )
 HC_NAME_ALREADY_EXISTS = "Host credential with name=%s already exists"
 CRED_TYPE_REQUIRED_CREATED = "cred_type is required for credential creation"
-CRED_ID_DOES_NOT_EXIST = "Credential id=%s does not exist."
 CRED_TYPE_NOT_ALLOWED_UPDATE = "cred_type is invalid for credential update"
 CRED_DELETE_NOT_VALID_W_SOURCES = (
     "Credential cannot be deleted because it is used by 1 or more sources."
 )
-CRED_ID_DELETE_NOT_VALID_W_SOURCES = (
-    "Credential id=%s cannot be deleted because it is used by 1 or more sources."
+CRED_IDS_DO_NOT_EXIST = "One or more credentials do not exist. ids=%s"
+CRED_IDS_DELETE_NOT_VALID_W_SOURCES = (
+    "One or more credentials cannot be deleted"
+    " because they are used by 1 or more sources. ids=%s"
 )
 UNKNOWN_CRED_TYPE = "Credential type invalid."
 FIELD_NOT_ALLOWED_FOR_DATA_SOURCE = "Field not allowed for '%s' credential."

--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -12,6 +12,7 @@ from api.views import (
     SourceViewSet,
     UserViewSet,
     async_merge_reports,
+    credential_bulk_delete,
     deployments,
     details,
     insights,
@@ -30,6 +31,7 @@ ROUTER.register(r"jobs", ScanJobViewSet, basename="scanjob")
 ROUTER.register(r"users", UserViewSet, basename="users")
 
 urlpatterns = [
+    path("credentials/bulk_delete/", credential_bulk_delete),
     path("reports/<int:report_id>/details/", details),
     path("reports/<int:report_id>/deployments/", deployments),
     path("reports/<int:report_id>/insights/", insights),

--- a/quipucords/api/views.py
+++ b/quipucords/api/views.py
@@ -3,6 +3,7 @@
 # flake8: noqa
 
 from api.credential.view import CredentialViewSet
+from api.credential.view import credential_bulk_delete
 from api.deployments_report.view import deployments
 from api.details_report.view import DetailsReportsViewSet, details
 from api.insights_report.view import insights


### PR DESCRIPTION
- Adding support for deleting credentials in bulk via the /api/v1/credentials/bulk_delete/ POST URL. That URL takes the list if ids to delete via the ids: [ id1, id2, ... ] entry in the posted request.

- [x] Needs an updated openapi schema
- [x] Needs Unit tests

Related to: https://issues.redhat.com/browse/DISCOVERY-511
