### PR TITLE
chore: requires Python >= 3.11 for setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.11",
     ],
     license="GPLv3",
-    python_requires=">=3.7",
+    python_requires=">=3.11",
 )


### PR DESCRIPTION
We are using Python 3.11 (at minimum) everywhere and we forgot to update setuptools.