### PR TITLE
fix: ignore unexpected fields in credential serializer

### DIFF
--- a/quipucords/api/credential/serializer.py
+++ b/quipucords/api/credential/serializer.py
@@ -116,24 +116,6 @@ class CredentialSerializer(NotEmptySerializer):
             raise ValidationError(_(messages.CRED_TYPE_NOT_ALLOWED_UPDATE))
         return cred_type
 
-    def validate(self, attrs):
-        """Validate if fields received are appropriate for each credential."""
-        if self.__class__ == CredentialSerializer:
-            # Vanilla CredentialSerializer is not supposed to perform validation and
-            # write data. This must be done only via specialized serializers
-            raise NotImplementedError
-        errors = {}
-        if hasattr(self, "initial_data"):
-            unknown_keys = set(self.initial_data.keys()) - set(self.fields.keys())
-            for key in unknown_keys:
-                if self.initial_data.get(key) is not None:
-                    errors[key] = (
-                        messages.FIELD_NOT_ALLOWED_FOR_DATA_SOURCE % attrs["cred_type"]
-                    )
-        if errors:
-            raise ValidationError(errors)
-        return attrs
-
     def to_representation(self, instance):
         """Overload DRF representation method to mask encrypted fields."""
         _data = super().to_representation(instance)

--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -48,7 +48,6 @@ CRED_IDS_DELETE_NOT_VALID_W_SOURCES = (
     " because they are used by 1 or more sources. ids=%s"
 )
 UNKNOWN_CRED_TYPE = "Credential type invalid."
-FIELD_NOT_ALLOWED_FOR_DATA_SOURCE = "Field not allowed for '%s' credential."
 
 # source messages
 SOURCE_NAME_ALREADY_EXISTS = "Source with name=%s already exists"

--- a/quipucords/tests/api/credential/test_serializer.py
+++ b/quipucords/tests/api/credential/test_serializer.py
@@ -72,52 +72,6 @@ def test_openshift_cred_correct_fields():
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "input_data,improper_fields",
-    (
-        pytest.param(
-            {
-                "name": "cred",
-                "cred_type": DataSources.OPENSHIFT,
-                "auth_token": "test_auth_token",
-                "become_password": "test_become_password",
-            },
-            {"become_password"},
-            id="1",
-        ),
-        pytest.param(
-            {
-                "name": "cred",
-                "cred_type": DataSources.NETWORK,
-                "auth_token": "test_auth_token",
-                "password": "test_password",
-                "username": "some-user",
-            },
-            {"auth_token"},
-            id="2",
-        ),
-        pytest.param(
-            {
-                "name": "cred",
-                "cred_type": DataSources.VCENTER,
-                "auth_token": "test_auth_token",
-                "password": "test_password",
-                "username": "some-user",
-                "become_password": "test_become_password",
-            },
-            {"auth_token", "become_password"},
-            id="3",
-        ),
-    ),
-)
-def test_openshift_cred_unallowed_fields(input_data, improper_fields):
-    """Test if serializer is invalid when passing unallowed fields."""
-    serializer = CredentialSerializer(data=input_data)
-    assert not serializer.is_valid()
-    assert improper_fields == set(serializer.errors.keys())
-
-
-@pytest.mark.django_db
 def test_openshift_cred_empty_auth_token():
     """Test if serializer is invalid when auth token is empty."""
     data = {


### PR DESCRIPTION
This simply removes the custom `CredentialSerializer.validate` method to restore standard DRF behaviors.

Relates to JIRA: DISCOVERY-534
https://issues.redhat.com/browse/DISCOVERY-534