### PR TITLE
fix: fix incorrect middleware product identifiers…

### DIFF
--- a/quipucords/api/aggregate_report/model.py
+++ b/quipucords/api/aggregate_report/model.py
@@ -30,8 +30,8 @@ from math import ceil
 from api.deployments_report.model import Product, SystemFingerprint
 from api.inspectresult.model import InspectResult
 from api.reports.model import Report
-from api.scan.model import Scan
 from constants import DataSources
+from fingerprinter import jboss_eap, jboss_web_server
 from utils.datetime import average_date
 
 logger = logging.getLogger(__name__)
@@ -168,8 +168,8 @@ def _aggregate_from_system_fingerprints(  # noqa: C901,PLR0912,PLR0915
             product.name: bool(product.presence == Product.PRESENT)
             for product in fingerprint.products.all()
         }
-        jboss_eap_present = product_presences.get(Scan.JBOSS_EAP, False)
-        jboss_ws_present = product_presences.get(Scan.JBOSS_WS, False)
+        jboss_eap_present = product_presences.get(jboss_eap.PRODUCT, False)
+        jboss_ws_present = product_presences.get(jboss_web_server.PRODUCT, False)
         jboss_eap_cpu_core_count = cpu_core_count if jboss_eap_present else 0
         jboss_ws_cpu_core_count = cpu_core_count if jboss_ws_present else 0
 

--- a/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
+++ b/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
@@ -14,8 +14,8 @@ from api.aggregate_report.model import (
 from api.deployments_report.model import DeploymentsReport, Product, SystemFingerprint
 from api.inspectresult.model import InspectResult
 from api.reports.model import Report
-from api.scan.model import Scan
 from constants import DataSources
+from fingerprinter import jboss_eap, jboss_web_server
 from tests.factories import (
     DeploymentReportFactory,
     InspectGroupFactory,
@@ -69,7 +69,7 @@ def report_and_expected_aggregate() -> tuple[Report, AggregateReport]:  # noqa: 
         system_creation_date=date(2024, 3, 31),
     )
     Product.objects.create(
-        name=Scan.JBOSS_EAP, presence=Product.PRESENT, fingerprint=fingerprint
+        name=jboss_eap.PRODUCT, presence=Product.PRESENT, fingerprint=fingerprint
     )  # jboss_eap_instances++, jboss_eap_cores_virtual += 2
     expected_aggregate.instances_virtual += 1
     expected_aggregate.socket_pairs += 1
@@ -91,7 +91,7 @@ def report_and_expected_aggregate() -> tuple[Report, AggregateReport]:  # noqa: 
         system_creation_date=date(2024, 4, 2),
     )
     Product.objects.create(
-        name=Scan.JBOSS_WS, presence=Product.PRESENT, fingerprint=fingerprint
+        name=jboss_web_server.PRODUCT, presence=Product.PRESENT, fingerprint=fingerprint
     )  # jboss_ws_instances++, jboss_ws_cores_physical += 8
     expected_aggregate.instances_physical += 1
     expected_aggregate.missing_system_purpose += 1


### PR DESCRIPTION
…that always resulted in 0 aggregate counts in real-world tests

Relates to JIRA: DISCOVERY-611

After this code change and after scanning a real AWS EC2 instance with EAP (not WS) installed:
```sh
qpc report aggregate --scan-job 13 | jq '{jboss_eap_instances, jboss_eap_cores_virtual, jboss_eap_cores_physical, jboss_ws_instances, jboss_ws_cores_virtual, jboss_ws_cores_physical}'
```
```json
{
  "jboss_eap_instances": 1,
  "jboss_eap_cores_virtual": 1.0,
  "jboss_eap_cores_physical": 0,
  "jboss_ws_instances": 0,
  "jboss_ws_cores_virtual": 0,
  "jboss_ws_cores_physical": 0
}
```