### PR TITLE
DISCOVERY-340: ensure fingerprint-only scan jobs are properly working

### DIFF
--- a/quipucords/api/details_report/util.py
+++ b/quipucords/api/details_report/util.py
@@ -159,17 +159,18 @@ def _validate_source_json(source_json):
     return False, None
 
 
-def create_report(report_version, json_details_report):
+def create_report(report_version, json_details_report, raise_exception=False):
     """Create report.
 
     Fact collection consists of a Report record
     :param report_version: major.minor.patch version of report.
     :param json_details_report: dict representing a details report
+    :param raise_exception: raise exception on validation error
     :returns: The newly created Report
     """
     # Create new details report
     serializer = DetailsReportSerializer(data=json_details_report)
-    if serializer.is_valid():
+    if serializer.is_valid(raise_exception=raise_exception):
         report = serializer.save()
         # removed by serializer since it is read-only.  Set again.
         report.report_version = report_version

--- a/quipucords/api/inspectresult/model.py
+++ b/quipucords/api/inspectresult/model.py
@@ -2,15 +2,13 @@
 
 These models are used in the REST definitions
 """
-from datetime import datetime
-from json import JSONEncoder
 
 from django.db import models
 from django.utils.translation import gettext as _
 
 from api import messages
+from api.common.util import RawFactEncoder
 from api.source.model import Source
-from compat.pydantic import BaseModel, PydanticErrorProxy
 
 
 class JobInspectionResult(models.Model):
@@ -58,20 +56,6 @@ class SystemInspectionResult(models.Model):
         """Metadata for model."""
 
         verbose_name_plural = _(messages.PLURAL_SYS_INSPECT_RESULTS_MSG)
-
-
-class RawFactEncoder(JSONEncoder):
-    """Customize the JSONField Encoder for RawFact values."""
-
-    def default(self, o):
-        """Update the default Encoder to handle types beyond just the basic ones."""
-        if isinstance(o, (BaseModel, PydanticErrorProxy)):
-            return o.dict()
-        if isinstance(o, datetime):
-            return o.isoformat()
-        if isinstance(o, set):
-            return sorted(o)
-        return super().default(o)
 
 
 class RawFact(models.Model):

--- a/quipucords/api/migrations/0029_migrate_rawfact_value_to_jsonfield.py
+++ b/quipucords/api/migrations/0029_migrate_rawfact_value_to_jsonfield.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-from api.inspectresult.model import RawFactEncoder
+from api.common.util import RawFactEncoder
 
 
 class Migration(migrations.Migration):

--- a/quipucords/api/reports/model.py
+++ b/quipucords/api/reports/model.py
@@ -4,7 +4,7 @@ import uuid
 
 from django.db import models
 
-from api.inspectresult.model import RawFactEncoder
+from api.common.util import RawFactEncoder
 
 
 class Report(models.Model):

--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -508,8 +508,8 @@ class FingerprintTaskRunner(ScanTaskRunner):
                 fingerprint = self.process_facts_for_datasource(
                     source_type, source, fact
                 )
-            except KeyError:
-                self.scan_task.log_message.error(
+            except NotImplementedError:
+                self.scan_task.log_message(
                     "Could not process source, " f"unknown source type: {source_type}",
                     log_level=logging.ERROR,
                 )

--- a/quipucords/tests/integration/test_openshift_scan.py
+++ b/quipucords/tests/integration/test_openshift_scan.py
@@ -5,7 +5,7 @@ from logging import getLogger
 
 import pytest
 
-from api.inspectresult.model import RawFactEncoder
+from api.common.util import RawFactEncoder
 from constants import DataSources
 from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.entities import (

--- a/quipucords/tests/utils/raw_facts_generator.py
+++ b/quipucords/tests/utils/raw_facts_generator.py
@@ -73,7 +73,7 @@ def _network_raw_facts():
         "insights_client_id": _faker.uuid4(),
         "installed_products": fake_installed_products(),
         "subscription_manager_id": _faker.uuid4(),
-        "system_memory_bytes": _faker.pyint(max_value=2**65),  # max value for bigint
+        "system_memory_bytes": _faker.pyint(max_value=2**63),  # max value for bigint
         "system_purpose_json": None,
         "uname_processor": _faker.random_element(["x86_64", "ARM"]),
         "virt_type": _faker.random_element(["vmware", "xen", "kvm", None]),
@@ -82,7 +82,8 @@ def _network_raw_facts():
     # enough for testing
     facts["virt_virt"] = "virt-guest" if facts["virt_type"] else "virt-host"
     facts["virt_what_type"] = facts["virt_type"]
-    facts["cpu_core_per_socket"] = facts["cpu_core_count"] / facts["cpu_socket_count"]
+    # use integer division as a float will be invalid in fingerprint validation
+    facts["cpu_core_per_socket"] = facts["cpu_core_count"] // facts["cpu_socket_count"]
     return facts
 
 
@@ -112,10 +113,11 @@ def _vcenter_raw_facts():
 def _satellite_raw_facts():
     os_version = fake_major_minor_ver()
     major_ver = os_version.split(".")[0]
-    satellite_date_format = "%Y-%m-%d %H-%M-%S %Z"
+    satellite_date_format = "%Y-%m-%d %H:%M:%S"
     arch = _faker.random_element(["x86_64", "ARM"])
     return {
         "architecture": _faker.random_element([arch, None]),
+        "connection_timestamp": _faker.date_time().strftime(satellite_date_format),
         "cores": str(_faker.pyint(min_value=1, max_value=9)),
         "entitlements": [],
         "errata_out_of_date": _faker.pyint(min_value=0, max_value=1000),
@@ -135,7 +137,7 @@ def _satellite_raw_facts():
         "os_version": os_version,
         "packages_out_of_date": _faker.pyint(min_value=0, max_value=1000),
         "registration_time": _faker.date_time().strftime(satellite_date_format),
-        "uuid": _faker.pybool(),
+        "uuid": str(_faker.uuid4()),
         "virt_type": _faker.random_element(["vmware", "xen", "kvm", None]),
         "virtual": _faker.random_element(["hypervisor", None]),
         "virtual_host_name": _faker.hostname(),


### PR DESCRIPTION
Adds test coverage to fingerprint-only scan jobs as a pre-requisite for the upcoming refactors for upload & merge views.

Relates to JIRA: DISCOVERY-340