### PR TITLE
test: run shellcheck against deploy scripts to avoid bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,11 @@ jobs:
           cache: "poetry"
           cache-dependency-path: "poetry.lock"
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: poetry install
+
+      - name: Install additional tools
+        run: sudo apt-get install -y shellcheck
 
       - name: Run Test
         run: make ${{ matrix.type }} -k

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+enable=add-default-case
+enable=avoid-nullary-conditions
+enable=check-extra-masked-returns
+enable=check-set-e-suppressed
+enable=check-unassigned-uppercase
+enable=deprecate-which
+enable=quote-safe-variables
+enable=require-double-brackets
+enable=require-variable-braces

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ help:
 	@echo "  lint-ruff                     to run ultrafast ruff linter"
 	@echo "  lint-black                    to run the black format checker"
 	@echo "  lint-ansible                  to run the ansible linter (for now only do syntax check)"
+	@echo "  lint-shell                    to run the shellcheck linter"
 	@echo "  lock-requirements             to lock all python dependencies"
 	@echo "  update-requirements           to update all python dependencies"
 	@echo "  check-requirements            to check python dependency files"
@@ -122,7 +123,7 @@ test-integration:
 swagger-valid:
 	node_modules/swagger-cli/swagger-cli.js validate docs/swagger.yml
 
-lint: lint-ruff lint-black lint-ansible
+lint: lint-shell lint-ruff lint-black lint-ansible
 
 lint-ruff:
 	poetry run ruff .
@@ -133,6 +134,9 @@ lint-black:
 lint-ansible:
 	# syntax check playbooks (related roles are loaded and validated as well)
 	poetry run ansible-playbook -e variable_host=localhost -c local quipucords/scanner/network/runner/*.yml --syntax-check
+
+lint-shell:
+	shellcheck ./deploy/*.sh
 
 server-makemigrations:
 	$(PYTHON) quipucords/manage.py makemigrations api --settings quipucords.settings

--- a/deploy/entrypoint_celery_worker.sh
+++ b/deploy/entrypoint_celery_worker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
-eval `ssh-agent -s`
+# shellcheck disable=SC2312
+eval "$(ssh-agent -s)"
 
 make celery-worker 2>&1 | tee -a /var/log/celery_worker.log


### PR DESCRIPTION
I've been using `shellcheck` on my local development environments for a few years, and I find it helps make shell scripts more consistent in their style and catches bugs that I missed myself. I thought it might be time to add it to `quipucords` since our little shell scripts are starting to grow a bit.

This change adds a PR check to run `shellcheck ./deploy/*.sh`. I also applied several recommended `shellcheck` fixes to our existing code to make the check happy:

```
SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
SC2046 (warning): Quote this to prevent word splitting.
SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
SC2248 (style): Prefer double quoting even when variables don't contain special characters.
SC2250 (style): Prefer putting braces around variable references even when not strictly required.
SC2292 (style): Prefer [[ ]] over [ ] for tests in Bash/Ksh.
SC2312 (info): Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).
```