### PR TITLE
fix: ensure cloud_provider facts are never None when processing

### DIFF
--- a/quipucords/scanner/network/processing/cloud_provider.py
+++ b/quipucords/scanner/network/processing/cloud_provider.py
@@ -68,10 +68,10 @@ class ProcessCloudProvider(process.Processor):
     @staticmethod
     def process(output, dependencies):
         """Pass the output back through."""
-        dmi_bios_version = dependencies.get("dmi_bios_version", "")
-        dmi_chassis_asset_tag = dependencies.get("dmi_chassis_asset_tag", "")
-        dmi_system_manufacturer = dependencies.get("dmi_system_manufacturer", "")
-        dmi_system_product_name = dependencies.get("dmi_system_product_name", "")
+        dmi_bios_version = dependencies.get("dmi_bios_version", "") or ""
+        dmi_chassis_asset_tag = dependencies.get("dmi_chassis_asset_tag", "") or ""
+        dmi_system_manufacturer = dependencies.get("dmi_system_manufacturer", "") or ""
+        dmi_system_product_name = dependencies.get("dmi_system_product_name", "") or ""
         if "amazon" in dmi_bios_version.lower():
             return AMAZON
         if "google" in dmi_bios_version.lower():


### PR DESCRIPTION
Should fix this exception that @bruno-fs and I have seen on rare occasions:
```
[ERROR 2024-06-06T20:37:01 pid=64315 tid=140704491662208 api/scantask/model.py:_log_scan_message:195] Job 25, Task 2 of 3 (inspect, network, 20240606, elapsed_time: 78s) - FAILED POST PROCESSING [IP ADDRESS]. Processor for cloud_provider got value QPC_FORCE_POST_PROCESS, returned Traceback (most recent call last):
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/network/processing/process.py", line 146, in process
    processor_out = processor.process(fact_value, dependencies)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brasmith/projects/quipucords/quipucords/scanner/network/processing/cloud_provider.py", line 75, in process
    if "amazon" in dmi_bios_version.lower():
                   ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
```