### PR TITLE
feat(Logging): adding and using a relative_pathname for the verbose logger

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -36,6 +36,18 @@ PRODUCTION = env.bool("PRODUCTION", False)
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 
+class RelativePathnameFormatter(logging.Formatter):
+    """Define a custom formatter to add a relative pathname."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def format(self, record):
+        """Add a relative_pathname attribute."""
+        record.relative_pathname = Path(record.pathname).relative_to(BASE_DIR)
+        return super().format(record)
+
+
 def create_random_key():
     """Create a randomized string."""
     return "".join(
@@ -296,7 +308,7 @@ LOGGING_HANDLERS = env.list("DJANGO_LOG_HANDLERS", default=["console"])
 QUIPUCORDS_LOGGING_VERBOSE_FORMAT = env.str(
     "QUIPUCORDS_LOGGING_VERBOSE_FORMAT",
     "[%(levelname)s %(asctime)s pid=%(process)d tid=%(thread)d "
-    "%(pathname)s:%(funcName)s:%(lineno)d] %(message)s",
+    "%(relative_pathname)s:%(funcName)s:%(lineno)d] %(message)s",
 )
 LOG_DIRECTORY = Path(env.str("QPC_LOG_DIRECTORY", str(DEFAULT_DATA_DIR / "logs")))
 LOGGING_FILE = Path(env.str("DJANGO_LOG_FILE", str(LOG_DIRECTORY / "app.log")))
@@ -306,6 +318,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
+            "()": RelativePathnameFormatter,
             "format": QUIPUCORDS_LOGGING_VERBOSE_FORMAT,
             "datefmt": "%Y-%m-%dT%H:%M:%S",
         },


### PR DESCRIPTION
- While the pathname is good to have, it is sometimes quite long for what we just need is just the relative path to the filename being logged from the root of the project.

  Adding and using a relative_pathname attribute for the verbose formatter.

  This saves on logging output size and our eyes.

Current verbose log output:
```
[INFO 2024-02-09T13:31:48 pid=26460 tid=6174175232 /Users/abellotti/DevHome/projects/discovery/quipucords/quipucords/scanner/manager.py:log_info:107] SCAN JOB MANAGER: No scan job currently running.  Scan queue length is 0. Queued jobs: []
[INFO 2024-02-09T13:31:49 pid=26460 tid=6191001600 /Users/abellotti/DevHome/projects/discovery/quipucords/quipucords/scanner/manager.py:log_info:107] SCAN JOB MANAGER: No scan job currently running.  Scan queue length is 0. Queued jobs: []
...
```

New verbose log output:
```
[INFO 2024-02-09T13:30:23 pid=22920 tid=6175125504 scanner/manager.py:log_info:107] SCAN JOB MANAGER: No scan job currently running.  Scan queue length is 0. Queued jobs: []
[INFO 2024-02-09T13:30:24 pid=22920 tid=6191951872 scanner/manager.py:log_info:107] SCAN JOB MANAGER: No scan job currently running.  Scan queue length is 0. Queued jobs: []
...
```