### PR TITLE
ScanJob ViewSet for v2 API

### DIFF
--- a/quipucords/api/merge_report/view.py
+++ b/quipucords/api/merge_report/view.py
@@ -19,7 +19,7 @@ from api.common.common_report import REPORT_TYPE_DETAILS
 from api.common.util import is_int
 from api.details_report.util import create_report, validate_details_report_json
 from api.models import Report, ScanJob, ScanTask
-from api.serializers import ScanJobSerializer
+from api.serializers import ScanJobSerializerV1
 from api.signal.scanjob_signal import start_scan
 from api.user.authentication import QuipucordsExpiringTokenAuthentication
 
@@ -81,7 +81,7 @@ def _get_async_merge_report_status(merge_job_id):
     merge_job = get_object_or_404(ScanJob.objects.all(), pk=merge_job_id)
     if merge_job.scan_type != ScanTask.SCAN_TYPE_FINGERPRINT:
         return Response(status=status.HTTP_404_NOT_FOUND)
-    job_serializer = ScanJobSerializer(merge_job)
+    job_serializer = ScanJobSerializerV1(merge_job)
     response_data = job_serializer.data
     return Response(response_data, status=status.HTTP_200_OK)
 
@@ -110,7 +110,7 @@ def _create_async_merge_report_job(details_report_data):
         scan_type=ScanTask.SCAN_TYPE_FINGERPRINT, report=details_report
     )
     merge_job.log_current_status()
-    job_serializer = ScanJobSerializer(merge_job)
+    job_serializer = ScanJobSerializerV1(merge_job)
     response_data = job_serializer.data
 
     # start fingerprint job

--- a/quipucords/api/scan/view.py
+++ b/quipucords/api/scan/view.py
@@ -27,7 +27,7 @@ from api.common.util import expand_scanjob_with_times, is_int
 from api.filters import ListFilter
 from api.models import Scan, ScanJob, ScanTask, Source
 from api.scanjob.serializer import expand_scanjob
-from api.serializers import ScanJobSerializer, ScanSerializer
+from api.serializers import ScanJobSerializerV1, ScanSerializer
 from api.signal.scanjob_signal import cancel_scan, start_scan
 from api.user.authentication import QuipucordsExpiringTokenAuthentication
 
@@ -89,21 +89,21 @@ def jobs(request, scan_id=None):
         page = paginator.paginate_queryset(job_queryset, request)
 
         if page is not None:
-            serializer = ScanJobSerializer(page, many=True)
+            serializer = ScanJobSerializerV1(page, many=True)
             for scan in serializer.data:
                 json_scan = expand_scanjob(scan)
                 result.append(json_scan)
             return paginator.get_paginated_response(serializer.data)
 
         for job in job_queryset:
-            job_serializer = ScanJobSerializer(job)
+            job_serializer = ScanJobSerializerV1(job)
             job_json = job_serializer.data
             job_json = expand_scanjob(job_serializer.data)
             result.append(job_json)
         return Response(result)
     job_data = {}
     job_data["scan"] = scan_id
-    job_serializer = ScanJobSerializer(data=job_data)
+    job_serializer = ScanJobSerializerV1(data=job_data)
     job_serializer.is_valid(raise_exception=True)
     job_serializer.save()
     scanjob_obj = ScanJob.objects.get(pk=job_serializer.data["id"])

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -19,6 +19,7 @@ from api.scan.model import (
     Scan,
     ScanOptions,
 )
+from api.scanjob.queryset import ScanJobQuerySet
 from api.scantask.model import ScanTask
 from api.source.model import Source
 
@@ -66,6 +67,8 @@ class ScanJob(models.Model):
     )
 
     report = models.OneToOneField(Report, null=True, on_delete=models.CASCADE)
+
+    objects = ScanJobQuerySet.as_manager()
 
     class Meta:
         """Metadata for model."""

