### PR TITLE
feat: add support for bulk deleting scans

### DIFF
--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -3,6 +3,7 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
 
+from api.scan.view import scan_bulk_delete
 from api.views import (
     CredentialViewSet,
     DetailsReportsViewSet,
@@ -42,11 +43,8 @@ v1_urls = [
         credential_bulk_delete,
         name="credentials-bulk-delete",
     ),
-    path(
-        "sources/bulk_delete/",
-        source_bulk_delete,
-        name="sources-bulk-delete",
-    ),
+    path("sources/bulk_delete/", source_bulk_delete, name="sources-bulk-delete"),
+    path("scans/bulk_delete/", scan_bulk_delete, name="scans-bulk-delete"),
     path("reports/<int:report_id>/details/", details, name="reports-details"),
     path(
         "reports/<int:report_id>/deployments/", deployments, name="reports-deployments"

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -1,4 +1,4 @@
-"""Test the API application."""
+"""Tests for quipucords.api.source.view."""
 import datetime
 import random
 import time

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -1,4 +1,11 @@
-"""Tests for quipucords.api.source.view."""
+"""Tests for quipucords.api.source.view.
+
+Several tests in TestCredentialBulkDelete overlap significantly with tests in
+TestSourceBulkDelete and TestScanBulkDelete because their underlying
+functionality is very similar.
+
+@TODO abstract bulk delete logic tests and deduplicate their code (DRY!)
+"""
 import datetime
 import random
 import time

--- a/quipucords/tests/api/scan/test_scan_bulk_delete.py
+++ b/quipucords/tests/api/scan/test_scan_bulk_delete.py
@@ -1,0 +1,132 @@
+"""Tests for quipucords.api.scan.view.scan_bulk_delete."""
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from api.common.util import ALL_IDS_MAGIC_STRING
+from api.scan.model import Scan
+from api.scanjob.model import ScanJob
+from tests.factories import (
+    ReportFactory,
+    ScanFactory,
+    ScanJobFactory,
+    ScanTaskFactory,
+    generate_invalid_id,
+)
+
+
+@pytest.mark.django_db
+class TestScanBulkDelete:
+    """Tests the Scan bulk_delete function."""
+
+    def test_bulk_delete_specific_ids(self, client_logged_in):
+        """Test that bulk delete deletes all requested scans."""
+        scan1 = ScanFactory()
+        scan2 = ScanFactory()
+        delete_request = {"ids": [scan1.id, scan2.id]}
+        response = client_logged_in.post(
+            reverse("v1:scans-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(Scan.objects.filter(id__in=[scan1.id, scan2.id])) == 0
+
+    def test_bulk_delete_all_ids(self, client_logged_in):
+        """Test that bulk delete deletes all scans."""
+        scan1 = ScanFactory()
+        scan2 = ScanFactory()
+        delete_request = {"ids": ALL_IDS_MAGIC_STRING}
+        response = client_logged_in.post(
+            reverse("v1:scans-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(Scan.objects.filter(id__in=[scan1.id, scan2.id])) == 0
+        assert Scan.objects.count() == 0
+
+    def test_bulk_delete_rejects_invalid_inputs(self, client_logged_in):
+        """
+        Test that bulk delete rejects unexpected value types in "ids".
+
+        Note: test_set_of_ids_or_all_str covers bad inputs more exhaustively.
+        """
+        invalid_delete_params = {"ids": []}
+        response = client_logged_in.post(
+            reverse("v1:scans-bulk-delete"),
+            data=invalid_delete_params,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_bulk_delete_ignores_missing_ids(self, client_logged_in, faker):
+        """Test bulk delete succeeds and reports missing IDs."""
+        scan1 = ScanFactory()
+        scan2 = ScanFactory()
+        non_existent_id = generate_invalid_id(faker)
+        delete_request = {"ids": [non_existent_id, scan1.id, scan2.id]}
+        response = client_logged_in.post(
+            reverse("v1:scans-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = response.json()
+        assert set(response_json["deleted"]) == set([scan1.id, scan2.id])
+        assert response_json["missing"] == [non_existent_id]
+        assert not Scan.objects.filter(pk__in=[scan1.id, scan2.id]).exists()
+
+    def test_bulk_delete_ignores_errors(self, client_logged_in):
+        """Test bulk delete succeeds and deletes related objects."""
+        scan1 = ScanFactory()
+        scan2_in_use = ScanFactory()
+        scan2report = ReportFactory(scanjob=None)
+        scan2job = ScanJobFactory(scan=scan2_in_use, report=scan2report)
+        scan2task = ScanTaskFactory(job=scan2job)
+        delete_request = {"ids": [scan2_in_use.id, scan1.id]}
+        response = client_logged_in.post(
+            reverse("v1:scans-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = response.json()
+        assert set(response_json["deleted"]) == {scan1.id, scan2_in_use.id}
+        assert response_json["missing"] == []
+        assert not Scan.objects.filter(pk__in=[scan1.id, scan2_in_use.id]).exists()
+
+        # Deleting a scan should clean up its jobs and tasks.
+        with pytest.raises(scan2job.DoesNotExist):
+            scan2job.refresh_from_db()
+        with pytest.raises(scan2task.DoesNotExist):
+            scan2task.refresh_from_db()
+        # However, its report is orphaned and breaks its link to the job.
+        # This is a "legacy" behavior that I'm not too happy with.
+        # Maybe we should change that and clear objects better in the future.
+        # TODO Maybe deleting a scan/task/job should also delete its reports.
+        scan2report.refresh_from_db()
+        with pytest.raises(ScanJob.DoesNotExist):
+            assert scan2report.scanjob
+
+    def test_bulk_delete_all(self, client_logged_in):
+        """Test bulk delete succeeds with magic "all" token."""
+        scan1 = ScanFactory()
+        scan2_in_use = ScanFactory()
+        ScanJobFactory(scan=scan2_in_use)
+
+        delete_request = {"ids": ALL_IDS_MAGIC_STRING}
+        response = client_logged_in.post(
+            reverse("v1:scans-bulk-delete"),
+            data=delete_request,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        response_json = response.json()
+        assert set(response_json["deleted"]) == {
+            scan1.id,
+            scan2_in_use.id,
+        }
+        assert response_json["missing"] == []
+
+        assert not Scan.objects.filter(pk__in=[scan1.id, scan2_in_use.id]).exists()

--- a/quipucords/tests/api/scan/test_scan_bulk_delete.py
+++ b/quipucords/tests/api/scan/test_scan_bulk_delete.py
@@ -1,4 +1,12 @@
-"""Tests for quipucords.api.scan.view.scan_bulk_delete."""
+"""
+Tests for quipucords.api.scan.view.scan_bulk_delete.
+
+Several tests in TestScanBulkDelete overlap significantly with tests in
+TestSourceBulkDelete and TestCredentialBulkDelete because their underlying
+functionality is very similar.
+
+@TODO abstract bulk delete logic tests and deduplicate their code (DRY!)
+"""
 import pytest
 from django.urls import reverse
 from rest_framework import status

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -1,4 +1,12 @@
-"""Tests for quipucords.api.source.view.source_bulk_delete."""
+"""
+Tests for quipucords.api.source.view.source_bulk_delete.
+
+Several tests in TestSourceBulkDelete overlap significantly with tests in
+TestScanBulkDelete and TestCredentialBulkDelete because their underlying
+functionality is very similar.
+
+@TODO abstract bulk delete logic tests and deduplicate their code (DRY!)
+"""
 import pytest
 from django.urls import reverse
 from rest_framework import status

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -1,4 +1,4 @@
-"""Tests for quipucords.api.source.source_bulk_delete."""
+"""Tests for quipucords.api.source.view.source_bulk_delete."""
 import pytest
 from django.urls import reverse
 from rest_framework import status


### PR DESCRIPTION
This change is a followup to https://github.com/quipucords/quipucords/pull/2540, https://github.com/quipucords/quipucords/pull/2586, https://github.com/quipucords/quipucords/pull/2593, https://github.com/quipucords/quipucords/pull/2605, and https://github.com/quipucords/quipucords/pull/2608 to add the ability to bulk delete scans with a single HTTP POST. The new scans bulk delete API behaves similar to the recent credentials bulk delete and sources bulk delete APIs.


To delete *all* scans, post a json payload like `{"ids": "all"}`:

```bash
http post \
  http://127.0.0.1:8000/api/v1/scans/bulk_delete/ \
  'Cookie:csrftoken=mytoken; sessionid=mysession' 'X-CSRFToken:mytoken' \
  ids:='"all"'
```

To delete specific scans, post a json payload like `{"ids": [13652,13653,13654,13655]}`:

```bash
http post \
  http://127.0.0.1:8000/api/v1/scans/bulk_delete/ \
  'Cookie:csrftoken=mytoken; sessionid=mysession' 'X-CSRFToken:mytoken' \
  ids:='[13652,13653,13654,13655]'
```

Responses generally look like this example:

```json
{
    "deleted": [
        13654,
        13655
    ],
    "message": "Deleted 2 scans. Could not find 2 scans.",
    "missing": [
        13652,
        13653
    ]
}
```

Note that if you bulk delete all scans _while_ a scan is running, the delete will succeed, and the server will (likely very soon) raise an exception and log errors with stack traces like this:

```
[ERROR 2024-03-18T18:03:38 pid=8522 tid=123145546133504 api/scantask/model.py:_log_scan_message:173] Job 17514, Task 2 of 3 (inspect, network, dev01 rhel9-with-ssh, elapsed_time: 6s) - Unexpected failure occurred. See context below.
SCAN JOB: ScanJob object (17514)
TASK: ScanTask object (16969)
SOURCE: Source object (13499)
CREDENTIALS: [['Credential object (17651)']]
```
...
```
psycopg2.errors.ForeignKeyViolation: insert or update on table "api_scantask" violates foreign key constraint "api_scantask_job_id_d5f59645_fk_api_scanjob_id"
DETAIL:  Key (job_id)=(17514) is not present in table "api_scanjob".
```
...
```
django.db.utils.IntegrityError: insert or update on table "api_scantask" violates foreign key constraint "api_scantask_job_id_d5f59645_fk_api_scanjob_id"
DETAIL:  Key (job_id)=(17514) is not present in table "api_scanjob".

[INFO 2024-03-18T18:03:40 pid=7038 tid=123145546133504 api/scanjob/model.py:log_message:116] Job 17514 (inspect, elapsed_time: 0s) - SCAN JOB MANAGER: Process successfully terminated.
```

The server itself recovers just fine after those errors, and I'm able to interact with the API and UI normally, create a new scan, etc.

Relates to JIRA: DISCOVERY-573 DISCOVERY-468