### PR TITLE
fix: change the constrain logic to shutdown a scanjob after timeout

### DIFF
--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -263,7 +263,7 @@ class Manager(Thread):
                     self.termination_elapsed_time += self.run_queue_sleep_time
                     if (
                         self.termination_elapsed_time
-                        == settings.MAX_TIMEOUT_ORDERLY_SHUTDOWN
+                        >= settings.MAX_TIMEOUT_ORDERLY_SHUTDOWN
                     ):
                         self.terminated_job_runner.scan_job.log_message(
                             "FORCEFUL TERMINATION OF JOB PROCESS"


### PR DESCRIPTION
There is a situation where the scan_job is not terminated by timeout due to the moment of comparison being to restrict and slips way from being shutting down (it may be caused by concurrency).

This change amplifies the range of comparison, from being 'exactly equal' to 'equal or greater than' MAX_TIMEOUT_ORDERLY_SHUTDOWN.


How this env var is set.
```
MAX_TIMEOUT_ORDERLY_SHUTDOWN = env.int("MAX_TIMEOUT_ORDERLY_SHUTDOWN", 30)
```

Example of scan_job not being shutting down:

```
[INFO 2024-03-28T14:13:39 pid=25 tid=140226408220224 api/scanjob/model.py:log_message:116] Job 24 (inspect, elapsed_time: 0s) - SCAN JOB MANAGER: Scan job has not acknowledged request to terminate after 8665s.
[INFO 2024-03-28T14:13:44 pid=25 tid=140226408220224 api/scanjob/model.py:log_message:116] Job 24 (inspect, elapsed_time: 0s) - SCAN JOB MANAGER: Scan job has not acknowledged request to terminate after 8670s.
[INFO 2024-03-28T14:13:49 pid=25 tid=140226408220224 api/scanjob/model.py:log_message:116] Job 24 (inspect, elapsed_time: 0s) - SCAN JOB MANAGER: Scan job has not acknowledged request to terminate after 8675s.
```