### PR TITLE
feat: improve logout security

### DIFF
--- a/quipucords/api/user/view.py
+++ b/quipucords/api/user/view.py
@@ -39,4 +39,4 @@ class UserViewSet(viewsets.GenericViewSet):
         if instance:
             token = Token.objects.create(user=instance)
 
-        return Response()
+        return Response(headers={"Clear-Site-Data": '"cookies", "storage"'})

--- a/quipucords/api/user/view.py
+++ b/quipucords/api/user/view.py
@@ -31,12 +31,7 @@ class UserViewSet(viewsets.GenericViewSet):
     @action(detail=False, methods=["put"])
     def logout(self, request):
         """Log out the current authenticated user."""
-        instance = request.user
+        if user := request.user:
+            Token.objects.filter(user=user).all().delete()
         logout(request)
-        token = Token.objects.filter(user=instance).first()
-        if token:
-            token.delete()
-        if instance:
-            token = Token.objects.create(user=instance)
-
         return Response(headers={"Clear-Site-Data": '"cookies", "storage"'})

--- a/quipucords/tests/api/user/test_user.py
+++ b/quipucords/tests/api/user/test_user.py
@@ -23,3 +23,13 @@ def test_logout_sends_clear_header(qpc_user, django_client):
     assert response.status_code == status.HTTP_200_OK
     assert "Clear-Site-Data" in response.headers
     assert response.text == ""
+
+
+def test_logout_deletes_token(qpc_user, django_client):
+    """Test that user logout deletes its auth tokens."""
+    auth_token, _ = Token.objects.get_or_create(user=qpc_user)
+    assert auth_token is not None
+    logout_url = reverse("v1:users-logout")
+    response = django_client.put(logout_url)
+    assert response.status_code == status.HTTP_200_OK
+    assert Token.objects.filter(user=qpc_user).count() == 0

--- a/quipucords/tests/api/user/test_user.py
+++ b/quipucords/tests/api/user/test_user.py
@@ -1,18 +1,25 @@
 """Test the API application."""
 
-
 import pytest
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from rest_framework.reverse import reverse
 
+pytestmark = pytest.mark.django_db  # all user tests require the database
 
-@pytest.mark.django_db
-class TestUser:
-    """Test the basic user APIs."""
 
-    def test_current(self, qpc_user, django_client):
-        """Test the current API endpoint."""
-        url = reverse("v1:users-current")
-        response = django_client.get(url)
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {"username": qpc_user.username}
+def test_current(qpc_user, django_client):
+    """Test the current API endpoint."""
+    url = reverse("v1:users-current")
+    response = django_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"username": qpc_user.username}
+
+
+def test_logout_sends_clear_header(qpc_user, django_client):
+    """Test that user logout sends the Clear-Site-Data header."""
+    logout_url = reverse("v1:users-logout")
+    response = django_client.put(logout_url)
+    assert response.status_code == status.HTTP_200_OK
+    assert "Clear-Site-Data" in response.headers
+    assert response.text == ""


### PR DESCRIPTION
This branch changes three behaviors to improve the security of quipucords' logout API: 

1. Include the `Clear-Site-Data` response header to encourage clients to clear their local data.
2. Delete *all* of the user's tokens at logout, not just the first (unordered!) result from the database.
3.  *Do not* create a new auth token at logout. Only new logins should create tokens. I don't understand why we ever would want to create a new token at logout, but I confirmed manually with the UI and `qpc` CLI that my updated behavior works fine.

Relates to JIRA: DISCOVERY-468
https://issues.redhat.com/browse/DISCOVERY-468