### PR TITLE
Port Source API tests from Camayoc

### DIFF
--- a/quipucords/tests/api/source/test_source.py
+++ b/quipucords/tests/api/source/test_source.py
@@ -1,5 +1,6 @@
 """Test the API application."""
 
+import random
 from datetime import datetime
 from unittest.mock import patch
 
@@ -68,6 +69,19 @@ def openshift_cred():
 
 
 @pytest.fixture
+def ansible_cred():
+    """Return Ansible credential object."""
+    return Credential.objects.create(
+        name="ansible_cred1",
+        cred_type=DataSources.ANSIBLE,
+        username="username",
+        password="password",
+        become_password=None,
+        ssh_keyfile=None,
+    )
+
+
+@pytest.fixture
 def rhacs_cred():
     """Return RHACS credential object."""
     return Credential.objects.create(
@@ -75,6 +89,30 @@ def rhacs_cred():
         cred_type=DataSources.RHACS,
         auth_token="acs_token",
     )
+
+
+@pytest.fixture
+def valid_cred(  # noqa: PLR0913
+    net_cred, vc_cred, sat_cred, openshift_cred, ansible_cred, rhacs_cred
+):
+    """Return credential object based on source type."""
+
+    def inner(source_type):
+        match source_type:
+            case DataSources.NETWORK:
+                return net_cred
+            case DataSources.VCENTER:
+                return vc_cred
+            case DataSources.SATELLITE:
+                return sat_cred
+            case DataSources.OPENSHIFT:
+                return openshift_cred
+            case DataSources.ANSIBLE:
+                return ansible_cred
+            case DataSources.RHACS:
+                return rhacs_cred
+
+    return inner
 
 
 @pytest.fixture
@@ -271,28 +309,63 @@ class TestSource:
         }
         self.create_expect_400_with_query(query, data, django_client)
 
-    def test_successful_net_create(self, django_client, net_cred):
+    @pytest.mark.parametrize("source_type", (ds for ds in DataSources))
+    def test_successful_create(self, django_client, valid_cred, source_type):
         """A valid create request should succeed."""
+        valid_cred_obj = valid_cred(source_type)
         data = {
             "name": "source1",
-            "source_type": DataSources.NETWORK,
+            "source_type": source_type,
             "hosts": ["1.2.3.4"],
             "port": "22",
-            "credentials": [net_cred.id],
+            "credentials": [valid_cred_obj.id],
         }
         response = self.create_expect_201(data, django_client)
         assert "id" in response
 
-    def test_successful_net_create_no_port(self, django_client, net_cred):
+    @pytest.mark.parametrize(
+        "source_type,default_port",
+        (
+            (DataSources.NETWORK, 22),
+            (DataSources.VCENTER, 443),
+            (DataSources.SATELLITE, 443),
+            (DataSources.OPENSHIFT, 6443),
+            (DataSources.ANSIBLE, 443),
+            (DataSources.RHACS, 443),
+        ),
+    )
+    def test_successful_create_no_port(
+        self, django_client, valid_cred, source_type, default_port
+    ):
         """A valid create request should succeed without port."""
+        valid_cred_obj = valid_cred(source_type)
         data = {
             "name": "source1",
-            "source_type": DataSources.NETWORK,
+            "source_type": source_type,
             "hosts": ["1.2.3.4"],
-            "credentials": [net_cred.id],
+            "credentials": [valid_cred_obj.id],
         }
         response = self.create_expect_201(data, django_client)
         assert "id" in response
+        assert response.get("port") == default_port
+
+    @pytest.mark.parametrize("source_type", (ds for ds in DataSources))
+    def test_successful_create_custom_port(
+        self, django_client, valid_cred, source_type
+    ):
+        """A valid create request should succeed."""
+        port = random.randint(1, 65535)
+        valid_cred_obj = valid_cred(source_type)
+        data = {
+            "name": "source1",
+            "source_type": source_type,
+            "hosts": ["1.2.3.4"],
+            "port": str(port),
+            "credentials": [valid_cred_obj.id],
+        }
+        response = self.create_expect_201(data, django_client)
+        assert "id" in response
+        assert response.get("port") == port
 
     def test_double_create(self, django_client, net_cred):
         """A duplicate create should fail."""
