### PR TITLE
feat: support partial deletes in bulk delete API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ var/
 
 # vagrant data
 .vagrant/
+
+# test profiling results
+prof/

--- a/quipucords/api/common/util.py
+++ b/quipucords/api/common/util.py
@@ -197,11 +197,6 @@ def expand_scanjob_with_times(scanjob, connect_only=False):  # noqa: PLR0912, C9
     return job_json
 
 
-def ids_to_str(id_list):
-    """Convert a list of ids to a comma seperated string of sorted ids."""
-    return ",".join([str(i) for i in sorted(id_list)])
-
-
 class RawFactEncoder(JSONEncoder):
     """Customize the JSONField Encoder for RawFact values."""
 

--- a/quipucords/api/credential/view.py
+++ b/quipucords/api/credential/view.py
@@ -49,6 +49,7 @@ def credential_bulk_delete(request):
         not isinstance(ids, (list, str))
         or (isinstance(ids, str) and ids != DELETE_ALL_IDS_MAGIC_STRING)
         or (isinstance(ids, list) and len(ids) == 0)
+        or (isinstance(ids, list) and any([not isinstance(_id, int) for _id in ids]))
     ):
         raise ParseError(
             detail=_(

--- a/quipucords/api/credential/view.py
+++ b/quipucords/api/credential/view.py
@@ -53,8 +53,8 @@ def credential_bulk_delete(request):
         raise ParseError(
             detail=_(
                 "Missing 'ids' list of credential ids "
-                "or '%(DELETE_ALL_IDS_MAGIC_STRING)s' string"
-            ).format({"DELETE_ALL_IDS_MAGIC_STRING": DELETE_ALL_IDS_MAGIC_STRING})
+                "or '{DELETE_ALL_IDS_MAGIC_STRING}' string"
+            ).format(DELETE_ALL_IDS_MAGIC_STRING=DELETE_ALL_IDS_MAGIC_STRING)
         )
     elif not isinstance(ids, str):
         ids = set(ids)  # remove duplicates

--- a/quipucords/api/exceptions.py
+++ b/quipucords/api/exceptions.py
@@ -1,16 +1,7 @@
 """Quipucords API exceptions."""
 
-from django.utils.translation import gettext_lazy as _
 from rest_framework import status
 from rest_framework.exceptions import APIException
-
-
-class UnprocessableEntity(APIException):
-    """APIException for status code 422 - Unprocessable Entity."""
-
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-    default_detail = _("Unprocessable Entity.")
-    default_code = "unprocessable_entity"
 
 
 class FailedDependencyError(APIException):

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -1047,7 +1047,7 @@ class TestCredentialBulkDelete:
         assert len(Credential.objects.filter(id__in=[cred1.id, cred2.id])) == 0
         assert Credential.objects.count() == 0
 
-    @pytest.mark.parametrize("bad_ids", ["1", False, None])
+    @pytest.mark.parametrize("bad_ids", ["1", False, None, [1, "2"]])
     def test_bulk_delete_rejects_invalid_inputs(self, bad_ids, django_client):
         """Test that bulk delete rejects unexpected value types in "ids"."""
         delete_request = {"ids": bad_ids}


### PR DESCRIPTION
This also fixes a few minor issues in recent commits to this API, and this also adds a new `client_logged_in` test fixture that is much faster than our `django_client` fixture that this code was previously using extensively.

Running `poetry run pytest quipucords/tests/api/credential/test_credential.py` on my local system at commit f49787ad (**before** converting it to the new fixture):

```
129 passed, 5 warnings in 116.75s (0:01:56)
```

Running `poetry run pytest quipucords/tests/api/credential/test_credential.py` on my local system at commit fe44a58d (**after** converting it to the new fixture):

```
129 passed, 4 warnings in 8.62s
```

Gotta go fast. 🦔💨

I could split out the new fixtures into a separate PR if requested.