### PR TITLE
fix: handle very large date deltas in aggregate report

### DIFF
--- a/quipucords/tests/utils/test_datetime.py
+++ b/quipucords/tests/utils/test_datetime.py
@@ -39,3 +39,23 @@ from utils.datetime import average_date
 def test_average_date(input_dates, expected_result):
     """Test average_date with various inputs."""
     assert average_date(input_dates) == expected_result
+
+
+def test_average_date_very_large_list_delta():
+    """
+    Test average_date with a list of dates with a very large date delta.
+
+    This special test case exists because an earlier implementation of
+    average_date tried to add timedelta objects, but with a list of dates
+    having a sufficiently large delta from the oldest date, we could
+    exceed Python timedelta's limit of 999999999 days. The data in this
+    test is defined deliberately to exceed >999999999 total days in the
+    calculations to confirm that we no longer raise an OverflowError.
+    If you invoke a debugger and step through average_date while running
+    this test, you should find sum_delta_since_oldest = 1004470089 which
+    is greater than the previously encountered 999999999 limit.
+    """
+    input_dates = [date(2025, 1, 1) for _ in range(50000)]
+    input_dates.append(date(1970, 1, 1))
+    expected_average = date(2024, 12, 31)
+    assert average_date(input_dates) == expected_average

--- a/quipucords/utils/datetime.py
+++ b/quipucords/utils/datetime.py
@@ -10,8 +10,9 @@ def average_date(dates: Iterable[date | None]) -> date | None:
     if not dates:
         return None
     oldest = min(dates)
-    sum_delta_since_oldest = sum(
-        (_date - oldest for _date in dates if _date), timedelta()
+    sum_delta_since_oldest: int = sum(
+        ((_date - oldest).days for _date in dates if _date), 0
     )
-    average = oldest + sum_delta_since_oldest / len(dates)
+    average_days_delta = sum_delta_since_oldest / len(dates)
+    average = oldest + timedelta(days=average_days_delta)
     return average


### PR DESCRIPTION
This resolves an OverflowError that I encountered when generating the aggregate report for ~600,000 fingerprints, as described here: https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1718142917844699?thread_ts=1718140520.843159&cid=C02QSNF1UKE

Relates to JIRA: DISCOVERY-611