### PR TITLE
fix: set `TERM=dumb` to discourage systemctl from writing ANSI escape codes

### DIFF
--- a/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
@@ -232,7 +232,7 @@
   ignore_errors: yes
 
 - name: look for jboss systemd service
-  raw: export LANG=C LC_ALL=C; /usr/bin/systemctl list-unit-files --no-pager
+  raw: export LANG=C LC_ALL=C TERM=dumb; /usr/bin/systemctl list-unit-files --no-pager
   register: internal_jboss_eap_systemctl_unit_files
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
@@ -110,7 +110,7 @@
 # KARAF_HOME (or even whether it's Fuse-on-Karaf or Fuse-on-EAP).
 
 - name: look for fuse systemd service
-  raw: export LANG=C LC_ALL=C; /usr/bin/systemctl list-unit-files --no-pager
+  raw: export LANG=C LC_ALL=C TERM=dumb; /usr/bin/systemctl list-unit-files --no-pager
   register: internal_jboss_fuse_systemctl_unit_files
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -144,7 +144,7 @@
   # Ver 5.x.x has a jws5-tomcat.service unit installed.
   # Only provides major version (5).
 - name: find JWS version through systemctl
-  raw: export LANG=C LC_ALL=C; systemctl status 'jws*-tomcat.service' 2>/dev/null | grep "Apache Tomcat Web" | grep -o 'jws[0-9]\+'
+  raw: export LANG=C LC_ALL=C TERM=dumb; systemctl status 'jws*-tomcat.service' 2>/dev/null | grep "Apache Tomcat Web" | grep -o 'jws[0-9]\+'
   register: internal_jws_version_5_systemctl
   ignore_errors: yes
   when: 'internal_have_systemctl and jboss_ws'


### PR DESCRIPTION
This is a followup to https://github.com/quipucords/quipucords/pull/2685 since I discovered very ugly output being captured by Ansible in network scans for _some_ systems. Also discussed in Slack [here](https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1719351251768579).

Quoting myself:

> I just noticed that when Ansible is invoking hostnamectl, sometimes it's getting ansi escape codes that are totally mucking up the output. These are the hidden bytes that add color and style like in this screenshot.
>
> When we get those bytes, we keep passing them along, and facts can get ugly and useless like this bit copied from a details.json:
```json
"hostnamectl": {
  "value": {
    "\u001b[0;94m______________kernel": "\u001b[0m Linux 6.9.4-200.fc40.x86_64",
    "\u001b[0;94m_____________boot_id": "\u001b[0m a0dc318ab0210abc94ab1a679fa75606",
    "\u001b[0;94m_____________chassis": "\u001b[0m vm 🖴",
    "\u001b[0;94m___________icon_name": "\u001b[0m computer-vm",
    "\u001b[0;94m__________machine_id": "\u001b[0m c3165da6c71e4ad5be417ff471f5b62f",
    "\u001b[0;94m_________cpe_os_name": "\u001b[0m cpe:/o:fedoraproject:fedora:40",
    "\u001b[0;94m________architecture": "\u001b[0m x86-64",
    "\u001b[0;94m________firmware_age": "\u001b[0m \u001b[0;1;38;5;185m9y 4month 2w 4d                 \u001b[0m",
    "\u001b[0;94m_______firmware_date": "\u001b[0m Fri 2015-02-06",
    "\u001b[0;94m______hardware_model": "\u001b[0m Standard PC _Q35 + ICH9, 2009_",
    "\u001b[0;94m______os_support_end": "\u001b[0m Tue 2025-05-13",
    "\u001b[0;94m______virtualization": "\u001b[0m qemu",
    "\u001b[0;94m_____hardware_vendor": "\u001b[0m QEMU",
    "\u001b[0;94m_____static_hostname": "\u001b[0m fedora40",
    "\u001b[0;94m____firmware_version": "\u001b[0m 0.0.0",
    "\u001b[0;94m____operating_system": "\u001b[0m \u001b]8;;https://fedoraproject.org/\u0007Fedora Linux 40 (Server Edition)\u001b]8;;\u0007",
    "\u001b[0;94mos_support_remaining": "\u001b[0m 10month 2w 2d"
  },
```
> Feeding `TERM=dumb` or `SYSTEMD_COLORS=0` into the command seems to prevent their output, but both feel gross. _sigh_ If this works, I may want to go add `TERM=dumb` to all our Ansible raw commands like back when I added `LANG=C LC_ALL=C` to them. 😕 