### PR TITLE
chore(pagination): Upping the default paging size to 100

### DIFF
--- a/quipucords/api/common/pagination.py
+++ b/quipucords/api/common/pagination.py
@@ -6,6 +6,6 @@ from rest_framework.pagination import PageNumberPagination
 class StandardResultsSetPagination(PageNumberPagination):
     """Create standard paginiation class with page size."""
 
-    page_size = 10
+    page_size = 100
     page_size_query_param = "page_size"
     max_page_size = 1000


### PR DESCRIPTION
- While the UI may have a restriction to not show more than 10 items at a time, the default paging size for an API back-end server should be larger than 10 items.

  we have the enforced paging size limit of 1000, let's up the default paging size to 100.

  UI was calling the requests with the appropriate ?page_size=10 so this should have no effect there.