### PR TITLE
feat: add support for bulk deleting sources

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -463,6 +463,31 @@ paths:
           description: "Not authorized"
         404:
           description: "Source not found"
+  /sources/bulk_delete/:
+    post:
+      tags:
+        - "Source"
+      summary: "Bulk delete sources"
+      description: "Bulk delete sources by ids"
+      operationId: "bulkDeleteSources"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of Source IDs to delete or the string 'all'"
+        required: true
+        schema:
+          $ref: "#/definitions/BulkDeleteParameters"
+      responses:
+        200:
+          description: "Sources deleted"
+        400:
+          description: "Invalid input"
+        401:
+          description: "Not authorized"
   /scans/:
     post:
       tags:

--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -19,6 +19,7 @@ from api.views import (
     insights,
     jobs,
     reports,
+    source_bulk_delete,
     status,
 )
 
@@ -40,6 +41,11 @@ v1_urls = [
         "credentials/bulk_delete/",
         credential_bulk_delete,
         name="credentials-bulk-delete",
+    ),
+    path(
+        "sources/bulk_delete/",
+        source_bulk_delete,
+        name="sources-bulk-delete",
     ),
     path("reports/<int:report_id>/details/", details, name="reports-details"),
     path(

--- a/quipucords/api/views.py
+++ b/quipucords/api/views.py
@@ -11,7 +11,7 @@ from api.merge_report.view import async_merge_reports
 from api.reports.view import reports
 from api.scan.view import ScanViewSet, jobs
 from api.scanjob.view import ScanJobViewSetV1, ScanJobViewSetV2
-from api.source.view import SourceViewSet
+from api.source.view import SourceViewSet, source_bulk_delete
 from api.status.view import status
 from api.user.token_view import QuipucordsExpiringAuthTokenView
 from api.user.view import UserViewSet

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -13,7 +13,12 @@ from api.common.util import DELETE_ALL_IDS_MAGIC_STRING
 from api.models import Credential, Source
 from api.vault import decrypt_data_as_unicode
 from constants import ENCRYPTED_DATA_MASK, DataSources
-from tests.factories import CredentialFactory, SourceFactory
+from tests.factories import (
+    CredentialFactory,
+    SourceFactory,
+    generate_invalid_id,
+    generate_openssh_pkey,
+)
 
 ACCEPT_JSON_HEADER = {"Accept": "application/json"}
 
@@ -23,20 +28,6 @@ def alt_cred_type(cred_type):
     cred_types = DataSources.values.copy()
     cred_types.remove(cred_type)
     return random.choice(cred_types)
-
-
-def generate_openssh_pkey(faker):
-    """Generate a random OpenSSH private key."""
-    pkey = "-----BEGIN OPENSSH EXAMPLE KEY-----\n"
-    for __ in range(5):
-        pkey += f"{faker.lexify('?' * 70)}\n"
-    pkey += "-----END OPENSSH EXAMPLE KEY-----\n"
-    return pkey
-
-
-def generate_invalid_id(faker):
-    """Return an invalid Credential id that will likely not exist."""
-    return faker.pyint(min_value=990000, max_value=999999)
 
 
 @pytest.mark.django_db

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -1110,23 +1110,16 @@ class TestCredentialBulkDelete:
         assert len(Credential.objects.filter(id__in=[cred1.id, cred2.id])) == 0
         assert Credential.objects.count() == 0
 
-    @pytest.mark.parametrize("bad_ids", ["1", False, None, [1, "2"]])
-    def test_bulk_delete_rejects_invalid_inputs(self, bad_ids, client_logged_in):
-        """Test that bulk delete rejects unexpected value types in "ids"."""
-        delete_request = {"ids": bad_ids}
-        response = client_logged_in.post(
-            reverse("v1:credentials-bulk-delete"),
-            data=delete_request,
-            content_type="application/json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+    def test_bulk_delete_rejects_invalid_inputs(self, client_logged_in):
+        """
+        Test that bulk delete rejects unexpected value types in "ids".
 
-    def test_bulk_delete_empty_list_bad_request(self, client_logged_in):
-        """Test that bulk delete requires some IDs."""
-        delete_request = {"ids": []}
+        Note: test_set_of_ids_or_all_str covers bad inputs more exhaustively.
+        """
+        invalid_delete_params = {"ids": []}
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
-            data=delete_request,
+            data=invalid_delete_params,
             content_type="application/json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -9,7 +9,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from api import messages
-from api.common.util import DELETE_ALL_IDS_MAGIC_STRING
+from api.common.util import ALL_IDS_MAGIC_STRING
 from api.models import Credential, Source
 from api.vault import decrypt_data_as_unicode
 from constants import ENCRYPTED_DATA_MASK, DataSources
@@ -1100,7 +1100,7 @@ class TestCredentialBulkDelete:
         """Test that bulk delete deletes all credentials."""
         cred1 = CredentialFactory()
         cred2 = CredentialFactory()
-        delete_request = {"ids": DELETE_ALL_IDS_MAGIC_STRING}
+        delete_request = {"ids": ALL_IDS_MAGIC_STRING}
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=delete_request,
@@ -1121,7 +1121,7 @@ class TestCredentialBulkDelete:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_bulk_delete_empty_list_ok(self, client_logged_in):
+    def test_bulk_delete_empty_list_bad_request(self, client_logged_in):
         """Test that bulk delete requires some IDs."""
         delete_request = {"ids": []}
         response = client_logged_in.post(
@@ -1179,7 +1179,7 @@ class TestCredentialBulkDelete:
         cred2 = CredentialFactory()
         cred_in_use = CredentialFactory()
         source = SourceFactory(credentials=[cred_in_use])
-        delete_request = {"ids": DELETE_ALL_IDS_MAGIC_STRING}
+        delete_request = {"ids": ALL_IDS_MAGIC_STRING}
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=delete_request,

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -45,23 +45,16 @@ class TestSourceBulkDelete:
         assert len(Source.objects.filter(id__in=[source1.id, source2.id])) == 0
         assert Source.objects.count() == 0
 
-    @pytest.mark.parametrize("bad_ids", ["1", False, None, [1, "2"]])
-    def test_bulk_delete_rejects_invalid_inputs(self, bad_ids, client_logged_in):
-        """Test that bulk delete rejects unexpected value types in "ids"."""
-        delete_request = {"ids": bad_ids}
-        response = client_logged_in.post(
-            reverse("v1:sources-bulk-delete"),
-            data=delete_request,
-            content_type="application/json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+    def test_bulk_delete_rejects_invalid_inputs(self, client_logged_in):
+        """
+        Test that bulk delete rejects unexpected value types in "ids".
 
-    def test_bulk_delete_empty_list_bad_request(self, client_logged_in):
-        """Test that bulk delete requires some IDs."""
-        delete_request = {"ids": []}
+        Note: test_set_of_ids_or_all_str covers bad inputs more exhaustively.
+        """
+        invalid_delete_params = {"ids": []}
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
-            data=delete_request,
+            data=invalid_delete_params,
             content_type="application/json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -3,7 +3,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from api.common.util import DELETE_ALL_IDS_MAGIC_STRING
+from api.common.util import ALL_IDS_MAGIC_STRING
 from api.source.model import Source
 from tests.factories import (
     ScanFactory,
@@ -35,7 +35,7 @@ class TestSourceBulkDelete:
         """Test that bulk delete deletes all sources."""
         source1 = SourceFactory()
         source2 = SourceFactory()
-        delete_request = {"ids": DELETE_ALL_IDS_MAGIC_STRING}
+        delete_request = {"ids": ALL_IDS_MAGIC_STRING}
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=delete_request,
@@ -117,7 +117,7 @@ class TestSourceBulkDelete:
         scan2job = ScanJobFactory(scan=scan2)
         scan2job.sources.add(source_in_use2)
         scan2task = ScanTaskFactory(job=scan2job, source=source_in_use2)
-        delete_request = {"ids": DELETE_ALL_IDS_MAGIC_STRING}
+        delete_request = {"ids": ALL_IDS_MAGIC_STRING}
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=delete_request,

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -1,0 +1,154 @@
+"""Tests for quipucords.api.source.source_bulk_delete."""
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from api.common.util import DELETE_ALL_IDS_MAGIC_STRING
+from api.source.model import Source
+from tests.api.credential.test_credential import generate_invalid_id
+from tests.factories import ScanFactory, ScanJobFactory, ScanTaskFactory, SourceFactory
+
+
+@pytest.mark.django_db
+class TestSourceBulkDelete:
+    """Tests the Source bulk_delete function."""
+
+    def test_bulk_delete_specific_ids(self, client_logged_in):
+        """Test that bulk delete deletes all requested sources."""
+        source1 = SourceFactory()
+        source2 = SourceFactory()
+        delete_request = {"ids": [source1.id, source2.id]}
+        response = client_logged_in.post(
+            reverse("v1:sources-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(Source.objects.filter(id__in=[source1.id, source2.id])) == 0
+
+    def test_bulk_delete_all_ids(self, client_logged_in):
+        """Test that bulk delete deletes all sources."""
+        source1 = SourceFactory()
+        source2 = SourceFactory()
+        delete_request = {"ids": DELETE_ALL_IDS_MAGIC_STRING}
+        response = client_logged_in.post(
+            reverse("v1:sources-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(Source.objects.filter(id__in=[source1.id, source2.id])) == 0
+        assert Source.objects.count() == 0
+
+    @pytest.mark.parametrize("bad_ids", ["1", False, None, [1, "2"]])
+    def test_bulk_delete_rejects_invalid_inputs(self, bad_ids, client_logged_in):
+        """Test that bulk delete rejects unexpected value types in "ids"."""
+        delete_request = {"ids": bad_ids}
+        response = client_logged_in.post(
+            reverse("v1:sources-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_bulk_delete_empty_list_bad_request(self, client_logged_in):
+        """Test that bulk delete requires some IDs."""
+        delete_request = {"ids": []}
+        response = client_logged_in.post(
+            reverse("v1:sources-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_bulk_delete_ignores_missing_ids(self, client_logged_in, faker):
+        """Test bulk delete succeeds and reports missing IDs."""
+        source1 = SourceFactory()
+        source2 = SourceFactory()
+        non_existent_id = generate_invalid_id(faker)
+        delete_request = {"ids": [non_existent_id, source1.id, source2.id]}
+        response = client_logged_in.post(
+            reverse("v1:sources-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = response.json()
+        assert set(response_json["deleted"]) == set([source1.id, source2.id])
+        assert response_json["missing"] == [non_existent_id]
+        assert response_json["skipped"] == []
+        assert not Source.objects.filter(pk__in=[source1.id, source2.id]).exists()
+
+    def test_bulk_delete_ignores_errors(self, client_logged_in):
+        """Test bulk delete succeeds and reports skipped IDs."""
+        source = SourceFactory()
+        source_in_use = SourceFactory()
+        scan1 = ScanFactory(sources=[source_in_use])
+        scan2 = ScanFactory(sources=[source_in_use])
+        delete_request = {"ids": [source_in_use.id, source.id]}
+        response = client_logged_in.post(
+            reverse("v1:sources-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = response.json()
+        assert response_json["deleted"] == [source.id]
+        assert response_json["missing"] == []
+        assert len(response_json["skipped"]) == 1
+        assert response_json["skipped"][0]["source"] == source_in_use.id
+        assert set(response_json["skipped"][0]["scans"]) == set([scan1.id, scan2.id])
+        assert not Source.objects.filter(pk=source.id).exists()
+        assert Source.objects.filter(pk=source_in_use.id).exists()
+
+    def test_bulk_delete_all(self, client_logged_in):
+        """Test bulk delete succeeds with magic "all" token."""
+        source1 = SourceFactory()
+        source2 = SourceFactory()
+        source_in_use1 = SourceFactory()
+        scan1 = ScanFactory(sources=[source_in_use1])
+        source_in_use2 = SourceFactory()
+        scan2 = ScanFactory(sources=[source_in_use2])
+        scan2job = ScanJobFactory(scan=scan2)
+        scan2job.sources.add(source_in_use2)
+        scan2task = ScanTaskFactory(job=scan2job, source=source_in_use2)
+        delete_request = {"ids": DELETE_ALL_IDS_MAGIC_STRING}
+        response = client_logged_in.post(
+            reverse("v1:sources-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = response.json()
+        assert set(response_json["deleted"]) == set([source1.id, source2.id])
+        assert response_json["missing"] == []
+
+        # Note that lists like "skipped" may not be sorted.
+        expected_skipped = sorted(
+            [
+                {
+                    "source": source_in_use1.id,
+                    "scans": [scan1.id],
+                    "scanjobs": [],
+                    "scantasks": [],
+                },
+                {
+                    "source": source_in_use2.id,
+                    "scans": [scan2.id],
+                    "scanjobs": [scan2job.id],
+                    "scantasks": [scan2task.id],
+                },
+            ],
+            key=lambda skipped: skipped["source"],
+        )
+        actual_skipped = sorted(
+            response_json["skipped"], key=lambda skipped: skipped["source"]
+        )
+        assert expected_skipped == actual_skipped
+
+        assert not Source.objects.exclude(
+            pk__in=[source_in_use1.id, source_in_use2.id]
+        ).exists()
+        assert Source.objects.filter(
+            pk__in=[source_in_use1.id, source_in_use2.id]
+        ).exists()

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -5,8 +5,13 @@ from rest_framework import status
 
 from api.common.util import DELETE_ALL_IDS_MAGIC_STRING
 from api.source.model import Source
-from tests.api.credential.test_credential import generate_invalid_id
-from tests.factories import ScanFactory, ScanJobFactory, ScanTaskFactory, SourceFactory
+from tests.factories import (
+    ScanFactory,
+    ScanJobFactory,
+    ScanTaskFactory,
+    SourceFactory,
+    generate_invalid_id,
+)
 
 
 @pytest.mark.django_db

--- a/quipucords/tests/api/test_urls.py
+++ b/quipucords/tests/api/test_urls.py
@@ -25,6 +25,7 @@ from rest_framework.reverse import reverse
         ),
         ("v1:source-list", {}, "/api/v1/sources/"),
         ("v1:source-detail", {"pk": 1}, "/api/v1/sources/1/"),
+        ("v1:sources-bulk-delete", {}, "/api/v1/sources/bulk_delete/"),
         ("v1:scan-list", {}, "/api/v1/scans/"),
         ("v1:scan-detail", {"pk": 1}, "/api/v1/scans/1/"),
         ("v1:scan-filtered-jobs", {"scan_id": 1}, "/api/v1/scans/1/jobs/"),

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -306,3 +306,17 @@ class InspectResultFactory(DjangoModelFactory):
         """Factory options."""
 
         model = "api.InspectResult"
+
+
+def generate_invalid_id(faker: factory.Faker) -> int:
+    """Return a large number that likely does not exist as a real model object id."""
+    return faker.pyint(min_value=990000, max_value=999999)
+
+
+def generate_openssh_pkey(faker: factory.Faker) -> str:
+    """Generate a random OpenSSH private key."""
+    pkey = "-----BEGIN OPENSSH EXAMPLE KEY-----\n"
+    for __ in range(5):
+        pkey += f"{faker.lexify('?' * 70)}\n"
+    pkey += "-----END OPENSSH EXAMPLE KEY-----\n"
+    return pkey

--- a/quipucords/tests/scanner/network/test_network_connect.py
+++ b/quipucords/tests/scanner/network/test_network_connect.py
@@ -20,7 +20,7 @@ from scanner.network.utils import (
     delete_ssh_keyfiles,
     is_gen_ssh_keyfile,
 )
-from tests.api.credential.test_credential import generate_openssh_pkey
+from tests.factories import generate_openssh_pkey
 from tests.scanner.test_util import create_scan_job
 
 

--- a/quipucords/tests/scanner/network/test_network_inspect.py
+++ b/quipucords/tests/scanner/network/test_network_inspect.py
@@ -23,7 +23,7 @@ from scanner.network.exceptions import NetworkCancelException, NetworkPauseExcep
 from scanner.network.inspect import construct_inventory
 from scanner.network.inspect_callback import InspectCallback
 from scanner.network.utils import delete_ssh_keyfiles, is_gen_ssh_keyfile
-from tests.api.credential.test_credential import generate_openssh_pkey
+from tests.factories import generate_openssh_pkey
 from tests.scanner.test_util import create_scan_job
 
 ANSIBLE_FACTS = "ansible_facts"


### PR DESCRIPTION
This change is a followup to https://github.com/quipucords/quipucords/pull/2540, https://github.com/quipucords/quipucords/pull/2586, and https://github.com/quipucords/quipucords/pull/2593 to add the ability to bulk delete sources with a single HTTP POST. The new sources bulk delete API behaves similar to the recent credentials bulk delete API.

To delete *all* sources, post a json payload like `{"ids": "all"}`:

```bash
http post \
  http://127.0.0.1:8000/api/v1/sources/bulk_delete/ \
  'Cookie:csrftoken=mytoken; sessionid=mysession' 'X-CSRFToken:mytoken' \
  ids:='"all"'
```

To delete specific sources, post a json payload like `{"ids": [1,2,3,4]}`:

```bash
http post \
  http://127.0.0.1:8000/api/v1/sources/bulk_delete/ \
  'Cookie:csrftoken=mytoken; sessionid=mysession' 'X-CSRFToken:mytoken' \
  ids:='[1,2,3,4]'
```

Sources that are still in use by other scans (or scan-related objects) will be skipped and reported as such in the response. For example:

```json
{
  "message": "Deleted 4 sources. Could not find 0 sources. Failed to delete 4 sources.",
  "deleted": [
    18090,
    18091,
    18092,
    18093
  ],
  "missing": [],
  "skipped": [
    {
      "source": 18078,
      "scans": [
        11707
      ],
      "scanjobs": [
        19200
      ],
      "scantasks": [
        15759,
        15758
      ]
    },
    {
      "source": 18079,
      "scans": [
        11708
      ],
      "scanjobs": [
        19201
      ],
      "scantasks": [
        15761,
        15762
      ]
    },
    {
      "source": 18080,
      "scans": [
        11709
      ],
      "scanjobs": [
        19202
      ],
      "scantasks": [
        15765,
        15764
      ]
    },
    {
      "source": 18081,
      "scans": [
        11710
      ],
      "scanjobs": [
        19203
      ],
      "scantasks": [
        15768,
        15767
      ]
    }
  ]
}
```