### PR TITLE
refactor: store cached deployment report CSV and fingerprints JSON in files, not in the database

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -51,6 +51,8 @@ def default_data_dir(settings, tmp_path: Path) -> Path:
     settings.DEFAULT_DATA_DIR = data_dir
     settings.LOG_DIRECTORY = data_dir / "logs"
     settings.LOG_DIRECTORY.mkdir(parents=True)
+    settings.QUIPUCORDS_CACHED_REPORTS_DATA_DIR = data_dir / "cached_reports"
+    settings.QUIPUCORDS_CACHED_REPORTS_DATA_DIR.mkdir(parents=True)
     return data_dir
 
 

--- a/quipucords/api/apps.py
+++ b/quipucords/api/apps.py
@@ -1,6 +1,7 @@
 """Apps module for Django server application."""
 
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class ApiConfig(AppConfig):
@@ -10,3 +11,4 @@ class ApiConfig(AppConfig):
 
     def ready(self):
         """Mark server ready."""
+        settings.QUIPUCORDS_CACHED_REPORTS_DATA_DIR.mkdir(parents=True, exist_ok=True)

--- a/quipucords/api/migrations/0054_remove_deploymentsreport_cached_csv_and_more.py
+++ b/quipucords/api/migrations/0054_remove_deploymentsreport_cached_csv_and_more.py
@@ -1,0 +1,92 @@
+"""Migrate DeploymentsReport cached fields from DB columns to files on disk."""
+
+import json
+from sys import stdout
+from time import time
+
+from django.conf import settings
+from django.db import migrations, models
+
+import api.deployments_report.model
+
+CACHED_FILE_NAME_FORMAT = "deployments-report-{id}-{unixtime}.{extension}"
+
+
+def migrate_deployments_report_cached_fields(apps, schema_editor):
+    """Migrate DeploymentsReport cached_csv and cached_fingerprints to files."""
+    data_dir = settings.QUIPUCORDS_CACHED_REPORTS_DATA_DIR
+    data_dir.mkdir(parents=True, exist_ok=True)
+    DeploymentsReport = apps.get_model("api", "DeploymentsReport")
+    any_dirty = False
+    for deployments_report in DeploymentsReport.objects.all():
+        dirty = False
+        if deployments_report.cached_csv:
+            file_path = data_dir / CACHED_FILE_NAME_FORMAT.format(
+                id=deployments_report.id, unixtime=time(), extension="csv"
+            )
+            with file_path.open("w") as f:
+                stdout.write(
+                    f"\n  Migrating DeploymentsReport {deployments_report.id} "
+                    f"cached_csv to {file_path}",
+                )
+                f.write(deployments_report.cached_csv)
+            deployments_report.cached_csv_path = file_path
+            dirty = True
+        if deployments_report.cached_fingerprints:
+            file_path = data_dir / CACHED_FILE_NAME_FORMAT.format(
+                id=deployments_report.id, unixtime=time(), extension="json"
+            )
+            with file_path.open("w") as f:
+                stdout.write(
+                    f"\n  Migrating DeploymentsReport {deployments_report.id} "
+                    f"cached_fingerprints to {file_path}",
+                )
+                json.dump(deployments_report.cached_fingerprints, f)
+            deployments_report.cached_fingerprints_path = file_path
+            dirty = True
+        if dirty:
+            any_dirty = True
+            deployments_report.save()
+    if any_dirty:
+        stdout.write("\n  ...")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0053_alter_report_report_version"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="deploymentsreport",
+            name="cached_csv_file_path",
+            field=models.FilePathField(
+                blank=True,
+                max_length=255,
+                null=True,
+                path=api.deployments_report.model.cached_files_path,
+            ),
+        ),
+        migrations.AddField(
+            model_name="deploymentsreport",
+            name="cached_fingerprints_file_path",
+            field=models.FilePathField(
+                blank=True,
+                max_length=255,
+                null=True,
+                path=api.deployments_report.model.cached_files_path,
+            ),
+        ),
+        migrations.RunPython(
+            migrate_deployments_report_cached_fields,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RemoveField(
+            model_name="deploymentsreport",
+            name="cached_csv",
+        ),
+        migrations.RemoveField(
+            model_name="deploymentsreport",
+            name="cached_fingerprints",
+        ),
+    ]

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -520,3 +520,9 @@ if QUIPUCORDS_ENABLE_REDIS_CACHE:
 
 # Let's define various cache TTL's
 QPC_SCAN_JOB_TTL = env.int("QPC_SCAN_JOB_TTL", default=24 * 3600)
+
+QUIPUCORDS_CACHED_REPORTS_DATA_DIR = Path(
+    env.str(
+        "QUIPUCORDS_CACHED_REPORTS_DATA_DIR", str(DEFAULT_DATA_DIR / "cached_reports")
+    )
+)

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -109,6 +109,11 @@ class DeploymentReportFactory(DjangoModelFactory):
         """Reproduce the logic responsible for DUPLICATION of fingerprints."""
         # only attempt to generate fingerprints for obj already saved to db
         # and with a "STATUS_COMPLETE"
