### PR TITLE
fix(Logging): Verbose logging fails with non relative pathnames

### DIFF
--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -44,7 +44,10 @@ class RelativePathnameFormatter(logging.Formatter):
 
     def format(self, record):
         """Add a relative_pathname attribute."""
-        record.relative_pathname = Path(record.pathname).relative_to(BASE_DIR)
+        if Path(record.pathname).is_relative_to(BASE_DIR) is True:
+            record.relative_pathname = Path(record.pathname).relative_to(BASE_DIR)
+        else:
+            record.relative_pathname = record.pathname
         return super().format(record)
 
 


### PR DESCRIPTION
- For pathnames that are not relative to the project's BASE_DIR, relative_to fails with an exception causing the logging to fail. In such cases (i.e. error from a python library file), let's lost the full pathname instead.