### PR TITLE
perf: allow bypassing cached_fingerprints build for non-production dev environments

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -107,8 +107,14 @@ class ScanJob(BaseModel):
 
         self.log_message(message, log_level=log_level)
 
-    def log_message(self, message, log_level=logging.INFO):
-        """Log a message for this job."""
+    def log_message(self, message: str, log_level=logging.INFO):
+        """
+        Log a message for this job.
+
+        TODO Rewrite this function to take a list of arguments instead of a string.
+        Or kill this function and just use standard logger functionality.
+        Variables in the message should be interpreted by standard logger functionality.
+        """
         elapsed_time = self._compute_elapsed_time()
         actual_message = (
             f"Job {self.id:d}"

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -142,9 +142,15 @@ class ScanTask(BaseModel):
 
     # All task types
     def log_message(
-        self, message, log_level=logging.INFO, static_options=None, exception=None
+        self, message: str, log_level=logging.INFO, static_options=None, exception=None
     ):
-        """Log a message for this task."""
+        """
+        Log a message for this task.
+
+        TODO Rewrite this function to take a list of arguments instead of a string.
+        Or kill this function and just use standard logger functionality.
+        Variables in the message should be interpreted by standard logger functionality.
+        """
         if exception:
             logger.exception("Got an exception.")
 
@@ -154,8 +160,16 @@ class ScanTask(BaseModel):
             self._log_scan_message(message, log_level, static_options)
 
     # All scan task types
-    def _log_scan_message(self, message, log_level=logging.INFO, static_options=None):
-        """Log a message for this task."""
+    def _log_scan_message(
+        self, message: str, log_level=logging.INFO, static_options=None
+    ):
+        """
+        Log a message for this task.
+
+        TODO Rewrite this function to take a list of arguments instead of a string.
+        Or kill this function and just use standard logger functionality.
+        Variables in the message should be interpreted by standard logger functionality.
+        """
         if not self.source:
             logger.warning("Missing source for job ID %s", self.job_id)
             source_type = None
@@ -181,8 +195,14 @@ class ScanTask(BaseModel):
         logger.log(log_level, actual_message)
 
     # Fingerprint task type
-    def _log_fingerprint_message(self, message, log_level=logging.INFO):
-        """Log a message for this task."""
+    def _log_fingerprint_message(self, message: str, log_level=logging.INFO):
+        """
+        Log a message for this task.
+
+        TODO Rewrite this function to take a list of arguments instead of a string.
+        Or kill this function and just use standard logger functionality.
+        Variables in the message should be interpreted by standard logger functionality.
+        """
         elapsed_time = self._compute_elapsed_time()
         details_report_id = None
         if self.job.report:

--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -219,24 +219,25 @@ class FingerprintTaskRunner(ScanTaskRunner):
                     number_invalid += 1
                     self.scan_task.log_message(
                         "The fingerprint could not be saved. "
-                        f"Fingerprint: {str(error).strip()}. Error: {fingerprint_dict}",
+                        f"Fingerprint: {str(error).strip()}.",
                         log_level=logging.ERROR,
                         exception=error,
                     )
+                    logger.error(fingerprint_dict)
             else:
                 number_invalid += 1
                 self.scan_task.log_message(
-                    f"Invalid fingerprint: {fingerprint_dict}",
-                    log_level=logging.ERROR,
+                    "Invalid fingerprint.", log_level=logging.ERROR
                 )
+                logger.error(fingerprint_dict)
                 self.scan_task.log_message(
                     f"Fingerprint errors: {serializer.errors}",
                     log_level=logging.ERROR,
                 )
             self.scan_task.log_message(
-                f"Fingerprints (report id={report.id}): {fingerprint_dict}",
-                log_level=logging.DEBUG,
+                f"Fingerprints (report id={report.id})", log_level=logging.DEBUG
             )
+            logger.debug(fingerprint_dict)
 
         # Mark completed because engine has processed raw facts
         status = ScanTask.COMPLETED

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -477,6 +477,12 @@ QPC_ENABLE_CELERY_SCAN_MANAGER = env.bool("QPC_ENABLE_CELERY_SCAN_MANAGER", Fals
 MAX_TIMEOUT_ORDERLY_SHUTDOWN = env.int("MAX_TIMEOUT_ORDERLY_SHUTDOWN", 30)
 QUIPUCORDS_MANAGER_HEARTBEAT = env.int("QUIPUCORDS_MANAGER_HEARTBEAT", 60 * 15)
 
+QUIPUCORDS_BYPASS_BUILD_CACHED_FINGERPRINTS = (
+    False
+    if PRODUCTION
+    else env.bool("QUIPUCORDS_BYPASS_BUILD_CACHED_FINGERPRINTS", default=False)
+)
+
 # Defining both local memory and Redis as Django back-end caches.
 #
 # For now, we're keeping the default as local memory cache, this way


### PR DESCRIPTION
🙈 🙈 🙈

🤫

🔥 🐶 ☕ 🔥 

This PR adds support for a new environment variable `QUIPUCORDS_BYPASS_BUILD_CACHED_FINGERPRINTS` that will bypass building and setting `DeploymentsReport.cached_fingerprints` during the fingerprinting process. This will cause problems if actual customers tried to enable that variable because it will result in empty or broken data when they try to download their report tarball. So, I set this only when `PRODUCTION` is not `True`, and that means our containers (both upstream and downstream) _will not_ enable this bypass because they both set `ENV PRODUCTION=True` in their respective `Dockerfile`s.

Then why am I adding this bypass? I'm performance testing quipucords with moderately large sets of simulated raw facts and fingerprints, but due to https://issues.redhat.com/browse/DISCOVERY-691, our service is not capable of handling more than ~60,000 fingerprints. I need far more than that, and my perf tests don't need `cached_fingerprints`. Hopefully this is a short-lived bypass until we better handle DISCOVERY-691, but we may want to keep this around until we further refactor our "cached" data.