+        if kwargs.get("skip", False):
+            # Note: We have to use `kwargs` and not a real keyword argument due to
+            # factoryboy internal workings. Using a real keyword argument here would
+            # raise a `TypeError` ("got multiple values for argument 'skip'").
+            return
         if obj.id and obj.status == models.DeploymentsReport.STATUS_COMPLETE:
             # TODO get RID of this OUTRAGEOUS logic.
             serializer = SystemFingerprintSerializer(


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-691

Aside from confirming that unit tests still pass, I manually verified with a running server a few ways, probably most interestingly by migrating an existing database that already had several small scans and few "large" scans (one with about 60,000 related raw facts).

Before applying migrations:

```
❯ psql -U qpc -c 'vacuum full analyze'
VACUUM
❯ du -sh $(echo $(psql -U qpc -tc 'show data_directory')/base/$(psql -U qpc -tc "select oid from pg_database where datname='qpc'") | tr -d '[:space:]')
460M	/usr/local/var/postgresql@14/base/21683799
```

Migration output looks like this:

```
❯ poetry run make server-migrate
/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.12/bin/python quipucords/manage.py migrate --settings quipucords.settings -v 3
Operations to perform:
  Apply all migrations: admin, api, auth, authtoken, axes, contenttypes, sessions
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application authtoken
Running pre-migrate handlers for application axes
Running pre-migrate handlers for application api
Running migrations:
  Applying api.0054_remove_deploymentsreport_cached_csv_and_more...
  Migrating DeploymentsReport 10778 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-10778-1717793966.1283772.json
  Migrating DeploymentsReport 29079 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29079-1717793966.2422888.json
  Migrating DeploymentsReport 29080 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29080-1717793966.243911.json
  Migrating DeploymentsReport 29083 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29083-1717793966.251919.csv
  Migrating DeploymentsReport 29083 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29083-1717793966.252394.json
  Migrating DeploymentsReport 29081 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29081-1717793966.255309.json
  Migrating DeploymentsReport 29082 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29082-1717793966.293715.csv
  Migrating DeploymentsReport 29082 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29082-1717793966.294166.json
  Migrating DeploymentsReport 29084 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29084-1717793966.3031108.json
  Migrating DeploymentsReport 29087 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29087-1717793966.475737.json
  Migrating DeploymentsReport 29086 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29086-1717793966.478357.csv
  Migrating DeploymentsReport 29086 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29086-1717793966.478936.json
  Migrating DeploymentsReport 29085 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29085-1717793966.489054.json
  Migrating DeploymentsReport 29088 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29088-1717793966.491429.json
  Migrating DeploymentsReport 29095 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29095-1717793966.496751.json
  Migrating DeploymentsReport 29089 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29089-1717793966.500248.json
  Migrating DeploymentsReport 29090 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29090-1717793966.673933.json
  Migrating DeploymentsReport 29091 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29091-1717793966.75205.json
  Migrating DeploymentsReport 29093 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29093-1717793966.755611.json
  Migrating DeploymentsReport 29094 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29094-1717793966.761337.json
  Migrating DeploymentsReport 29096 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29096-1717793966.9149241.csv
  Migrating DeploymentsReport 29096 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29096-1717793966.915353.json
  Migrating DeploymentsReport 29097 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29097-1717793966.948511.csv
  Migrating DeploymentsReport 29097 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29097-1717793966.9490292.json
  Migrating DeploymentsReport 29098 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29098-1717793967.03342.csv
  Migrating DeploymentsReport 29098 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29098-1717793967.03398.json
  Migrating DeploymentsReport 29099 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29099-1717793967.409823.csv
  Migrating DeploymentsReport 29099 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29099-1717793967.4109929.json
  Migrating DeploymentsReport 29100 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29100-1717793968.178751.csv
  Migrating DeploymentsReport 29100 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29100-1717793968.180159.json
  Migrating DeploymentsReport 29101 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29101-1717793970.506237.csv
  Migrating DeploymentsReport 29101 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29101-1717793970.5126882.json
  Migrating DeploymentsReport 29102 cached_csv to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29102-1717793978.571181.csv
  Migrating DeploymentsReport 29102 cached_fingerprints to /Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-29102-1717793978.579415.json
  ... OK (47.371s)
Running post-migrate handlers for application admin
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application authtoken
Running post-migrate handlers for application axes
Running post-migrate handlers for application api
```

After migrations completed:

```
❯ psql -U qpc -c 'vacuum full analyze'
VACUUM
❯ du -sh $(echo $(psql -U qpc -tc 'show data_directory')/base/$(psql -U qpc -tc "select oid from pg_database where datname='qpc'") | tr -d '[:space:]')
383M	/usr/local/var/postgresql@14/base/21759782
```
```
❯ du -sh var/cached_reports
327M	var/cached_reports
```
```
❯ ls -la var/cached_reports
total 669920
drwxr-xr-x  36 brasmith  staff       1152 Jun  7 16:59 .
drwxr-xr-x  10 brasmith  staff        320 Jun  7 16:59 ..
-rw-r--r--   1 brasmith  staff     906977 Jun  7 16:59 deployments-report-10778-1717793966.1283772.json
-rw-r--r--   1 brasmith  staff        653 Jun  7 16:59 deployments-report-29079-1717793966.2422888.json
-rw-r--r--   1 brasmith  staff      12873 Jun  7 16:59 deployments-report-29080-1717793966.243911.json
-rw-r--r--   1 brasmith  staff     275072 Jun  7 16:59 deployments-report-29081-1717793966.255309.json
-rw-r--r--   1 brasmith  staff       5786 Jun  7 16:59 deployments-report-29082-1717793966.293715.csv
-rw-r--r--   1 brasmith  staff      22256 Jun  7 16:59 deployments-report-29082-1717793966.294166.json
-rw-r--r--   1 brasmith  staff       2576 Jun  7 16:59 deployments-report-29083-1717793966.251919.csv
-rw-r--r--   1 brasmith  staff      12873 Jun  7 16:59 deployments-report-29083-1717793966.252394.json
-rw-r--r--   1 brasmith  staff    1284227 Jun  7 16:59 deployments-report-29084-1717793966.3031108.json
-rw-r--r--   1 brasmith  staff        653 Jun  7 16:59 deployments-report-29085-1717793966.489054.json
-rw-r--r--   1 brasmith  staff       7439 Jun  7 16:59 deployments-report-29086-1717793966.478357.csv
-rw-r--r--   1 brasmith  staff      35129 Jun  7 16:59 deployments-report-29086-1717793966.478936.json
-rw-r--r--   1 brasmith  staff        653 Jun  7 16:59 deployments-report-29087-1717793966.475737.json
-rw-r--r--   1 brasmith  staff      12873 Jun  7 16:59 deployments-report-29088-1717793966.491429.json
-rw-r--r--   1 brasmith  staff     947003 Jun  7 16:59 deployments-report-29089-1717793966.500248.json
-rw-r--r--   1 brasmith  staff     408871 Jun  7 16:59 deployments-report-29090-1717793966.673933.json
-rw-r--r--   1 brasmith  staff      10747 Jun  7 16:59 deployments-report-29091-1717793966.75205.json
-rw-r--r--   1 brasmith  staff      22258 Jun  7 16:59 deployments-report-29093-1717793966.755611.json
-rw-r--r--   1 brasmith  staff    1423862 Jun  7 16:59 deployments-report-29094-1717793966.761337.json
-rw-r--r--   1 brasmith  staff        412 Jun  7 16:59 deployments-report-29095-1717793966.496751.json
-rw-r--r--   1 brasmith  staff      17033 Jun  7 16:59 deployments-report-29096-1717793966.9149241.csv
-rw-r--r--   1 brasmith  staff     207134 Jun  7 16:59 deployments-report-29096-1717793966.915353.json
-rw-r--r--   1 brasmith  staff      50795 Jun  7 16:59 deployments-report-29097-1717793966.948511.csv
-rw-r--r--   1 brasmith  staff     635566 Jun  7 16:59 deployments-report-29097-1717793966.9490292.json
-rw-r--r--   1 brasmith  staff     163513 Jun  7 16:59 deployments-report-29098-1717793967.03342.csv
-rw-r--r--   1 brasmith  staff    2077774 Jun  7 16:59 deployments-report-29098-1717793967.03398.json
-rw-r--r--   1 brasmith  staff     514735 Jun  7 16:59 deployments-report-29099-1717793967.409823.csv
-rw-r--r--   1 brasmith  staff    6557205 Jun  7 16:59 deployments-report-29099-1717793967.4109929.json
-rw-r--r--   1 brasmith  staff    1615512 Jun  7 16:59 deployments-report-29100-1717793968.178751.csv
-rw-r--r--   1 brasmith  staff   20479757 Jun  7 16:59 deployments-report-29100-1717793968.180159.json
-rw-r--r--   1 brasmith  staff    5118502 Jun  7 16:59 deployments-report-29101-1717793970.506237.csv
-rw-r--r--   1 brasmith  staff   64827508 Jun  7 16:59 deployments-report-29101-1717793970.5126882.json
-rw-r--r--   1 brasmith  staff   16145443 Jun  7 16:59 deployments-report-29102-1717793978.571181.csv
-rw-r--r--   1 brasmith  staff  204931534 Jun  7 16:59 deployments-report-29102-1717793978.579415.json
```

Note that postgresql itself already automatically compresses text in some fields when the length is greater than a certain size. So, even though the migration dropped a 300+ MB of uncompressed data from the database, the original data compressed very well and apparently only "cost" ~65 MB compressed. Nevertheless, the goal of moving data is not to recover space in the database but to avoid the problems of hitting individual record maximum size limits in postgres.
