### PR TITLE
fix: allow legacy UI to be used with Celery and Quadlets

### DIFF
--- a/deploy/entrypoint_web.sh
+++ b/deploy/entrypoint_web.sh
@@ -37,6 +37,7 @@ else
     # 1. with this simpler config we delegate to nginx to deal with https shenanigans
     # 2. we can set a higher number of workers, since there's no risk for race conditions
     #    with the celery-based manager
+    handle_certificates
     GUNICORN_CONF="/deploy/gunicorn_conf.py"
 fi
 

--- a/deploy/gunicorn_conf.py
+++ b/deploy/gunicorn_conf.py
@@ -17,4 +17,8 @@ errorlog = "-"
 loglevel = "info"
 accesslog = "-"
 
+# SSL configuration
+keyfile = "/etc/ssl/qpc/server.key"
+certfile = "/etc/ssl/qpc/server.crt"
+
 start_debugger_if_required()


### PR DESCRIPTION
- Allow the legacy UI to be used when the Celery scan manager is enabled and used in a quadlet environment.


We can change this once the new UI replaces it and we can eliminate the legacy one.