--- a/quipucords/api/scanjob/queryset.py
+++ b/quipucords/api/scanjob/queryset.py
@@ -1,0 +1,80 @@
+"""Module for ScanTaskQuerySet."""
+
+from django.db.models import Case, F, Q, QuerySet, Sum, When
+
+from api.scantask.model import ScanTask
+
+
+class ScanJobQuerySet(QuerySet):
+    """Custom QuerySet for ScanJob."""
+
+    def with_counts(self):
+        """Annotate ScanJob with system counts from associated tasks."""
+        return self.annotate(
+            # inspection type jobs use connect type tasks as reference for systems_count
+            # Other types only use their own type.
+            systems_count=Case(
+                When(
+                    scan_type=ScanTask.SCAN_TYPE_INSPECT,
+                    then=Sum(
+                        "tasks__systems_count",
+                        filter=Q(tasks__scan_type=ScanTask.SCAN_TYPE_CONNECT),
+                        default=0,
+                    ),
+                ),
+                default=Sum(
+                    "tasks__systems_count",
+                    filter=Q(tasks__scan_type=F("scan_type")),
+                    default=0,
+                ),
+            ),
+            systems_scanned=Sum(
+                "tasks__systems_scanned",
+                # only counts of tasks with the same scan_type should be considered
+                filter=Q(tasks__scan_type=F("scan_type")),
+                default=0,
+            ),
+            # case required for following annotations because inpection type scansjobs
+            # sum failed/unreachable values from both connect and inspect tasks, while
+            # connection type scanjobs only look for connection tasks
+            systems_failed=Case(
+                When(
+                    scan_type=ScanTask.SCAN_TYPE_INSPECT,
+                    then=Sum(
+                        "tasks__systems_failed",
+                        filter=Q(
+                            tasks__scan_type__in=(
+                                ScanTask.SCAN_TYPE_CONNECT,
+                                ScanTask.SCAN_TYPE_INSPECT,
+                            )
+                        ),
+                        default=0,
+                    ),
+                ),
+                default=Sum(
+                    "tasks__systems_failed",
+                    filter=Q(tasks__scan_type=F("scan_type")),
+                    default=0,
+                ),
+            ),
+            systems_unreachable=Case(
+                When(
+                    scan_type=ScanTask.SCAN_TYPE_INSPECT,
+                    then=Sum(
+                        "tasks__systems_unreachable",
+                        filter=Q(
+                            tasks__scan_type__in=(
+                                ScanTask.SCAN_TYPE_CONNECT,
+                                ScanTask.SCAN_TYPE_INSPECT,
+                            )
+                        ),
+                        default=0,
+                    ),
+                ),
+                default=Sum(
+                    "tasks__systems_unreachable",
+                    filter=Q(tasks__scan_type=F("scan_type")),
+                    default=0,
+                ),
+            ),
+        )

--- a/quipucords/api/scanjob/serializer.py
+++ b/quipucords/api/scanjob/serializer.py
@@ -5,6 +5,7 @@ from rest_framework.serializers import (
     CharField,
     DateTimeField,
     IntegerField,
+    ModelSerializer,
     PrimaryKeyRelatedField,
     ValidationError,
 )
@@ -97,7 +98,7 @@ class TaskField(PrimaryKeyRelatedField):
         return serializer.data
 
 
-class ScanJobSerializer(NotEmptySerializer):
+class ScanJobSerializerV1(NotEmptySerializer):
     """Serializer for the ScanJob model."""
 
     scan = ScanField(required=True, many=False, queryset=Scan.objects.all())
@@ -138,3 +139,43 @@ class ScanJobSerializer(NotEmptySerializer):
             raise ValidationError(_(messages.SJ_REQ_SOURCES))
 
         return sources
+
+
+class InternalSourceSerializer(ModelSerializer):
+    """Summarized source serializer for ScanJobSerializer."""
+
+    class Meta:
+        """Serializer metadata."""
+
+        model = Source
+        fields = ["id", "name", "source_type"]
+
+
+class ScanJobSerializerV2(ModelSerializer):
+    """ScanJob serializer for api v2."""
+
+    sources = InternalSourceSerializer(many=True)
+    systems_count = IntegerField(read_only=True)
+    systems_scanned = IntegerField(read_only=True)
+    systems_failed = IntegerField(read_only=True)
+    systems_unreachable = IntegerField(read_only=True)
+
+    class Meta:
+        """Metadata for serializer."""
+
+        model = ScanJob
+        fields = [
+            "id",
+            "scan_id",
+            "report_id",
+            "scan_type",
+            "status",
+            "status_message",
+            "start_time",
+            "end_time",
+            "sources",
+            "systems_count",
+            "systems_scanned",
+            "systems_failed",
+            "systems_unreachable",
+        ]

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -19,7 +19,7 @@ from api.inspectresult.serializer import (
     TaskInspectionResultSerializer,
 )
 from api.scan.serializer import ScanSerializer
