### PR TITLE
refactor error handling in network scan

### DIFF
--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -248,10 +248,9 @@ class InspectTaskRunner(ScanTaskRunner):
                     cmdline=all_commands,
                     verbosity=verbosity_lvl,
                 )
-            except Exception as error:
+            except Exception:
                 logger.exception("Uncaught exception during Ansible Runner execution")
-                delete_ssh_keyfiles(inventory)
-                raise AnsibleRunnerException(str(error)) from error
+                continue
 
             log_message = (
                 "INSPECT PROCESSING GROUP ANSIBLE RUNNER COMPLETED"

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -257,7 +257,7 @@ class InspectTaskRunner(ScanTaskRunner):
                 f" group {group_name}: {runner_obj.status=}"
                 f" {runner_obj.rc=} {runner_obj.stats=}"
             )
-            self.scan_task.log_message(log_message, log_level=logging.DEBUG)
+            self.scan_task.log_message(log_message, log_level=logging.INFO)
 
             # Let's delete any private ssh key files that we generated
             delete_ssh_keyfiles(inventory)

--- a/quipucords/scanner/network/inspect_callback.py
+++ b/quipucords/scanner/network/inspect_callback.py
@@ -59,7 +59,7 @@ class InspectCallback:
         host = event_data.get("host", UNKNOWN_HOST)
         task = event_data.get("task")
         role = event_data.get("role")
-        logger.info("[host=%s] processing role='%s' task='%s'", host, role, task)
+        logger.debug("[host=%s] processing role='%s' task='%s'", host, role, task)
         self._process_task_facts(ansible_facts, host)
 
     def _process_task_facts(self, ansible_facts, host):
@@ -87,12 +87,18 @@ class InspectCallback:
         task = event_data.get("task")
         role = event_data.get("role")
         if result.get("rc") == TIMEOUT_RC:
-            logger.error("[host=%s] Task '%s' timed out", host, task)
+            logger.error("[host=%s role='%s' task='%s'] timed out", host, role, task)
 
         # Only log an error when ignore errors is false
         if event_data.get("ignore_errors", False):
             err_reason = result.get("msg", event_data)
-            logger.warning("[host=%s] failed - reason: %s", host, err_reason)
+            logger.warning(
+                "[host=%s role='%s' task='%s'] failed - reason: %s",
+                host,
+                role,
+                task,
+                err_reason,
+            )
 
         task_facts = result.get("ansible_facts")
         if task_facts:
@@ -100,7 +106,7 @@ class InspectCallback:
             # but do we really want to collect facts for a failed event?
             # TODO: keep an eye on logs from test lab and field for the following
             logger.warning(
-                "[host=%s] role='%s' task='%s' FAILED and contains ansible_facts",
+                "[host=%s role='%s' task='%s'] FAILED and contains ansible_facts",
                 host,
                 role,
                 task,

--- a/quipucords/tests/scanner/network/test_inspect_callback.py
+++ b/quipucords/tests/scanner/network/test_inspect_callback.py
@@ -226,7 +226,13 @@ class TestInspectCallback:
     @pytest.mark.parametrize(
         "ignore_errors,expected_messages",
         (
-            (True, ["[host=127.0.0.1] failed - reason: non-zero return code"]),
+            (
+                True,
+                [
+                    "[host=127.0.0.1 role='check_dependencies' task='gather "
+                    "internal_have_java_cmd'] failed - reason: non-zero return code"
+                ],
+            ),
             (False, []),
         ),
     )
@@ -258,8 +264,8 @@ class TestInspectCallback:
         callback.event_callback(event_failed)
         assert callback._ansible_facts["127.0.0.1"] == {"watermelon": "melancia"}
         assert caplog.messages == [
-            "[host=127.0.0.1] failed - reason: non-zero return code",
-            "[host=127.0.0.1] role='check_dependencies' task='gather internal_have_java_cmd' FAILED and contains ansible_facts",  # noqa: E501
+            "[host=127.0.0.1 role='check_dependencies' task='gather internal_have_java_cmd'] failed - reason: non-zero return code",  # noqa: E501
+            "[host=127.0.0.1 role='check_dependencies' task='gather internal_have_java_cmd'] FAILED and contains ansible_facts",  # noqa: E501
         ]
 
     def test_task_on_unreachable(self, event_unreachable, mocker):


### PR DESCRIPTION
Fix a vulnerability found in network scan that could cause a whole scan to fail if a failure occurs in a single "inspection group".

This is related to [DISCOVERY-353](https://issues.redhat.com/browse/DISCOVERY-353) and could also be related to   [DISCOVERY-464](https://issues.redhat.com/browse/DISCOVERY-464) 

Relates to JIRA: DISCOVERY-353
