### PR TITLE
refactor: simply use DEFAULT_PERMISSION_CLASSES for all views

### DIFF
--- a/quipucords/api/credential/view.py
+++ b/quipucords/api/credential/view.py
@@ -6,10 +6,9 @@ from django.http import Http404
 from django.utils.translation import gettext as _
 from django_filters.rest_framework import CharFilter, DjangoFilterBackend, FilterSet
 from rest_framework import status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view
 from rest_framework.exceptions import ParseError
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.viewsets import ModelViewSet
@@ -20,11 +19,8 @@ from api.filters import ListFilter
 from api.models import Credential, Source
 from api.serializers import CredentialSerializer
 
-perm_classes = (IsAuthenticated,)
-
 
 @api_view(["post"])
-@permission_classes(perm_classes)
 def credential_bulk_delete(request):
     """Bulk delete credentials.
 
@@ -116,8 +112,6 @@ class CredentialFilter(FilterSet):
 
 class CredentialViewSet(ModelViewSet):
     """A view set for the Credential model."""
-
-    permission_classes = (IsAuthenticated,)
 
     queryset = Credential.objects.all()
     serializer_class = CredentialSerializer

--- a/quipucords/api/deployments_report/view.py
+++ b/quipucords/api/deployments_report/view.py
@@ -4,8 +4,7 @@ import logging
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from rest_framework import status
-from rest_framework.decorators import api_view, permission_classes, renderer_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
@@ -18,11 +17,8 @@ from api.models import DeploymentsReport
 
 logger = logging.getLogger(__name__)
 
-perm_classes = (IsAuthenticated,)
-
 
 @api_view(["GET"])
-@permission_classes(perm_classes)
 @renderer_classes(
     (JSONRenderer, BrowsableAPIRenderer, DeploymentCSVRenderer, ReportJsonGzipRenderer)
 )

--- a/quipucords/api/details_report/view.py
+++ b/quipucords/api/details_report/view.py
@@ -5,12 +5,7 @@ import logging
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from rest_framework import mixins, status, viewsets
-from rest_framework.decorators import (
-    api_view,
-    permission_classes,
-    renderer_classes,
-)
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
@@ -27,11 +22,8 @@ from scanner.job import ScanJobRunner
 
 logger = logging.getLogger(__name__)
 
-perm_classes = (IsAuthenticated,)
-
 
 @api_view(["GET"])
-@permission_classes(perm_classes)
 @renderer_classes(
     (JSONRenderer, BrowsableAPIRenderer, DetailsCSVRenderer, ReportJsonGzipRenderer)
 )
@@ -55,8 +47,6 @@ class DetailsReportsViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
 
     This is internal API for a sync way to create a report.
     """
-
-    permission_classes = (IsAuthenticated,)
 
     queryset = Report.objects.all()
     serializer_class = DetailsReportSerializer

--- a/quipucords/api/insights_report/view.py
+++ b/quipucords/api/insights_report/view.py
@@ -2,9 +2,8 @@
 import logging
 
 from django.shortcuts import get_object_or_404
-from rest_framework.decorators import api_view, permission_classes, renderer_classes
+from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.exceptions import NotFound
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 
@@ -16,11 +15,8 @@ from api.models import DeploymentsReport, SystemFingerprint
 
 logger = logging.getLogger(__name__)
 
-perm_classes = (IsAuthenticated,)
-
 
 @api_view(["GET"])
-@permission_classes(perm_classes)
 @renderer_classes((JSONRenderer, InsightsGzipRenderer, BrowsableAPIRenderer))
 def insights(request, report_id=None):
     """Lookup and return an Insights system report."""

--- a/quipucords/api/merge_report/view.py
+++ b/quipucords/api/merge_report/view.py
@@ -4,8 +4,7 @@ import logging
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from rest_framework import status
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
@@ -19,11 +18,8 @@ from api.signal.scanjob_signal import start_scan
 
 logger = logging.getLogger(__name__)
 
-perm_classes = (IsAuthenticated,)
-
 
 @api_view(["get", "put", "post"])
