### PR TITLE
chore(migrations): make credentials timestamp attribute migration reversible

### DIFF
--- a/quipucords/api/migrations/0044_credential_created_at_credential_updated_at.py
+++ b/quipucords/api/migrations/0044_credential_created_at_credential_updated_at.py
@@ -31,5 +31,5 @@ class Migration(migrations.Migration):
             name="updated_at",
             field=models.DateTimeField(auto_now=True, db_index=True),
         ),
-        migrations.RunPython(update_timestamps),
+        migrations.RunPython(update_timestamps, reverse_code=migrations.RunPython.noop),
     ]


### PR DESCRIPTION


- Adding the reverse_code to the migration, while we would lose the *_at attributes added since those were added and we don't have those before the 0044 migration, we can at least reverse the migration.