### PR TITLE
refactor: use a configurable batch_size in all current Django model bulk_create calls

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -6,6 +6,7 @@ These models are used in the REST definitions.
 import logging
 from datetime import datetime
 
+from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Q
 from django.utils.translation import gettext as _
@@ -551,9 +552,15 @@ class ScanJob(BaseModel):
                     RawFact(name=k, value=v, inspect_result=inspect_result)
                     for k, v in fact_dict.items()
                 )
-        InspectGroup.objects.bulk_create(inspect_group_list)
-        InspectResult.objects.bulk_create(inspect_result_list)
-        RawFact.objects.bulk_create(raw_fact_list)
+        InspectGroup.objects.bulk_create(
+            inspect_group_list, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
+        InspectResult.objects.bulk_create(
+            inspect_result_list, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
+        RawFact.objects.bulk_create(
+            raw_fact_list, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
         inspect_task.inspect_groups.set(inspect_group_list)
 
     def copy_raw_facts_from_reports(self, report_id_list, task_sequence_number=1):

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -263,6 +263,7 @@ elif QPC_DBMS == "postgres":
             "PORT": QPC_DBMS_PORT,
         }
     }
+QUIPUCORDS_BULK_CREATE_BATCH_SIZE = env.int("QUIPUCORDS_BULK_CREATE_BATCH_SIZE", 100)
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators

--- a/quipucords/scanner/ansible/inspect.py
+++ b/quipucords/scanner/ansible/inspect.py
@@ -187,7 +187,9 @@ class InspectTaskRunner(AnsibleTaskRunner):
             inspect_group=inspect_group,
         )
         raw_facts = self._facts_dict_as_raw_facts(sys_result, **facts_dict)
-        RawFact.objects.bulk_create(raw_facts)
+        RawFact.objects.bulk_create(
+            raw_facts, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
         return sys_result
 
     def _facts_dict_as_raw_facts(

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -324,7 +324,9 @@ class InspectTaskRunner(ScanTaskRunner):
                     inspect_result=sys_result,
                 )
             )
-        RawFact.objects.bulk_create(raw_facts)
+        RawFact.objects.bulk_create(
+            raw_facts, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
         increment_kwargs = self._get_scan_task_increment_kwargs(ansible_results.status)
         self.scan_task.increment_stats(ansible_results.host, **increment_kwargs)
 

--- a/quipucords/scanner/openshift/inspect.py
+++ b/quipucords/scanner/openshift/inspect.py
@@ -146,7 +146,9 @@ class InspectTaskRunner(OpenShiftTaskRunner):
         raw_fact = self._entity_as_raw_fact(cluster, system_result)
         raw_fact.save()
         other_raw_facts = self._entities_as_raw_facts(system_result, other_facts)
-        RawFact.objects.bulk_create(other_raw_facts)
+        RawFact.objects.bulk_create(
+            other_raw_facts, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
         return system_result
 
     def _persist_facts(self, node: OCPNode) -> InspectResult:

--- a/quipucords/scanner/rhacs/inspect.py
+++ b/quipucords/scanner/rhacs/inspect.py
@@ -114,7 +114,9 @@ class InspectTaskRunner(RHACSTaskRunner):
             inspect_group=inspect_group,
         )
         raw_facts = self._facts_dict_as_raw_facts(sys_result, **facts_dict)
-        RawFact.objects.bulk_create(raw_facts)
+        RawFact.objects.bulk_create(
+            raw_facts, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
         return sys_result
 
     def _facts_dict_as_raw_facts(

--- a/quipucords/tests/api/common/test_entities.py
+++ b/quipucords/tests/api/common/test_entities.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from itertools import chain
 
 import pytest
+from django.conf import settings
 
 from api.common.entities import HostEntity, ReportEntity, ReportSlice
 from api.deployments_report.model import DeploymentsReport
@@ -35,7 +36,9 @@ def fingerprint_with_products():
         Product(name="JBoss Fuse", presence=Product.ABSENT, fingerprint=sys_fp),
         Product(name="UNKOWN PRODUCT", presence=Product.PRESENT, fingerprint=sys_fp),
     ]
-    Product.objects.bulk_create(products)
+    Product.objects.bulk_create(
+        products, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+    )
     return sys_fp
 
 

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -8,6 +8,7 @@
 import random
 
 import factory
+from django.conf import settings
 from factory.django import DjangoModelFactory
 from faker import Faker
 
@@ -423,7 +424,9 @@ class InspectResultFactory(DjangoModelFactory):
             models.RawFact(name=k, value=v, inspect_result=obj)
             for k, v in extracted.items()
         ]
-        models.RawFact.objects.bulk_create(raw_facts)
+        models.RawFact.objects.bulk_create(
+            raw_facts, batch_size=settings.QUIPUCORDS_BULK_CREATE_BATCH_SIZE
+        )
 
 
 def generate_invalid_id(faker: factory.Faker) -> int:


### PR DESCRIPTION
The motivation for this change is that when I tried performance testing quipucords with very large sets of synthetic (factory-generated) data, the system I was running quipucords would OOM or Postgres would reject some of the bulk insert requests for being too large.

We now read the env var `QUIPUCORDS_BULK_CREATE_BATCH_SIZE` with a default value of 100 to use in all current Django model bulk_create calls.

The default value 100 should comfortably cover the overwhelming majority of our users' needs, and the performance penalty shouldn't be too bad for users with larger data sets. Since it's configurable, we could always investigate performance on different hardware characteristics and recommend different values for different hardware.