### PR TITLE
fix: only count missing_cpu_core_count for network and satellite sources

### DIFF
--- a/quipucords/api/aggregate_report/model.py
+++ b/quipucords/api/aggregate_report/model.py
@@ -134,8 +134,11 @@ def _aggregate_from_system_fingerprints(  # noqa: C901,PLR0912,PLR0915
             # here even if the "is_redhat" attribute was not set on the fingerprint.
             continue
 
-        if not fingerprint.cpu_core_count and not has_vcenter_source:
-            # Do not penalize vCenter sources because they do not collect core counts.
+        if not fingerprint.cpu_core_count and (
+            has_network_source or has_satellite_source
+        ):
+            # Only network and satellite sources set this fact,
+            # and we don't want to penalize others for not having it.
             aggregated.missing_cpu_core_count += 1
 
         if not fingerprint.cpu_socket_count:

--- a/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
+++ b/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
@@ -116,6 +116,29 @@ def report_and_expected_aggregate() -> tuple[Report, AggregateReport]:  # noqa: 
     expected_aggregate.missing_system_creation_date += 1
     expected_aggregate.os_by_name_and_version[DEFAULT_RHEL_OS_NAME]["9.2"] = 1
 
+    # RHEL with several important facts not set ("missing")
+    SystemFingerprintFactory(
+        name=None,  # missing_name++
+        os_version=None,
+        infrastructure_type=SystemFingerprint.UNKNOWN,  # instances_unknown++
+        deployment_report=deployments_report,
+        cpu_count=None,  # cpu_count is only relevant for openshift sources
+        cpu_core_count=None,  # missing_cpu_core_count++
+        cpu_socket_count=None,  # missing_cpu_socket_count++
+        system_purpose=None,  # missing_system_purpose++
+        redhat_certs=None,  # missing_pem_files++
+        sources=[source_network],
+        system_creation_date=None,  # missing_system_creation_date++
+    )
+    expected_aggregate.instances_unknown += 1
+    expected_aggregate.missing_cpu_core_count += 1
+    expected_aggregate.missing_cpu_socket_count += 1
+    expected_aggregate.missing_name += 1
+    expected_aggregate.missing_pem_files += 1
+    expected_aggregate.missing_system_creation_date += 1
+    expected_aggregate.missing_system_purpose += 1
+    expected_aggregate.os_by_name_and_version[DEFAULT_RHEL_OS_NAME][UNKNOWN] = 1
+
     # largely unknown system found via ansible
     SystemFingerprintFactory(
         os_version=None,
@@ -124,14 +147,13 @@ def report_and_expected_aggregate() -> tuple[Report, AggregateReport]:  # noqa: 
         infrastructure_type=SystemFingerprint.UNKNOWN,  # instances_unknown++
         deployment_report=deployments_report,
         cpu_count=None,  # cpu_count is only relevant for openshift sources
-        cpu_core_count=None,  # missing_cpu_core_count++
+        cpu_core_count=None,  # ansible has no effect on missing_cpu_core_count
         cpu_socket_count=None,  # missing_cpu_socket_count++
         sources=[source_ansible],
         system_creation_date=None,  # missing_system_creation_date++
     )
     expected_aggregate.instances_unknown += 1
     expected_aggregate.missing_name += 1
-    expected_aggregate.missing_cpu_core_count += 1
     expected_aggregate.missing_cpu_socket_count += 1
     expected_aggregate.missing_system_creation_date += 1
     expected_aggregate.os_by_name_and_version[UNKNOWN] = {UNKNOWN: 1}


### PR DESCRIPTION
See also Slack discussion: https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1716241418596129

Relates to JIRA: DISCOVERY-611