### PR TITLE
fix: allow /api/v1/status to be public

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -126,6 +126,15 @@ def client_logged_in(qpc_user_simple, settings) -> Client:
     yield client
 
 
+@pytest.fixture
+def client_logged_out(settings) -> Client:
+    """Create a simpler Django test client without a logged-in user."""
+    settings.WHITENOISE_AUTOREFRESH = True
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"] = "9000/second"
+    client = Client()
+    yield client
+
+
 @pytest.fixture(scope="module")
 def vcr_config(_vcr_uri_map):
     """

--- a/quipucords/api/status/view.py
+++ b/quipucords/api/status/view.py
@@ -1,7 +1,13 @@
 """View for server status."""
 import os
 
-from rest_framework.decorators import api_view
+from django.views.decorators.csrf import csrf_protect
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from api import API_VERSION
@@ -16,6 +22,9 @@ from quipucords.environment import (
 
 
 @api_view(["GET"])
+@csrf_protect
+@authentication_classes([])
+@permission_classes((AllowAny,))
 def status(request):
     """Provide the server status information."""
     commit_info = commit()

--- a/quipucords/tests/api/status/test_status.py
+++ b/quipucords/tests/api/status/test_status.py
@@ -17,3 +17,11 @@ class TestStatus:
         assert response.headers.get("X-Server-Version")
         assert response.headers["X-Server-Version"] == server_version()
         assert response.json()["api_version"] == 1
+
+    def test_status_endpoint_logged_out(self, client_logged_out):
+        """Test the status endpoint without a logged-in user."""
+        url = reverse("v1:server-status")
+        response = client_logged_out.get(url)
+        assert response.headers.get("X-Server-Version")
+        assert response.headers["X-Server-Version"] == server_version()
+        assert response.json()["api_version"] == 1


### PR DESCRIPTION
- As we use status for liveness probes and such, let's make this endpoint public, but still do the CSRF protection.
- Added tests to test without a logged in user.