### PR TITLE
feat: add `openshift_operators_by_name` and `instances_not_redhat` to aggregate report

### DIFF
--- a/quipucords/api/aggregate_report/model.py
+++ b/quipucords/api/aggregate_report/model.py
@@ -72,6 +72,7 @@ class AggregateReport:
     missing_system_creation_date: int = 0
     missing_system_purpose: int = 0
     openshift_cores: int = 0
+    openshift_operators_by_name: dict = field(default_factory=dict)
     openshift_operators_by_kind: dict = field(default_factory=dict)
     os_by_name_and_version: dict = field(default_factory=dict)
     socket_pairs: int = 0
@@ -257,6 +258,7 @@ def _aggregate_from_raw_facts(
     """
     ansible_hosts_in_database = []
     ansible_hosts_in_jobs = []
+    openshift_operators_by_name = defaultdict(int)
     openshift_operators_by_kind = defaultdict(int)
 
     for source_type, raw_facts in grouped_facts:
@@ -285,6 +287,7 @@ def _aggregate_from_raw_facts(
                     aggregated.openshift_node_instances += 1
                 for operator in raw_fact.get("operators", []):
                     openshift_operators_by_kind[operator.get("kind", UNKNOWN)] += 1
+                    openshift_operators_by_name[operator.get("name", UNKNOWN)] += 1
 
     ansible_hosts_in_database = set(ansible_hosts_in_database)
     ansible_hosts_in_jobs = set(ansible_hosts_in_jobs)
@@ -295,6 +298,7 @@ def _aggregate_from_raw_facts(
     aggregated.ansible_hosts_in_jobs = len(ansible_hosts_in_jobs)
 
     aggregated.openshift_operators_by_kind.update(openshift_operators_by_kind)
+    aggregated.openshift_operators_by_name.update(openshift_operators_by_name)
 
 
 def build_aggregate_report(report_id: int) -> AggregateReport:

--- a/quipucords/api/aggregate_report/model.py
+++ b/quipucords/api/aggregate_report/model.py
@@ -56,6 +56,7 @@ class AggregateReport:
     inspect_result_status_unknown: int = 0
     inspect_result_status_unreachable: int = 0
     instances_hypervisor: int = 0
+    instances_not_redhat: int = 0
     instances_physical: int = 0
     instances_unknown: int = 0
     instances_virtual: int = 0
@@ -136,6 +137,7 @@ def _aggregate_from_system_fingerprints(  # noqa: C901,PLR0912,PLR0915
             # to count them if we positively identified Red Hat during fingerprinting.
             # We treat everything found by OpenShift or Satellite to be "is_redhat=True"
             # here even if the "is_redhat" attribute was not set on the fingerprint.
+            aggregated.instances_not_redhat += 1
             continue
 
         if not fingerprint.cpu_core_count and (

--- a/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
+++ b/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
@@ -197,6 +197,7 @@ def report_and_expected_aggregate() -> tuple[Report, AggregateReport]:  # noqa: 
         sources=[source_network],
         system_creation_date=date(1970, 1, 1),
     )
+    expected_aggregate.instances_not_redhat += 1
     expected_aggregate.os_by_name_and_version["LCARS"] = {"NCC-1701-D": 1}
 
     # os_name, os_version, and name are frequently blank in real vcenter scans.

--- a/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
+++ b/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
@@ -284,11 +284,11 @@ def report_and_expected_aggregate() -> tuple[Report, AggregateReport]:  # noqa: 
         with_raw_facts={
             "cluster": {"kind": "cluster"},  # openshift_cluster_instances++
             "operators": [
-                {"kind": "type1"},
+                {"kind": "type1", "name": "name1"},
                 {"kind": "type2"},
-                {"kind": "type1"},
+                {"kind": "type1", "name": "name2"},
                 {},
-                {"kind": "type2"},
+                {"kind": "type2", "name": "name2"},
                 {"kind": "type2"},
             ],  # openshift_operators_by_kind[...]++
         },
@@ -299,6 +299,9 @@ def report_and_expected_aggregate() -> tuple[Report, AggregateReport]:  # noqa: 
     expected_aggregate.openshift_operators_by_kind["unknown"] = 1
     expected_aggregate.openshift_operators_by_kind["type1"] = 2
     expected_aggregate.openshift_operators_by_kind["type2"] = 3
+    expected_aggregate.openshift_operators_by_name["unknown"] = 3
+    expected_aggregate.openshift_operators_by_name["name1"] = 1
+    expected_aggregate.openshift_operators_by_name["name2"] = 2
 
     InspectResultFactory(
         inspect_group=inspect_group,


### PR DESCRIPTION
Following a demo on 2024-05-29, Justin and I discussed several potential changes to the new aggregate report. These `openshift_operators_by_name` and `instances_not_redhat` additions were trivially easy and high on his request list.

This PR only adds those two new attributes to the response JSON and does not affect other aggregated counts or lists.

Example request and response after this change:
```sh
# report 32764 is from a real scan of an OCP target
qpc report aggregate --report 32764
```
```json
{
    "ansible_hosts_all": 0,
    "ansible_hosts_in_database": 0,
    "ansible_hosts_in_jobs": 0,
    "inspect_result_status_failed": 0,
    "inspect_result_status_success": 7,
    "inspect_result_status_unknown": 0,
    "inspect_result_status_unreachable": 0,
    "instances_hypervisor": 0,
    "instances_not_redhat": 0,
    "instances_physical": 0,
    "instances_unknown": 6,
    "instances_virtual": 0,
    "jboss_eap_cores_physical": 0,
    "jboss_eap_cores_virtual": 0,
    "jboss_eap_instances": 0,
    "jboss_ws_cores_physical": 0,
    "jboss_ws_cores_virtual": 0,
    "jboss_ws_instances": 0,
    "missing_cpu_core_count": 0,
    "missing_cpu_socket_count": 6,
    "missing_name": 0,
    "missing_pem_files": 0,
    "missing_system_creation_date": 0,
    "missing_system_purpose": 0,
    "openshift_cluster_instances": 1,
    "openshift_cores": 24,
    "openshift_node_instances": 6,
    "openshift_operators_by_kind": {
        "cluster-operator": 36,
        "olm-operator": 1
    },
    "openshift_operators_by_name": {
        "authentication": 1,
        "baremetal": 1,
        "cloud-controller-manager": 1,
        "cloud-credential": 1,
        "cluster-api": 1,
        "cluster-autoscaler": 1,
        "config-operator": 1,
        "console": 1,
        "control-plane-machine-set": 1,
        "csi-snapshot-controller": 1,
        "dns": 1,
        "etcd": 1,
        "image-registry": 1,
        "ingress": 1,
        "insights": 1,
        "kube-apiserver": 1,
        "kube-controller-manager": 1,
        "kube-scheduler": 1,
        "kube-storage-version-migrator": 1,
        "machine-api": 1,
        "machine-approver": 1,
        "machine-config": 1,
        "marketplace": 1,
        "monitoring": 1,
        "network": 1,
        "node-tuning": 1,
        "olm": 1,
        "openshift-apiserver": 1,
        "openshift-controller-manager": 1,
        "openshift-samples": 1,
        "operator-lifecycle-manager": 1,
        "operator-lifecycle-manager-catalog": 1,
        "operator-lifecycle-manager-packageserver": 1,
        "platform-operators-aggregated": 1,
        "rhacs-operator": 1,
        "service-ca": 1,
        "storage": 1
    },
    "os_by_name_and_version": {
        "unknown": {
            "unknown": 6
        }
    },
    "socket_pairs": 0,
    "system_creation_date_average": "2024-04-20",
    "vmware_hosts": 0,
    "vmware_vm_to_host_ratio": 0,
    "vmware_vms": 0
}
```