### PR TITLE
feat(rhacs): use new RHACS v4.3+ API paths

### DIFF
--- a/quipucords/scanner/rhacs/inspect.py
+++ b/quipucords/scanner/rhacs/inspect.py
@@ -64,14 +64,14 @@ class InspectTaskRunner(RHACSTaskRunner):
     def get_secured_units_current(self):
         """Retrieve RHACS secured node/cpu units metrics."""
         secured_units_current = self._fetch_rhacs_metric(
-            "/v1/product/usage/secured-units/current"
+            "/v1/administration/usage/secured-units/current"
         )
         return secured_units_current
 
     def get_secured_units_max(self):
         """Retrieve RHACS max secured node/cpu units metrics."""
         secured_units_max = self._fetch_rhacs_metric(
-            "/v1/product/usage/secured-units/max"
+            "/v1/administration/usage/secured-units/max"
         )
         return secured_units_max
 

--- a/quipucords/tests/integration/test_rhacs_scan.py
+++ b/quipucords/tests/integration/test_rhacs_scan.py
@@ -28,12 +28,12 @@ def mocked_requests(requests_mock, live_server, max_date):
     rhacs_host = "https://rhacs.host:443"
     requests_mock.get(f"{rhacs_host}/v1/auth/status")
     requests_mock.get(
-        f"{rhacs_host}/v1/product/usage/secured-units/current",
+        f"{rhacs_host}/v1/administration/usage/secured-units/current",
         json={"numNodes": "3", "numCpuUnits": "20"},
     )
 
     requests_mock.get(
-        f"{rhacs_host}/v1/product/usage/secured-units/max",
+        f"{rhacs_host}/v1/administration/usage/secured-units/max",
         json={
             "maxNodesAt": max_date,
             "maxNodes": "4",


### PR DESCRIPTION
Updated 2024-01-17: When fetching RHACS data, we now use the new API paths as introduced in RHACS 4.3. We expect requests to the older RHACS 4.2 API to fail.

~When fetching RHACS data, we now try the "new" API paths as introduced in RHACS 4.3. If a request to the new 4.3 API path fails, we seamlessly retry the request with the old RHACS 4.2 path.~

~This may be a good solution while 4.2 is still available and in use, but we should consider removing this retry logic and embrace the 4.3+ APIs exclusively after some amount of burn-in or if we learn that we have minimal or no customers using RHACS 4.2.~

Relates to JIRA: DISCOVERY-502
https://issues.redhat.com/browse/DISCOVERY-502