-@permission_classes(perm_classes)
 def async_merge_reports(request, scan_job_id=None):
     """Merge reports asynchronously."""
     if request.method == "GET":

--- a/quipucords/api/reports/view.py
+++ b/quipucords/api/reports/view.py
@@ -5,8 +5,7 @@ import logging
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from rest_framework import status
-from rest_framework.decorators import api_view, permission_classes, renderer_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
 
 from api.deployments_report.view import build_cached_json_report
@@ -16,11 +15,8 @@ from api.serializers import DetailsReportSerializer
 
 logger = logging.getLogger(__name__)
 
-perm_classes = (IsAuthenticated,)
-
 
 @api_view(["GET"])
-@permission_classes(perm_classes)
 @renderer_classes((ReportsGzipRenderer,))
 def reports(request, report_id):
     """Lookup and return reports."""

--- a/quipucords/api/scan/view.py
+++ b/quipucords/api/scan/view.py
@@ -9,9 +9,8 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from django_filters.rest_framework import CharFilter, DjangoFilterBackend, FilterSet
 from rest_framework import status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.viewsets import ModelViewSet
@@ -58,11 +57,7 @@ JOB_VALID_STATUS = [
 ]
 
 
-perm_classes = (IsAuthenticated,)
-
-
 @api_view(["get", "post"])
-@permission_classes(perm_classes)
 def jobs(request, scan_id=None):
     """Get the jobs of a scan."""
     # TODO: remove this view and adjust ScanJobViewSet to add any missing functionality
@@ -158,8 +153,6 @@ class ScanFilter(FilterSet):
 
 class ScanViewSet(ModelViewSet):
     """A view set for Scan."""
-
-    permission_classes = (IsAuthenticated,)
 
     queryset = Scan.objects.all()
     serializer_class = ScanSerializer

--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -9,7 +9,6 @@ from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
@@ -92,8 +91,6 @@ class ScanJobFilterV2(FilterSet):
 
 class ScanJobViewSetV1(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     """A view set for ScanJob."""
-
-    permission_classes = (IsAuthenticated,)
 
     queryset = ScanJob.objects.all()
     serializer_class = ScanJobSerializerV1
@@ -288,7 +285,6 @@ class ScanJobViewSetV1(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 class ScanJobViewSetV2(viewsets.ReadOnlyModelViewSet):
     """A viewset for ScanJobs."""
 
-    permission_classes = (IsAuthenticated,)
     queryset = ScanJob.objects.prefetch_related("sources").with_counts()
     serializer_class = ScanJobSerializerV2
     filter_backends = (DjangoFilterBackend, OrderingFilter)

--- a/quipucords/api/source/view.py
+++ b/quipucords/api/source/view.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext as _
 from django_filters.rest_framework import CharFilter, DjangoFilterBackend, FilterSet
 from rest_framework import status
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.viewsets import ModelViewSet
@@ -77,8 +76,6 @@ class SourceFilter(FilterSet):
 
 class SourceViewSet(ModelViewSet):
     """A view set for Sources."""
-
-    permission_classes = (IsAuthenticated,)
 
     queryset = Source.objects.all()
     filter_backends = (DjangoFilterBackend, OrderingFilter)

--- a/quipucords/api/user/view.py
+++ b/quipucords/api/user/view.py
@@ -5,7 +5,6 @@ from django.contrib.auth import logout
 from rest_framework import viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 logger = logging.getLogger(__name__)
@@ -13,8 +12,6 @@ logger = logging.getLogger(__name__)
 
 class UserViewSet(viewsets.GenericViewSet):
     """User view for logout and user data."""
-
-    permission_classes = (IsAuthenticated,)
 
     @action(detail=False, methods=["get"])
     def current(self, request):

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -210,6 +210,7 @@ REST_FRAMEWORK = {
         "api.user.authentication.QuipucordsExpiringTokenAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ),
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "DEFAULT_VERSION": "v1",
 }


### PR DESCRIPTION
This removes a lot of (probably copy-paste anti-pattern) unnecessary code duplicated across all our views.

DRY. ☀️ 🌵 

This is a followup to https://github.com/quipucords/quipucords/pull/2601 that implements a similar cleanup.