@@ -321,6 +394,17 @@ class TestSource:
     def test_create_no_name(self, django_client, net_cred):
         """A create request must have a name."""
         data = {
+            "hosts": "1.2.3.4",
+            "source_type": DataSources.NETWORK,
+            "port": "22",
+            "credentials": [net_cred.id],
+        }
+        self.create_expect_400(data, django_client)
+
+    def test_create_empty_name(self, django_client, net_cred):
+        """Empty name is not valid."""
+        data = {
+            "name": "",
             "hosts": "1.2.3.4",
             "source_type": DataSources.NETWORK,
             "port": "22",
@@ -361,11 +445,22 @@ class TestSource:
         self.create_expect_400(data, django_client)
 
     def test_create_empty_host(self, django_client, net_cred):
-        """An empty string is not a host identifier."""
+        """An empty array is not a host identifier."""
         data = {
             "name": "source1",
             "source_type": DataSources.NETWORK,
             "hosts": [],
+            "port": "22",
+            "credentials": [net_cred.id],
+        }
+        self.create_expect_400(data, django_client)
+
+    def test_create_host_empty_string(self, django_client, net_cred):
+        """An empty string is not a host identifier."""
+        data = {
+            "name": "source1",
+            "source_type": DataSources.NETWORK,
+            "hosts": [""],
             "port": "22",
             "credentials": [net_cred.id],
         }
@@ -404,17 +499,6 @@ class TestSource:
         }
         self.create_expect_400(data, django_client)
 
-    def test_create_negative_port(self, django_client, net_cred):
-        """negative port."""
-        data = {
-            "name": "source1",
-            "source_type": DataSources.NETWORK,
-            "hosts": ["1.2.3.4"],
-            "port": -1,
-            "credentials": [net_cred.id],
-        }
-        self.create_expect_400(data, django_client)
-
     def test_create_empty_ip(self, django_client, net_cred):
         """An empty string passed with valid ips."""
         data = {
@@ -425,7 +509,10 @@ class TestSource:
             "credentials": [net_cred.id],
         }
 
-        self.create_expect_201(data, django_client)
+        resp_json = self.create_expect_201(data, django_client)
+        resp_hosts = resp_json.get("hosts")
+        assert len(resp_hosts) == 1
+        assert resp_hosts == ["10.10.181.9"]
 
     def test_create_valid_hosts(self, django_client, net_cred):
         """Test valid host patterns."""
@@ -523,13 +610,14 @@ class TestSource:
         assert response.status_code == 400
         assert len(response.json()["hosts"]) == len(hosts)
 
-    def test_create_bad_port(self, django_client, net_cred):
-        """-1 is not a valid ssh port."""
+    @pytest.mark.parametrize("bad_port", ("string*!", "-1", "False", -1, False))
+    def test_create_bad_port(self, django_client, net_cred, bad_port):
+        """Some values are not a valid ssh port."""
         data = {
             "name": "source1",
             "source_type": DataSources.NETWORK,
             "hosts": ["1.2.3.4"],
-            "port": "-1",
+            "port": bad_port,
             "credentials": [net_cred.id],
         }
         self.create_expect_400(data, django_client)
@@ -576,6 +664,17 @@ class TestSource:
             "hosts": ["1.2.3.4"],
             "port": "22",
             "credentials": ["hi"],
+        }
+        self.create_expect_400(data, django_client)
+
+    def test_create_negative_credential_id(self, django_client):
+        """Negative numbers are not a valid id."""
+        data = {
+            "name": "source1",
+            "source_type": DataSources.NETWORK,
+            "hosts": ["1.2.3.4"],
+            "port": "22",
+            "credentials": [-5],
         }
         self.create_expect_400(data, django_client)
 
