### PR TITLE
fix: Work around dnf grouplist returning early on unknown groups

### DIFF
--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -56,14 +56,24 @@
 
 # ------------------------------ DETECT JWS/EWS -------------------------------
 - name: check jws presence with yum
-  raw: export LANG=C LC_ALL=C; yum grouplist jws3 jws3plus jws5 jws6 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-99]'
+  raw: "export LANG=C LC_ALL=C; yum grouplist {{item}} 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-99]'"
   register: internal_jws_installed_with_rpm
+  with_items:
+    - jws3
+    - jws3plus
+    - jws5
+    - jws6
   ignore_errors: yes
   when: 'jboss_ws'
 
 - name: set jws_installed_with_rpm fact
   set_fact:
-    jws_installed_with_rpm: "{{internal_jws_installed_with_rpm}}"
+    jws_installed_with_rpm: "{{
+      internal_jws_installed_with_rpm['results']
+        | selectattr('rc', 'eq', '0')
+        | first
+        | default(internal_jws_installed_with_rpm['results'][-1])
+      }}"
   ignore_errors: yes
 
   # If tomcat was installed with a Redhat product, a 'redhat' string can be found in certain files


### PR DESCRIPTION
dnf introduced backwards incompatible change - `dnf grouplist` will return early if any argument is not a valid group name. This means we can't ask for status of multiple groups at once and see which one is installed - if any is not a valid group identifier, dnf will not even check what is the status of others.

We need multiple `dnf grouplist` invocations in a loop. I tried just grabbing them all and processing them on quipucords side, but unfortunately too much of our code assumes that a raw fact value from ansible is going to be a dict similar to raw command return value. While I think we might want to re-think this design decision and allow processing of results list, that would be too much for what I hoped to be relatively easy change.

Alternative would be to loop in the shell, but that doesn't sound obviously better than doing this processing in Ansible.

Relates to JIRA: [DISCOVERY-456](https://issues.redhat.com/browse/DISCOVERY-456)