### PR TITLE
chore: port 1.4 changes to main

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -379,7 +379,7 @@ LOGGING = {
 # Reverse default behavior to avoid host key checking
 os.environ.setdefault("ANSIBLE_HOST_KEY_CHECKING", "False")
 # Reverse default behavior for better readability in log files
-os.environ.setdefault("ANSIBLE_NOCOLOR", "False")
+os.environ.setdefault("ANSIBLE_NOCOLOR", "True")
 
 QPC_EXCLUDE_INTERNAL_FACTS = env.bool("QPC_EXCLUDE_INTERNAL_FACTS", False)
 QPC_TOKEN_EXPIRE_HOURS = env.int("QPC_TOKEN_EXPIRE_HOURS", 24)

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -290,8 +290,11 @@ class InspectTaskRunner(ScanTaskRunner):
                 scan_job_id=self.scan_job.id,
                 output_type=f"ansible-{output}",
             )
-            file_handle = getattr(runner_obj, output)
-            output_path.write_text(file_handle.read())
+            with output_path.open("a") as file_obj:
+                log_contents = getattr(runner_obj, output).read()
+                if log_contents and not log_contents.endswith("\n"):
+                    log_contents += "\n"
+                file_obj.write(log_contents)
 
     def _obtain_discovery_data(self):
         """Obtain discover scan data.  Either via new scan or paused scan.

--- a/quipucords/tests/utils/test_sanitize_for_utf8_compatibility.py
+++ b/quipucords/tests/utils/test_sanitize_for_utf8_compatibility.py
@@ -1,0 +1,23 @@
+"""Tests for `utils.sanitize_for_utf8_compatibility`."""
+import pytest
+
+from utils import sanitize_for_utf8_compatibility
+
+
+@pytest.mark.parametrize(
+    "original,expected",
+    [
+        ("potato", "potato"),
+        ("potato\udcc0", "potato?"),
+        ("πø†åTØ🥔", "πø†åTØ🥔"),  # non-ASCII UTF-8 characters are okay
+        (["a", "b\udcc0"], ["a", "b?"]),
+        ({"a": "A\udcc0", "b\udcc0": "B"}, {"a": "A?", "b?": "B"}),
+        ({"a": ["A\udcc0"], "b\udcc0": "B"}, {"a": ["A?"], "b?": "B"}),
+        (("a", "b\udcc0"), ("a", "b?")),
+        (b"\udcc0", b"\udcc0"),  # we do not change raw bytes objects
+        (None, None),
+    ],
+)
+def test_sanitize_for_utf8_compatibility(original, expected):
+    """Test values are santized for utf-8 compatibility."""
+    assert sanitize_for_utf8_compatibility(original) == expected

--- a/quipucords/utils/__init__.py
+++ b/quipucords/utils/__init__.py
@@ -8,4 +8,4 @@ All utils should be imported here so the internal api for importing is just
 from .deepget import deepget
 from .default_getter import default_getter
 from .get_from_object_or_dict import get_from_object_or_dict
-from .misc import load_json_from_tarball
+from .misc import load_json_from_tarball, sanitize_for_utf8_compatibility

--- a/quipucords/utils/misc.py
+++ b/quipucords/utils/misc.py
@@ -5,3 +5,31 @@ import json
 def load_json_from_tarball(json_filename, tarball):
     """Extract a json as dict from given TarFile interface."""
     return json.loads(tarball.extractfile(json_filename).read())
+
+
+def sanitize_for_utf8_compatibility(value):
+    """
+    Sanitize the given value of non-UTF-8 bytes.
+
+    Ansible's raw facts may contain unexpected bytes in their `str` representations
+    that cannot be encoded as UTF-8. We need to ensure the strings are UTF-8 safe
+    before we store them in the database. This means we may lose some bytes from the
+    original values, but by using `errors="replace"`, any unexpected bytes will be
+    replaced with the `?` character.
+
+    Those original values could be strings, dicts... who knows?! So, we try a few
+    different approaches here to cover most cases. We are invoking recursive calls,
+    but I expect the objects we sanitize are shallow enough not to be a problem.
+    """
+    if isinstance(value, str):
+        return value.encode("utf-8", errors="replace").decode()
+    if isinstance(value, dict):
+        return {
+            sanitize_for_utf8_compatibility(key): sanitize_for_utf8_compatibility(value)
+            for key, value in value.items()
+        }
+    if isinstance(value, list):
+        return [sanitize_for_utf8_compatibility(value) for value in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_for_utf8_compatibility(value) for value in value)
+    return value


### PR DESCRIPTION
This branch/PR contains the following commits cherry-picked from the `release/1.4` branch:

* b4fe714f89eef2e44bd32517f89352ef783ffca0
* fb502b2115367b8f99d1a3847dfcbd03eaf343e3
* aa3cdc3771f34d263b9bfc604c3f1f01e836dbaa

This includes changed introduced by https://github.com/quipucords/quipucords/pull/2563 and https://github.com/quipucords/quipucords/pull/2565.

I believe all other recent commits in `release/1.4` already exist in some equivalent form in `main`. I specifically used `cherry-pick` instead of `rebase` because the branches have diverged significantly and the rebase operation introduced several conflicts that I did not want to resolve manually.