### PR TITLE
refactor: move jboss roles to the end because they seem to be problematic

### DIFF
--- a/quipucords/scanner/network/runner/inspect.yml
+++ b/quipucords/scanner/network/runner/inspect.yml
@@ -7,7 +7,6 @@
     # IMPORTANT NOTE:
     # The order of these roles is specific and deliberate.
     # Do not sort or reorder these without specific reasons.
-    - user_data
     - check_dependencies
     - connection
     - virt
@@ -16,11 +15,9 @@
     - dmi
     - cloud_provider
     - etc_release
-    - file_contents
     - ifconfig
     - ip
     - installed_products
-    - redhat_packages
     - subman
     - uname
     - virt_what
@@ -28,6 +25,9 @@
     - system_purpose
     - redhat_release
     - memory
+    - user_data
+    - redhat_packages
+    - file_contents
     - jboss_eap
     - jboss_eap5
     - jboss_brms

--- a/quipucords/scanner/network/runner/inspect.yml
+++ b/quipucords/scanner/network/runner/inspect.yml
@@ -4,6 +4,9 @@
   # update roles structure when we transition off ansible 2.3
   # https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html
   roles:
+    # IMPORTANT NOTE:
+    # The order of these roles is specific and deliberate.
+    # Do not sort or reorder these without specific reasons.
     - user_data
     - check_dependencies
     - connection
@@ -14,12 +17,6 @@
     - cloud_provider
     - etc_release
     - file_contents
-    - jboss_eap
-    - jboss_eap5
-    - jboss_brms
-    - jboss_fuse
-    - jboss_ws
-    - jboss_fuse_on_karaf
     - ifconfig
     - ip
     - installed_products
@@ -31,4 +28,10 @@
     - system_purpose
     - redhat_release
     - memory
+    - jboss_eap
+    - jboss_eap5
+    - jboss_brms
+    - jboss_fuse
+    - jboss_ws
+    - jboss_fuse_on_karaf
     - host_done


### PR DESCRIPTION
…, and we want to minimize their disruption to other roles

Also move a few more roles later that @bruno-fs identified that may be slow or problematic.

Relates to JIRA: DISCOVERY-676
https://issues.redhat.com/browse/DISCOVERY-676

This is a 1.7-specific version of https://github.com/quipucords/quipucords/pull/2647