-from api.scanjob.serializer import ScanJobSerializer, SourceField
+from api.scanjob.serializer import ScanJobSerializerV1, SourceField
 from api.scantask.serializer import ScanTaskSerializer
 from api.source.serializer import (
     CredentialsField,

--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -7,7 +7,8 @@ from api.views import (
     CredentialViewSet,
     DetailsReportsViewSet,
     QuipucordsExpiringAuthTokenView,
-    ScanJobViewSet,
+    ScanJobViewSetV1,
+    ScanJobViewSetV2,
     ScanViewSet,
     SourceViewSet,
     UserViewSet,
@@ -21,17 +22,18 @@ from api.views import (
     status,
 )
 
-ROUTER = SimpleRouter()
-
-ROUTER.register(r"credentials", CredentialViewSet, basename="credentials")
-ROUTER.register(r"reports", DetailsReportsViewSet, basename="reports")
-ROUTER.register(r"sources", SourceViewSet, basename="source")
-ROUTER.register(r"scans", ScanViewSet, basename="scan")
-ROUTER.register(r"jobs", ScanJobViewSet, basename="scanjob")
-ROUTER.register(r"users", UserViewSet, basename="users")
+ROUTER_V1 = SimpleRouter()
+ROUTER_V1.register(r"credentials", CredentialViewSet, basename="credentials")
+ROUTER_V1.register(r"reports", DetailsReportsViewSet, basename="reports")
+ROUTER_V1.register(r"sources", SourceViewSet, basename="source")
+ROUTER_V1.register(r"scans", ScanViewSet, basename="scan")
+ROUTER_V1.register(r"jobs", ScanJobViewSetV1, basename="scanjob")
+ROUTER_V1.register(r"users", UserViewSet, basename="users")
 
 ROUTER_V2 = SimpleRouter()
 ROUTER_V2.register(r"sources", SourceViewSet, basename="source")
+ROUTER_V2.register(r"jobs", ScanJobViewSetV2, basename="job")
+
 
 v1_urls = [
     path(
@@ -54,7 +56,7 @@ v1_urls = [
     path("scans/<int:scan_id>/jobs/", jobs, name="scan-filtered-jobs"),
     path("token/", QuipucordsExpiringAuthTokenView),
     path("status/", status, name="server-status"),
-    *ROUTER.urls,
+    *ROUTER_V1.urls,
 ]
 
 v2_urls = [

--- a/quipucords/api/views.py
+++ b/quipucords/api/views.py
@@ -10,7 +10,7 @@ from api.insights_report.view import insights
 from api.merge_report.view import async_merge_reports
 from api.reports.view import reports
 from api.scan.view import ScanViewSet, jobs
-from api.scanjob.view import ScanJobViewSet
+from api.scanjob.view import ScanJobViewSetV1, ScanJobViewSetV2
 from api.source.view import SourceViewSet
 from api.status.view import status
 from api.user.token_view import QuipucordsExpiringAuthTokenView

--- a/quipucords/tests/api/scanjob/test_scanjob_queryset.py
+++ b/quipucords/tests/api/scanjob/test_scanjob_queryset.py
@@ -1,0 +1,100 @@
+"""Test ScanJob custom queryset."""
+
+import pytest
+
+from api.models import ScanJob, ScanTask
+from tests.factories import ScanJobFactory, ScanTaskFactory
+
+
+@pytest.fixture
+def inspect_type_scanjob():
+    """Return a fixture representing a inspect type ScanJob."""
+    scanjob: ScanJob = ScanJobFactory(
+        scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.COMPLETED
+    )
+    _add_scantasks(scanjob)
+    return scanjob
+
+
+@pytest.fixture
+def connect_type_scanjob():
+    """Return a fixture representing a connect type ScanJob."""
+    scanjob: ScanJob = ScanJobFactory(
+        scan_type=ScanTask.SCAN_TYPE_CONNECT, status=ScanTask.COMPLETED
+    )
+    _add_scantasks(scanjob)
+    return scanjob
+
+
+@pytest.fixture
+def fingerprint_type_scanjob():
+    """Return a fixture representing a fingerprint type ScanJob."""
+    scanjob: ScanJob = ScanJobFactory(
+        scan_type=ScanTask.SCAN_TYPE_FINGERPRINT, status=ScanTask.COMPLETED
+    )
+    _add_scantasks(scanjob)
+    return scanjob
+
+
+def _add_scantasks(scanjob):
+    ScanTaskFactory(
+        job=scanjob,
+        scan_type=ScanTask.SCAN_TYPE_CONNECT,
+        systems_count=100,
+        systems_scanned=20,
+        systems_failed=30,
+        systems_unreachable=50,
+    )
+    ScanTaskFactory(
+        job=scanjob,
+        scan_type=ScanTask.SCAN_TYPE_INSPECT,
+        systems_count=20,
+        systems_scanned=10,
+        systems_failed=9,
+        systems_unreachable=1,
+    )
+    # fingerprint type counts are irrelevant and should be ignored (in production they
+    # are always zero). Using bigger numbers here to ensure they are ignored in
+    # subsequent tests with inspection/connection jobs
+    ScanTaskFactory(
+        job=scanjob,
+        scan_type=ScanTask.SCAN_TYPE_FINGERPRINT,
+        systems_count=999,
+        systems_scanned=999,
+        systems_failed=999,
+        systems_unreachable=999,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "scanjob,count,scanned,failed,unreachable",
+    (
+        ("inspect_type_scanjob", 100, 10, 39, 51),
+        ("connect_type_scanjob", 100, 20, 30, 50),
+        ("fingerprint_type_scanjob", 999, 999, 999, 999),
+    ),
+)
+def test_with_counts(  # noqa: PLR0913
+    request, scanjob, count, scanned, failed, unreachable
+):
+    """Test qs.with_counts results against hardcoded values in fixtures."""
+    scanjob = request.getfixturevalue(scanjob)
+    scanjob_with_counts = ScanJob.objects.with_counts().get(id=scanjob.id)
+    assert scanjob_with_counts.systems_count == count
+    assert scanjob_with_counts.systems_scanned == scanned
+    assert scanjob_with_counts.systems_failed == failed
+    assert scanjob_with_counts.systems_unreachable == unreachable
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("scanjob", ("inspect_type_scanjob", "connect_type_scanjob"))
+def test_with_counts_equivalency(request, scanjob):
+    """Ensure qs.with_counts is equivalent to ScanJob.calculate_counts()."""
+    scanjob = request.getfixturevalue(scanjob)
+    count, scanned, failed, unreachable, _ = scanjob.calculate_counts()
+    scanjob_with_counts = ScanJob.objects.with_counts().get(id=scanjob.id)
+    assert scanjob_with_counts.systems_count == count
+    assert scanjob_with_counts.systems_scanned == scanned
+    assert scanjob_with_counts.systems_failed == failed
+    assert scanjob_with_counts.systems_unreachable == unreachable


### PR DESCRIPTION
Add a new ViewSet for ScanJobs. It has list and retrieve, replacing both
`/v1/jobs/<job-id>`, `/v1/scans/<scan-id>/jobs/` and `/v1/report/merge/jobs/<job-id>`.
Part of the rationale is to support upcoming scanless fingerprint type
jobs that will be created for upload reports (DISCOVERY-452). If we would
follow the original pattern, yet another endpoint for listing jobs would be
required instead.

Compared to the original endpoints, this one lacks: 
- `scan.name` (since we are planning to move away from it - and name don't seem a really useful info in this context)
- tasks (since neither UI nor CLI actually use this info - and it will very likely be populated with way more than just 3 tasks to support parallel celery tasks in the future)
- counts_fingerprint (also not used by UI/CLI - and will very likely be irrelevant in the future).

The new viewset also aims to avoid N+1 issues with related objects, using prefetch related to get info from sources and annotations to calculate system counts.

Relates to JIRA: DISCOVERY-452 DISCOVERY-340