### PR TITLE
feat: check psql liveness before running migrations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:12
+        image: postgres:15
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN dnf install \
         jq \
         libpq \
         make \
+        nmap-ncat \
         openssh-clients \
         procps-ng \
         python3.11 \

--- a/deploy/check_related_services_liveness.sh
+++ b/deploy/check_related_services_liveness.sh
@@ -38,4 +38,19 @@ function check_db_liveness() {
     fi
 }
 
+function check_redis_liveness() {
+    local QPC_ENABLE_CELERY_SCAN_MANAGER
+    QPC_ENABLE_CELERY_SCAN_MANAGER=$(get_django_config QPC_ENABLE_CELERY_SCAN_MANAGER)
+    if [[ "${QPC_ENABLE_CELERY_SCAN_MANAGER}" == "True" ]]; then
+        local REDIS_HOST
+        REDIS_HOST=$(get_django_config REDIS_HOST)
+        local REDIS_PORT
+        REDIS_PORT=$(get_django_config REDIS_PORT)
+        check_svc_status "${REDIS_HOST}" "${REDIS_PORT}"
+    else
+        echo "Skipping redis liveness check."
+    fi
+}
+
 check_db_liveness
+check_redis_liveness

--- a/deploy/check_related_services_liveness.sh
+++ b/deploy/check_related_services_liveness.sh
@@ -33,6 +33,8 @@ function check_db_liveness() {
         local PSQL_PORT
         PSQL_PORT=$(get_django_config "DATABASES['default']['PORT']")
         check_svc_status "${PSQL_HOST}" "${PSQL_PORT}"
+    else
+        echo "Skipping postgres liveness check."
     fi
 }
 

--- a/deploy/check_related_services_liveness.sh
+++ b/deploy/check_related_services_liveness.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+shopt -s inherit_errexit
+
+function check_svc_status() {
+    local SVC_HOST=$1 SVC_PORT=$2
+    [[ $# -lt 2 ]] && echo "Error: Usage: check_svc_status SVC_HOST SVC_PORT" && exit 1
+
+    while true; do
+        echo "Checking ${SVC_HOST}:${SVC_PORT} status..."
+        ncat "${SVC_HOST}" "${SVC_PORT}" </dev/null && break
+        sleep 5
+    done
+    echo "${SVC_HOST}:${SVC_PORT} is accepting connections"
+}
+
+function get_django_config() {
+    local CONFIG_NAME=$1
+    [[ $# -lt 1 ]] && echo "Error: Usage: get_django_config CONFIG_NAME" && exit 1
+
+    PYTHON=$(poetry run command -v python 2>/dev/null || command -v python)
+    echo "from django.conf import settings;print(settings.${CONFIG_NAME})" |
+        "${PYTHON}" quipucords/manage.py shell --settings quipucords.settings
+}
+
+function check_db_liveness() {
+    local QPC_DBMS
+    QPC_DBMS=$(get_django_config QPC_DBMS)
+    if [[ "${QPC_DBMS}" == "postgres" ]]; then
+        local PSQL_HOST
+        PSQL_HOST=$(get_django_config "DATABASES['default']['HOST']")
+        local PSQL_PORT
+        PSQL_PORT=$(get_django_config "DATABASES['default']['PORT']")
+        check_svc_status "${PSQL_HOST}" "${PSQL_PORT}"
+    fi
+}
+
+check_db_liveness

--- a/deploy/entrypoint_celery_worker.sh
+++ b/deploy/entrypoint_celery_worker.sh
@@ -2,4 +2,8 @@
 # shellcheck disable=SC2312
 eval "$(ssh-agent -s)"
 
+SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
+SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
+"${SCRIPT_DIR}"/check_related_services_liveness.sh
+
 make celery-worker 2>&1 | tee -a /var/log/celery_worker.log

--- a/deploy/entrypoint_web.sh
+++ b/deploy/entrypoint_web.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+shopt -s inherit_errexit
 
 handle_certificates() {
     # verify if user provided certificates exist or create a self signed certificate.
@@ -41,6 +42,10 @@ else
     handle_certificates
     GUNICORN_CONF="/deploy/gunicorn_conf.py"
 fi
+
+SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
+SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
+"${SCRIPT_DIR}"/check_related_services_liveness.sh
 
 # We only start the server if both the DB
 # migration succeeds and the superuser is created.


### PR DESCRIPTION
If psql is the specified database but its port is not open, we now loop and emit messages like this before trying to run migrations:

```
Checking localhost:5432 status...
Ncat: Connection refused.
Checking localhost:5432 status...
Ncat: Connection refused.
```

Once the port is open, the loop exits, and migrations proceed.

I also upgraded to `postgresql:15` in our GitHub CI jobs since we recently updated to `postgresql-15` in discovery-ci.

I based these changes on the branch in https://github.com/quipucords/quipucords/pull/2622. So, that PR should merge before this one, or I need to yank its commits.