@@ -870,6 +969,26 @@ class TestSource:
         response = self.update_source(django_client, updated_data, initial["id"])
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_update_invalid_hosts(self, django_client, net_cred):
+        """Fail update due to invalid host."""
+        data = {
+            "name": "source",
+            "source_type": DataSources.NETWORK,
+            "hosts": ["1.2.3.4"],
+            "port": "22",
+            "credentials": [net_cred.id],
+        }
+        initial = self.create_expect_201(data, django_client)
+
+        updated_data = {
+            "name": "source",
+            "port": 22,
+            "credentials": [net_cred.id],
+            "hosts": ["1**2@33^"],
+        }
+        response = self.update_source(django_client, updated_data, initial["id"])
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_update_empty_hosts(self, django_client, net_cred):
         """Fail update due to empty host array."""
         data = {
@@ -890,6 +1009,42 @@ class TestSource:
         response = self.update_source(django_client, updated_data, initial["id"])
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["hosts"][0] == messages.SOURCE_HOSTS_CANNOT_BE_EMPTY
+
+    def test_update_missing_credentials(self, django_client, net_cred):
+        """Fail update due to missing credentials array."""
+        data = {
+            "name": "source",
+            "source_type": DataSources.NETWORK,
+            "hosts": ["1.2.3.4"],
+            "port": "22",
+            "credentials": [net_cred.id],
+        }
+        initial = self.create_expect_201(data, django_client)
+
+        updated_data = {"name": "source", "port": 22, "hosts": ["1.2.3.4"]}
+        response = self.update_source(django_client, updated_data, initial["id"])
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_empty_credentials(self, django_client, net_cred):
+        """Fail update due to empty credentials array."""
+        data = {
+            "name": "source",
+            "source_type": DataSources.NETWORK,
+            "hosts": ["1.2.3.4"],
+            "port": "22",
+            "credentials": [net_cred.id],
+        }
+        initial = self.create_expect_201(data, django_client)
+
+        updated_data = {
+            "name": "source",
+            "hosts": ["1.2.3.4"],
+            "port": 22,
+            "credentials": [],
+        }
+        response = self.update_source(django_client, updated_data, initial["id"])
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["credentials"][0] == messages.SOURCE_MIN_CREDS
 
     def test_update_type_passed(self, django_client, net_cred):
         """Fail update due to type passed."""
@@ -929,6 +1084,27 @@ class TestSource:
             "hosts": ["1.2.3.5"],
             "port": 23,
             "credentials": [vc_cred.id],
+        }
+        response = self.update_source(django_client, updated_data, initial["id"])
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_invalid_exclude_hosts(self, django_client, net_cred):
+        """Fail update due to invalid host."""
+        data = {
+            "name": "source",
+            "source_type": DataSources.NETWORK,
+            "hosts": ["1.2.3.4"],
+            "port": "22",
+            "credentials": [net_cred.id],
+        }
+        initial = self.create_expect_201(data, django_client)
+
+        updated_data = {
+            "name": "source",
+            "hosts": ["1.2.3.4"],
+            "port": "22",
+            "credentials": [net_cred.id],
+            "exclude_hosts": ["*invalid!!host&*"],
         }
         response = self.update_source(django_client, updated_data, initial["id"])
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -992,6 +1168,48 @@ class TestSource:
         assert response_json["detail"] == messages.SOURCE_DELETE_NOT_VALID_W_SCANS
         assert response_json["scans"][0]["name"] == "test_scan"
 
+    def test_delete_and_list(self, django_client, net_cred):
+        """Delete a Source and confirm other Sources remain intact."""
+        total_sources = 3
+        data = {
+            "name": "source",
+            "source_type": DataSources.NETWORK,
+            "port": "22",
+            "hosts": ["1.2.3.4"],
+            "credentials": [net_cred.id],
+        }
+        source_list = self.source_object_factory(
+            data, django_client, range_number=total_sources
+        )
+        cred_for_response = {"id": net_cred.id, "name": net_cred.name}
+        results = []
+        for source in source_list:
+            result_dict = {
+                "id": source["id"],
+                "name": source["name"],
+                "source_type": DataSources.NETWORK,
+                "port": 22,
+                "hosts": ["1.2.3.4"],
+                "credentials": [cred_for_response],
+            }
+            results.append(result_dict)
+
+        removed_source = results.pop(random.randrange(0, total_sources))
+        url = reverse("v1:source-detail", args=(removed_source["id"],))
+        response = django_client.delete(url, headers=ACCEPT_JSON_HEADER)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        expected = {
+            "count": len(results),
+            "next": None,
+            "previous": None,
+            "results": results,
+        }
+        response = self.get_source(django_client)
+        assert response.status_code == status.HTTP_200_OK
+        content = response.json()
+        assert content == expected
+
     def test_successful_vcenter_create(self, django_client, vc_cred):
         """A valid create request should succeed."""
         data = {
@@ -1032,34 +1250,53 @@ class TestSource:
         }
         self.create_expect_400(data, django_client)
 
-    def test_create_vc_with_hosts(self, django_client, vc_cred):
+    @pytest.mark.parametrize(
+        "source_type", (ds for ds in DataSources if ds != DataSources.NETWORK)
+    )
+    def test_negative_create_non_network_with_hosts(
+        self, django_client, valid_cred, source_type
+    ):
         """A vcenter source must not have multiple hosts."""
