### PR TITLE
refactor(network-inspect): don't let errors to ansible runner stop the scanner

### DIFF
--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -248,10 +248,9 @@ class InspectTaskRunner(ScanTaskRunner):
                     cmdline=all_commands,
                     verbosity=verbosity_lvl,
                 )
-            except Exception as error:
+            except Exception:
                 logger.exception("Uncaught exception during Ansible Runner execution")
-                delete_ssh_keyfiles(inventory)
-                raise AnsibleRunnerException(str(error)) from error
+                continue
 
             log_message = (
                 "INSPECT PROCESSING GROUP ANSIBLE RUNNER COMPLETED"

--- a/quipucords/tests/scanner/network/test_network_inspect.py
+++ b/quipucords/tests/scanner/network/test_network_inspect.py
@@ -1,5 +1,6 @@
 """Test the inspect scanner capabilities."""
 
+import logging
 from multiprocessing import Value
 from pathlib import Path
 from unittest.mock import ANY, Mock, patch
@@ -10,6 +11,7 @@ from ansible_runner.exceptions import AnsibleRunnerException
 from django.forms import model_to_dict
 from rest_framework.reverse import reverse
 
+from api.inspectresult.model import RawFact
 from api.models import (
     Credential,
     ScanJob,
@@ -234,14 +236,19 @@ class TestNetworkInspectScanner:
         assert inventory_dict[1] == expected
 
     @patch("ansible_runner.run")
-    def test_inspect_scan_failure(self, mock_run):
+    def test_inspect_scan_failure(self, mock_run, caplog):
         """Test scan flow with mocked manager and failure."""
         mock_run.side_effect = AnsibleRunnerException()
         scanner = InspectTaskRunner(self.scan_job, self.scan_task)
         scanner.connect_scan_task = self.connect_scan_task
-        with pytest.raises(AnsibleRunnerException):
-            scanner._inspect_scan(Value("i", ScanJob.JOB_RUN), self.host_list)
-            mock_run.assert_called()
+        caplog.set_level(logging.ERROR)
+        _, scan_result = scanner._inspect_scan(
+            Value("i", ScanJob.JOB_RUN), self.host_list
+        )
+        # an error should not prevent scan completion
+        assert scan_result == "completed"
+        # no raw fact produced, given the errors
+        assert RawFact.objects.count() == 0
 
     @patch("scanner.network.inspect.InspectTaskRunner._inspect_scan")
     def test_inspect_scan_error(self, mock_scan):


### PR DESCRIPTION
cherry-picks de45f84b

Relates to JIRA: DISCOVERY-353

[Standalone Jenkins job](https://stage-jenkins-csb-smqe.apps.ocp-c1.prod.psi.redhat.com/view/Discovery/job/discovery-standalone/110/)

EDIT: all ✅ in standalone jenkins job!