### PR TITLE
refactor: add --durations=10 to identify slow tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PIP_COMPILE_ARGS = --no-upgrade
 BINDIR  = bin
 PARALLEL_NUM ?= $(shell $(PYTHON) -c 'import multiprocessing as m;print(int(max(m.cpu_count()/2, 2)))')
 TEST_TIMEOUT ?= 15
-TEST_OPTS := -n $(PARALLEL_NUM) -ra -m 'not slow' --timeout=$(TEST_TIMEOUT)
+TEST_OPTS := -n $(PARALLEL_NUM) -ra -m 'not slow' --timeout=$(TEST_TIMEOUT) --durations=10
 
 QUIPUCORDS_CONTAINER_TAG ?= quipucords
 QUIPUCORDS_UI_PATH ?= ../quipucords-ui


### PR DESCRIPTION
As discussed in Slack here: https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1708458696080799?thread_ts=1708456997.169309&cid=C02QSNF1UKE