+        valid_cred_obj = valid_cred(source_type)
         data = {
             "name": "source1",
-            "source_type": DataSources.VCENTER,
+            "source_type": source_type,
             "hosts": ["1.2.3.4", "1.2.3.5"],
-            "credentials": [vc_cred.id],
+            "credentials": [valid_cred_obj.id],
         }
         self.create_expect_400(data, django_client)
 
-    def test_create_vc_with_excluded_hosts(self, django_client, vc_cred):
+    @pytest.mark.parametrize(
+        "source_type", (ds for ds in DataSources if ds != DataSources.NETWORK)
+    )
+    def test_negative_create_non_network_with_excluded_hosts(
+        self, django_client, valid_cred, source_type
+    ):
         """A vcenter source must not have any excluded hosts."""
+        valid_cred_obj = valid_cred(source_type)
         data = {
             "name": "source1",
-            "source_type": DataSources.VCENTER,
+            "source_type": source_type,
             "hosts": ["1.2.3.4"],
             "exclude_hosts": ["1.2.3.4"],
-            "credentials": [vc_cred.id],
+            "credentials": [valid_cred_obj.id],
         }
         self.create_expect_400(data, django_client)
 
-    def test_create_vc_with_host_range(self, django_client, vc_cred):
+    @pytest.mark.parametrize(
+        "source_type", (ds for ds in DataSources if ds != DataSources.NETWORK)
+    )
+    @pytest.mark.parametrize("hosts_range", ("1.2.3.4/5", "1.2.3.[0:255]"))
+    def test_negative_create_non_network_with_host_range(
+        self, django_client, valid_cred, source_type, hosts_range
+    ):
         """A vcenter source must not have multiple hosts."""
+        valid_cred_obj = valid_cred(source_type)
         data = {
             "name": "source1",
-            "source_type": DataSources.VCENTER,
-            "hosts": ["1.2.3.4/5"],
-            "credentials": [vc_cred.id],
+            "source_type": source_type,
+            "hosts": [hosts_range],
+            "credentials": [valid_cred_obj.id],
         }
         self.create_expect_400(data, django_client)
 
@@ -1222,37 +1459,6 @@ class TestSource:
             "name": "source1",
             "source_type": DataSources.SATELLITE,
             "hosts": [],
-            "credentials": [sat_cred.id],
-        }
-        self.create_expect_400(data, django_client)
-
-    def test_create_sat_with_hosts(self, django_client, sat_cred):
-        """A satellite source must not have multiple hosts."""
-        data = {
-            "name": "source1",
-            "source_type": DataSources.SATELLITE,
-            "hosts": ["1.2.3.4", "1.2.3.5"],
-            "credentials": [sat_cred.id],
-        }
-        self.create_expect_400(data, django_client)
-
-    def test_create_sat_with_exclude_hosts(self, django_client, sat_cred):
-        """A satellite source does not accept excluded hosts."""
-        data = {
-            "name": "source1",
-            "source_type": DataSources.SATELLITE,
-            "hosts": ["1.2.3.4"],
-            "exclude_hosts": ["1.2.3.4"],
-            "credentials": [sat_cred.id],
-        }
-        self.create_expect_400(data, django_client)
-
-    def test_create_sat_with_host_range(self, django_client, sat_cred):
-        """A satellite source must not have multiple hosts."""
-        data = {
-            "name": "source1",
-            "source_type": DataSources.SATELLITE,
-            "hosts": ["1.2.3.4/5"],
             "credentials": [sat_cred.id],
         }
         self.create_expect_400(data, django_client)
@@ -1506,23 +1712,3 @@ class TestSource:
         }
         response = self.update_source(django_client, updated_data, initial["id"])
         assert response.status_code == status.HTTP_200_OK
-
-    def test_update_rhacs_range_hosts(self, django_client, rhacs_cred):
-        """Fail update due to invalid host array."""
-        data = {
-            "name": "acs_source_1",
-            "source_type": DataSources.RHACS,
-            "hosts": ["1.2.3.4"],
-            "credentials": [rhacs_cred.id],
-        }
-        initial = self.create_expect_201(data, django_client)
-
-        updated_data = {
-            "name": "acs_source_1",
-            "hosts": ["1.2.3.4/5"],
-            "credentials": [rhacs_cred.id],
-        }
-        response = self.update_source(django_client, updated_data, initial["id"])
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        response = response.json()
-        assert response["hosts"][0] == messages.SOURCE_ONE_HOST


### PR DESCRIPTION
Adding unit tests for things that we have in Camayoc.

Also removed some duplication and generalized some tests (used pytest params where they make sense instead of keeping multiple almost identical tests).