### PR TITLE
feat(build): Create x.y release tags when building release containers

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           fetch-depth: 0  # fetches all commits/tags
 
+      - name: Define Release Tag
+        id: define-release-tag
+        shell: bash
+        run: echo "RELEASE_TAG=$([[ ${GITHUB_REF_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo ${GITHUB_REF_NAME%.[0-9]*}-arm64 || echo)" >> "$GITHUB_ENV"
+
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -44,7 +49,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}
           archs: arm64
-          tags: ${{ env.STABLE_TAG }} ${{ env.STABLE_TAG == 'main-arm64' && 'latest-arm64' || '' }}
+          tags: ${{ env.STABLE_TAG }} ${{ env.STABLE_TAG == 'main-arm64' && 'latest-arm64' || '' }} ${{ contains( env.RELEASE_TAG , '.' ) && env.RELEASE_TAG || '' }}
           containerfiles: |
             ./Dockerfile
           labels: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,18 @@ jobs:
         with:
           fetch-depth: 0  # fetches all commits/tags
 
+      - name: Define Release Tag
+        id: define-release-tag
+        shell: bash
+        run: echo "RELEASE_TAG=$([[ ${GITHUB_REF_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo ${GITHUB_REF_NAME%.[0-9]*} || echo)" >> "$GITHUB_ENV"
+
       - name: Build quipucords image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMAGE_NAME }}
           archs: amd64
-          tags: ${{ env.STABLE_TAG }} ${{ env.STABLE_TAG == 'main' && 'latest' || '' }}
+          tags: ${{ env.STABLE_TAG }} ${{ env.STABLE_TAG == 'main' && 'latest' || '' }} ${{ contains( env.RELEASE_TAG , '.' ) && env.RELEASE_TAG || '' }}
           containerfiles: |
             ./Dockerfile
           labels: |


### PR DESCRIPTION
- When building release containers, i.e. 1.7.1, let's make sure we create both, the x.y.z and x.y tags, i.e 1.7.1 and 1.7
- Same with the ARM64, when creating the 1.7.1-arm64 flavor of the container build, also create the 1.7-arm64 tag.