### PR TITLE
refactor(inspect-view): remove unused facts info

### DIFF
--- a/quipucords/api/inspectresult/serializer.py
+++ b/quipucords/api/inspectresult/serializer.py
@@ -36,8 +36,8 @@ class SystemInspectionResultSerializer(NotEmptySerializer):
         """Metadata for serializer."""
 
         model = SystemInspectionResult
-        fields = ["name", "status", "source", "facts"]
-        qpc_allow_empty_fields = ["facts", "source"]
+        fields = ["name", "status", "source"]
+        qpc_allow_empty_fields = ["source"]
 
 
 class TaskInspectionResultSerializer(NotEmptySerializer):

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -17,7 +17,7 @@ from rest_framework.serializers import ValidationError
 from api import messages
 from api.common.pagination import StandardResultsSetPagination
 from api.common.util import is_int
-from api.models import Credential, RawFact, ScanJob, ScanTask, Source
+from api.models import Credential, ScanJob, ScanTask, Source
 from api.scanjob.serializer import ScanJobSerializerV2, expand_scanjob
 from api.serializers import (
     ScanJobSerializerV1,
@@ -65,15 +65,6 @@ def expand_system_inspection(system):
     :param system: A dictionary for a inspection system result.
     """
     expand_source(system)
-    if "facts" in system.keys():
-        facts = []
-        fact_ids = system["facts"]
-        for fact_id in fact_ids:
-            raw_fact = (
-                RawFact.objects.filter(id=fact_id).values("name", "value").first()
-            )
-            facts.append(raw_fact)
-        system["facts"] = facts
 
 
 class ScanJobFilterV1(FilterSet):

--- a/quipucords/tests/api/scanjob/test_scanjob.py
+++ b/quipucords/tests/api/scanjob/test_scanjob.py
@@ -918,7 +918,6 @@ class TestScanJob:
                         "name": source.name,
                         "source_type": source.source_type,
                     },
-                    "facts": [{"name": "fact_key2", "value": "fact_value2"}],
                 }
             ],
         }
@@ -943,13 +942,6 @@ class TestScanJob:
         )
         inspect_sys_result.save()
 
-        fact = RawFact(
-            name="fact_key",
-            value="fact_value",
-            system_inspection_result=inspect_sys_result,
-        )
-        fact.save()
-
         inspect_sys_result2 = SystemInspectionResult(
             name="Foo2",
             status=SystemConnectionResult.SUCCESS,
@@ -957,13 +949,6 @@ class TestScanJob:
             task_inspection_result=inspection_result,
         )
         inspect_sys_result2.save()
-
-        fact2 = RawFact(
-            name="fact_key2",
-            value="fact_value2",
-            system_inspection_result=inspect_sys_result2,
-        )
-        fact2.save()
 
         inspect_sys_result3 = SystemInspectionResult(
             name="Foo3",
@@ -998,7 +983,6 @@ class TestScanJob:
                         "name": source2.name,
                         "source_type": source2.source_type,
                     },
-                    "facts": [],
                 },
                 {
                     "name": "Foo3",
@@ -1008,7 +992,6 @@ class TestScanJob:
                         "name": source2.name,
                         "source_type": source2.source_type,
                     },
-                    "facts": [],
                 },
                 {
                     "name": "Foo2",
@@ -1018,7 +1001,6 @@ class TestScanJob:
                         "name": source1.name,
                         "source_type": source1.source_type,
                     },
-                    "facts": [{"name": "fact_key2", "value": "fact_value2"}],
                 },
                 {
                     "name": "Foo1",
@@ -1028,7 +1010,6 @@ class TestScanJob:
                         "name": source1.name,
                         "source_type": source1.source_type,
                     },
-                    "facts": [{"name": "fact_key", "value": "fact_value"}],
                 },
             ],
         }
@@ -1054,13 +1035,6 @@ class TestScanJob:
         )
         inspect_sys_result.save()
 
-        fact = RawFact(
-            name="fact_key",
-            value="fact_value",
-            system_inspection_result=inspect_sys_result,
-        )
-        fact.save()
-
         inspect_sys_result2 = SystemInspectionResult(
             name="Foo2",
             status=SystemConnectionResult.SUCCESS,
@@ -1068,13 +1042,6 @@ class TestScanJob:
             task_inspection_result=inspection_result,
         )
         inspect_sys_result2.save()
-
-        fact2 = RawFact(
-            name="fact_key2",
-            value="fact_value2",
-            system_inspection_result=inspect_sys_result2,
-        )
-        fact2.save()
 
         inspect_sys_result3 = SystemInspectionResult(
             name="Foo3",
@@ -1109,7 +1076,6 @@ class TestScanJob:
                         "name": source2.name,
                         "source_type": source2.source_type,
                     },
-                    "facts": [],
                 },
                 {
                     "name": "Foo4",
@@ -1119,7 +1085,6 @@ class TestScanJob:
                         "name": source2.name,
                         "source_type": source2.source_type,
                     },
-                    "facts": [],
                 },
             ],
         }
@@ -1146,13 +1111,6 @@ class TestScanJob:
         )
         inspect_sys_result.save()
 
-        fact = RawFact(
-            name="fact_key",
-            value="fact_value",
-            system_inspection_result=inspect_sys_result,
-        )
-        fact.save()
-
         inspect_sys_result2 = SystemInspectionResult(
             name="Foo",
             status=SystemConnectionResult.SUCCESS,
@@ -1160,13 +1118,6 @@ class TestScanJob:
             task_inspection_result=inspection_result,
         )
         inspect_sys_result2.save()
-
-        fact2 = RawFact(
-            name="fact_key2",
-            value="fact_value2",
-            system_inspection_result=inspect_sys_result2,
-        )
-        fact2.save()
 
         inspect_sys_result3 = SystemInspectionResult(
             name="Foo",
@@ -1201,7 +1152,6 @@ class TestScanJob:
                         "name": source2.name,
                         "source_type": source2.source_type,
                     },
-                    "facts": [],
                 },
                 {
                     "name": "Foo",
@@ -1211,7 +1161,6 @@ class TestScanJob:
                         "name": source2.name,
                         "source_type": source2.source_type,
                     },
-                    "facts": [],
                 },
                 {
                     "name": "Foo",
@@ -1221,7 +1170,6 @@ class TestScanJob:
                         "name": source1.name,
                         "source_type": source1.source_type,
                     },
-                    "facts": [{"name": "fact_key", "value": "fact_value"}],
                 },
                 {
                     "name": "Foo",
@@ -1231,7 +1179,6 @@ class TestScanJob:
                         "name": source1.name,
                         "source_type": source1.source_type,
                     },
-                    "facts": [{"name": "fact_key2", "value": "fact_value2"}],
                 },
             ],
         }
@@ -1256,13 +1203,6 @@ class TestScanJob:
         )
         inspect_sys_result.save()
 
-        fact = RawFact(
-            name="fact_key",
-            value="fact_value",
-            system_inspection_result=inspect_sys_result,
-        )
-        fact.save()
-
         url = reverse("v1:scanjob-inspection", args=(scan_job.id,))
         response = django_client.get(url)
         assert response.status_code == status.HTTP_200_OK
@@ -1280,7 +1220,6 @@ class TestScanJob:
                         "name": source1.name,
                         "source_type": source1.source_type,
                     },
-                    "facts": [{"name": "fact_key", "value": "fact_value"}],
                 }
             ],
         }
@@ -1301,14 +1240,6 @@ class TestScanJob:
             task_inspection_result=inspection_result,
         )
         inspect_sys_result.save()
-
-        fact = RawFact(
-            name="fact_key",
-            value="fact_value",
-            system_inspection_result=inspect_sys_result,
-        )
-        fact.save()
-
         source.delete()
 
         url = reverse("v1:scanjob-inspection", args=(scan_job.id,))
@@ -1324,7 +1255,6 @@ class TestScanJob:
                     "name": "Foo",
                     "status": "success",
                     "source": "deleted",
-                    "facts": [{"name": "fact_key", "value": "fact_value"}],
                 }
             ],
         }


### PR DESCRIPTION
This view is only used by the UI, which isn't consuming nor will consume facts from this view. Removing facts from this view removes a potential issue for sources with multiple hosts/subnets, avoiding unnecessary queries and a unnecessary large json response.

Relates to JIRA: DISCOVERY-218