### PR TITLE
Draft: chore: requires Python >= 3.9 for setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.11",
     ],
     license="GPLv3",
-    python_requires=">=3.7",
+    python_requires=">=3.11",
 )


### PR DESCRIPTION
Note: the main purpose of this PR is to test the recent changes in Discovery CI pipeline regarding "copy ssh keys".

We are using Python 3.9 at minimum everywhere, actually 3.11. Should we have to update this version 3.11 everywhere in the project?