### PR TITLE
Replace django_client fixture on test async merge + test QoL

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,8 @@ from urllib.parse import urljoin
 import pytest
 from django.contrib.auth import get_user_model
 from django.core import management
-from django.test import Client, override_settings
+from django.test import Client as DjangoClient
+from django.test import override_settings
 
 
 @pytest.fixture(scope="session")
@@ -101,6 +102,28 @@ def qpc_user_simple(faker):
     For tests that don't actually need a password, this is much faster than qpc_user.
     """
     return get_user_model().objects.create(username=faker.user_name())
+
+
+class Client(DjangoClient):
+    """Django client for tests with some QoL changes."""
+
+    def post(self, *args, **kwargs):
+        """POST request."""
+        # set application/json as default for improved ergonomics
+        kwargs.setdefault("content_type", "application/json")
+        return super().post(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        """PUT request."""
+        # set application/json as default for improved ergonomics
+        kwargs.setdefault("content_type", "application/json")
+        return super().put(*args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        """PATCH request."""
+        # set application/json as default for improved ergonomics
+        kwargs.setdefault("content_type", "application/json")
+        return super().patch(*args, **kwargs)
 
 
 @pytest.fixture

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -74,7 +74,7 @@ class TestCredential:
     def create(self, data, client_logged_in):
         """Call the create endpoint."""
         url = reverse("v1:credentials-list")
-        return client_logged_in.post(url, data=data, content_type="application/json")
+        return client_logged_in.post(url, data=data)
 
     def create_expect_400(self, data, client_logged_in):
         """We will do a lot of create tests that expect HTTP 400s."""
@@ -208,9 +208,7 @@ class TestCredential:
         }
         if cred_type == DataSources.RHACS:
             data["auth_token"] = "auth token"
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -229,9 +227,7 @@ class TestCredential:
             "cred_type": cred_type,
             "password": "pass1",
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["username"]
 
@@ -247,9 +243,7 @@ class TestCredential:
             "username": "user1",
             "cred_type": DataSources.NETWORK,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
         assert response.json()["non_field_errors"] == [
             messages.HC_PWD_OR_KEYFILE_OR_KEY
@@ -268,9 +262,7 @@ class TestCredential:
             "cred_type": DataSources.NETWORK,
             "ssh_keyfile": "blah",
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["ssh_keyfile"]
 
@@ -292,9 +284,7 @@ class TestCredential:
             "ssh_keyfile": str(ssh_keyfile),
             "ssh_key": openssh_key,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["non_field_errors"] == [messages.HC_KEYFILE_OR_KEY]
@@ -313,9 +303,7 @@ class TestCredential:
             "password": "pass1",
             "ssh_key": openssh_key,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["non_field_errors"] == [messages.HC_PWD_NOT_WITH_KEY]
@@ -336,9 +324,7 @@ class TestCredential:
             "password": faker.password(length=12),
             "ssh_passphrase": faker.password(length=16),
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["ssh_passphrase"] == [messages.HC_NO_KEY_W_PASS]
@@ -357,9 +343,7 @@ class TestCredential:
             "password": "pass1",
             "cred_type": DataSources.NETWORK,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -379,9 +363,7 @@ class TestCredential:
             "password": "pass1",
             "cred_type": DataSources.NETWORK,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -401,9 +383,7 @@ class TestCredential:
             "password": "A" * 2000,
             "cred_type": DataSources.NETWORK,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -424,9 +404,7 @@ class TestCredential:
             "become_password": "A" * 2000,
             "cred_type": DataSources.NETWORK,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -446,9 +424,7 @@ class TestCredential:
             "ssh_keyfile": "A" * 2000,
             "cred_type": DataSources.NETWORK,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -508,7 +484,7 @@ class TestCredential:
         data = {"name": "cred2", "username": "user23", "password": "pass2"}
         data[field] = "newvalue"
         url = reverse("v1:credentials-detail", args=(resp["id"],))
-        resp = client_logged_in.put(url, data=data, content_type="application/json")
+        resp = client_logged_in.put(url, data=data)
         assert resp.status_code == status.HTTP_200_OK
 
     def test_hostcred_update_double(self, client_logged_in):
@@ -531,7 +507,7 @@ class TestCredential:
 
         data = {"name": "cred1", "username": "user2", "password": "pass2"}
         url = reverse("v1:credentials-detail", args=(resp2["id"],))
-        resp = client_logged_in.put(url, data=data, content_type="application/json")
+        resp = client_logged_in.put(url, data=data)
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_hostcred_retrieve_view(self, client_logged_in):
@@ -616,9 +592,7 @@ class TestCredential:
             "username": "user1",
             "ssh_keyfile": "keyfile",
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -648,9 +622,7 @@ class TestCredential:
         }
         if cred_type == DataSources.RHACS:
             data["auth_token"] = "auth token"
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_201_CREATED
         response_json = response.json()
         assert "become_method" not in response_json
@@ -751,9 +723,7 @@ class TestCredential:
             "password": "pass1",
             "become_method": method,
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_sat_cred_create(self, client_logged_in):
@@ -792,9 +762,7 @@ class TestCredential:
             "username": "user1",
             "ssh_keyfile": "keyfile",
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
@@ -840,7 +808,6 @@ class TestCredential:
         response = client_logged_in.post(
             url,
             data=data,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()[dict_key] == [message]
@@ -873,7 +840,6 @@ class TestCredential:
                 "password": "supersecretpassword",
                 "ssh_keyfile": None,
             },
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
 
@@ -901,15 +867,12 @@ class TestCredential:
         response = client_logged_in.post(
             reverse("v1:credentials-list"),
             data=credentials,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_201_CREATED
 
         credentials["cred_type"] = new_type
         url = reverse("v1:credentials-detail", args=(response.json()["id"],))
-        resp = client_logged_in.put(
-            url, data=credentials, content_type="application/json"
-        )
+        resp = client_logged_in.put(url, data=credentials)
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
         assert resp.json() == {
             "cred_type": ["cred_type is invalid for credential update"]
@@ -926,9 +889,7 @@ class TestCredential:
             "username": "some-user",
             "ssh_keyfile": str(ssh_keyfile1),
         }
-        response = client_logged_in.post(
-            reverse("v1:credentials-list"), data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:credentials-list"), data=data)
         assert response.status_code == status.HTTP_201_CREATED
 
         ssh_keyfile2 = tmp_path / faker.file_name(extension="pem")
@@ -936,9 +897,7 @@ class TestCredential:
         cred_id = response.json().get("id")
         url = reverse("v1:credentials-detail", args=(cred_id,))
         data = {"name": credential_name, "ssh_keyfile": str(ssh_keyfile2)}
-        response = client_logged_in.patch(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         response_ssh_keyfile = response.json().get("ssh_keyfile")
@@ -956,9 +915,7 @@ class TestCredential:
             "username": "some-user",
             "password": "some-password",
         }
-        response = client_logged_in.post(
-            reverse("v1:credentials-list"), data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:credentials-list"), data=data)
         assert response.status_code == status.HTTP_201_CREATED
 
         ssh_keyfile = tmp_path / faker.file_name(extension="pem")
@@ -970,9 +927,7 @@ class TestCredential:
             "password": None,
             "ssh_keyfile": str(ssh_keyfile),
         }
-        response = client_logged_in.patch(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         json_resp = response.json()
@@ -992,9 +947,7 @@ class TestCredential:
             "username": "some-user",
             "ssh_keyfile": str(ssh_keyfile1),
         }
-        response = client_logged_in.post(
-            reverse("v1:credentials-list"), data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:credentials-list"), data=data)
         assert response.status_code == status.HTTP_201_CREATED
 
         cred_id = response.json().get("id")
@@ -1004,9 +957,7 @@ class TestCredential:
             "password": "some-password",
             "ssh_keyfile": None,
         }
-        response = client_logged_in.patch(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         json_resp = response.json()
@@ -1025,9 +976,7 @@ class TestCredential:
             "cred_type": DataSources.NETWORK,
             "ssh_key": openssh_key,
         }
-        response = client_logged_in.post(
-            reverse("v1:credentials-list"), data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:credentials-list"), data=data)
         assert response.status_code == status.HTTP_201_CREATED
 
         cred_id = response.json()["id"]
@@ -1035,9 +984,7 @@ class TestCredential:
         updated_data = {
             "ssh_key": updated_openssh_key,
         }
-        response = client_logged_in.patch(
-            url, data=updated_data, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data=updated_data)
         assert response.status_code == status.HTTP_200_OK
 
         cred = Credential.objects.get(id=cred_id)
@@ -1058,17 +1005,13 @@ class TestCredential:
             "username": "user1",
             "password": "pass1",
         }
-        response = client_logged_in.post(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.post(url, data=data)
         assert response.status_code == status.HTTP_201_CREATED
 
         cred_id = response.json().get("id")
         url = reverse("v1:credentials-detail", args=(cred_id,))
         data.update({"ssh_key": openssh_key})
-        response = client_logged_in.patch(
-            url, data=data, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data=data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["non_field_errors"] == [messages.HC_PWD_NOT_WITH_KEY]
@@ -1098,7 +1041,6 @@ class TestCredentialBulkDelete:
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         assert len(Credential.objects.filter(id__in=[cred1.id, cred2.id])) == 0
@@ -1111,7 +1053,6 @@ class TestCredentialBulkDelete:
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         assert len(Credential.objects.filter(id__in=[cred1.id, cred2.id])) == 0
@@ -1127,7 +1068,6 @@ class TestCredentialBulkDelete:
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=invalid_delete_params,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -1140,7 +1080,6 @@ class TestCredentialBulkDelete:
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
@@ -1159,7 +1098,6 @@ class TestCredentialBulkDelete:
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
@@ -1183,7 +1121,6 @@ class TestCredentialBulkDelete:
         response = client_logged_in.post(
             reverse("v1:credentials-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()

--- a/quipucords/tests/api/scan/test_scan.py
+++ b/quipucords/tests/api/scan/test_scan.py
@@ -69,9 +69,7 @@ class TestScanCreate:
             expected_scan_type = scan_type
         else:
             expected_scan_type = ScanTask.SCAN_TYPE_INSPECT
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == {
             "id": mocker.ANY,
@@ -94,9 +92,7 @@ class TestScanCreate:
         # at view level).
         source = SourceFactory()
         payload = {"sources": [source.id]}
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {"name": ["This field is required."]}
 
@@ -116,9 +112,7 @@ class TestScanCreate:
         # at view level).
         payload = {"name": faker.bothify("Scan ????-######")}
         payload.update(extra_payload)
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {"sources": [expected_error_message]}
 
@@ -134,9 +128,7 @@ class TestScanCreate:
             "sources": [source.id],
             "scan_type": scan_type,
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {"scan_type": [mocker.ANY]}
         error_message = response.json()["scan_type"][0]
@@ -158,9 +150,7 @@ class TestScanCreate:
             "sources": [source.id],
             "scan_type": "",
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "scan_type": [
@@ -177,9 +167,7 @@ class TestScanCreate:
             "name": faker.bothify("Scan ????-######"),
             "sources": [faker.slug()],
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "sources": ["Source identifiers must be integer values."]
@@ -194,9 +182,7 @@ class TestScanCreate:
             "name": faker.bothify("Scan ????-######"),
             "sources": [999999],
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "sources": ["Source with id=999999 could not be found in database."]
@@ -214,9 +200,7 @@ class TestScanCreate:
                 }
             },
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_201_CREATED
         DEFAULT_MAX_CONCURRENCY = 25
         assert response.json() == {
@@ -257,9 +241,7 @@ class TestScanCreate:
                 "max_concurrency": -5,
             },
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "options": {
@@ -277,9 +259,7 @@ class TestScanCreate:
                 "max_concurrency": 10000,
             },
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "options": {
@@ -301,9 +281,7 @@ class TestScanCreate:
             "sources": [source.id],
             "options": {"disabled_optional_products": "foo"},
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "options": {
@@ -326,9 +304,7 @@ class TestScanCreate:
             "sources": [source.id],
             "options": {"disabled_optional_products": {"jboss_eap": option_value}},
         }
-        response = client_logged_in.post(
-            reverse("v1:scan-list"), data=payload, content_type="application/json"
-        )
+        response = client_logged_in.post(reverse("v1:scan-list"), data=payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "options": {
@@ -390,9 +366,7 @@ class TestScanUpdate:
             "sources": [new_source.id],
             "scan_type": ScanTask.SCAN_TYPE_CONNECT,
         }
-        response = client_logged_in.put(
-            url, data=payload, content_type="application/json"
-        )
+        response = client_logged_in.put(url, data=payload)
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() != original_json
 
@@ -417,9 +391,7 @@ class TestScanUpdate:
         assert original_response.status_code == status.HTTP_200_OK
         original_json = original_response.json()
 
-        response_update = client_logged_in.patch(
-            url, data={"name": "NEW NAME"}, content_type="application/json"
-        )
+        response_update = client_logged_in.patch(url, data={"name": "NEW NAME"})
         assert response_update.status_code == status.HTTP_200_OK
         assert response_update.json() == {
             "id": original_json["id"],
@@ -443,9 +415,7 @@ class TestScanUpdate:
         new_source = SourceFactory()
         assert original_source.id != new_source.id
         url = reverse("v1:scan-detail", args=(scan.id,))
-        response = client_logged_in.patch(
-            url, data={"sources": [new_source.id]}, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data={"sources": [new_source.id]})
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() == {
             "id": scan.id,
@@ -475,9 +445,7 @@ class TestScanUpdate:
                 "max_concurrency": max_concurrency,
             },
         }
-        response = client_logged_in.patch(
-            url, data=payload, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data=payload)
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() == {
             "id": scan.id,
@@ -508,9 +476,7 @@ class TestScanUpdate:
         new_scan_data = ScanFactory.build()
         url = reverse("v1:scan-detail", args=(scan.id,))
         assert scan.name != new_scan_data.name
-        response = client_logged_in.patch(
-            url, data={"name": new_scan_data.name}, content_type="application/json"
-        )
+        response = client_logged_in.patch(url, data={"name": new_scan_data.name})
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() == {
             "id": scan.id,
@@ -545,9 +511,7 @@ class TestScanUpdate:
                 }
             }
         }
-        response_patch = client_logged_in.patch(
-            url, data=payload, content_type="application/json"
-        )
+        response_patch = client_logged_in.patch(url, data=payload)
         assert response_patch.status_code == status.HTTP_200_OK, response_patch.json()
 
         updated_response = client_logged_in.get(url)
@@ -568,7 +532,6 @@ class TestScanUpdate:
         response = client_logged_in.patch(
             url,
             data={"scan_type": ScanTask.SCAN_TYPE_CONNECT},
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json()["scan_type"] == ScanTask.SCAN_TYPE_CONNECT

--- a/quipucords/tests/api/scan/test_scan_bulk_delete.py
+++ b/quipucords/tests/api/scan/test_scan_bulk_delete.py
@@ -35,7 +35,6 @@ class TestScanBulkDelete:
         response = client_logged_in.post(
             reverse("v1:scans-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         assert len(Scan.objects.filter(id__in=[scan1.id, scan2.id])) == 0
@@ -48,7 +47,6 @@ class TestScanBulkDelete:
         response = client_logged_in.post(
             reverse("v1:scans-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         assert len(Scan.objects.filter(id__in=[scan1.id, scan2.id])) == 0
@@ -64,7 +62,6 @@ class TestScanBulkDelete:
         response = client_logged_in.post(
             reverse("v1:scans-bulk-delete"),
             data=invalid_delete_params,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -77,7 +74,6 @@ class TestScanBulkDelete:
         response = client_logged_in.post(
             reverse("v1:scans-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
@@ -96,7 +92,6 @@ class TestScanBulkDelete:
         response = client_logged_in.post(
             reverse("v1:scans-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
@@ -127,7 +122,6 @@ class TestScanBulkDelete:
         response = client_logged_in.post(
             reverse("v1:scans-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -34,7 +34,6 @@ class TestSourceBulkDelete:
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         assert len(Source.objects.filter(id__in=[source1.id, source2.id])) == 0
@@ -47,7 +46,6 @@ class TestSourceBulkDelete:
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         assert len(Source.objects.filter(id__in=[source1.id, source2.id])) == 0
@@ -63,7 +61,6 @@ class TestSourceBulkDelete:
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=invalid_delete_params,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -76,7 +73,6 @@ class TestSourceBulkDelete:
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
@@ -95,7 +91,6 @@ class TestSourceBulkDelete:
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
@@ -135,7 +130,6 @@ class TestSourceBulkDelete:
         response = client_logged_in.post(
             reverse("v1:sources-bulk-delete"),
             data=delete_request,
-            content_type="application/json",
         )
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()


### PR DESCRIPTION
Replace `django_client` fixture with the much faster `client_logged_in`.

Also increase rate limit threshold for tests and "hack" django's test `Client` setting the default  `content_type="application/json"`.