### PR TITLE
fix: fail bigger when failing to access DeploymentsReport cached_fingerprints or cached_csv

### DIFF
--- a/quipucords/api/deployments_report/model.py
+++ b/quipucords/api/deployments_report/model.py
@@ -66,22 +66,23 @@ class DeploymentsReport(BaseModel):
         file_path = Path(self.cached_fingerprints_file_path).absolute()
         if file_path.parent != cached_files_path():
             # Check to protect against potentially malicious filesystem access.
-            logger.error(
-                "Unsupported parent path for DeploymentsReport %s file: %s",
-                self.id,
-                file_path,
+            message = (
+                "Unsupported parent path for DeploymentsReport "
+                f"{self.id} cached_fingerprints file: {file_path}"
             )
-            return None
+            logger.error(message)
+            raise PermissionError(message)
         try:
             with file_path.open("r") as f:
                 return json.load(f)
-        except FileNotFoundError:
-            logger.warning(
-                "Cached fingerprints file for DeploymentsReport %s not found at %s",
+        except FileNotFoundError as e:
+            logger.exception(e)
+            logger.error(
+                "Cached fingerprints file for DeploymentsReport %s not found at '%s'",
                 self.id,
                 file_path,
             )
-            return None
+            raise
 
     @cached_fingerprints.setter
     def cached_fingerprints(self, data):
@@ -103,12 +104,12 @@ class DeploymentsReport(BaseModel):
         file_path = Path(self.cached_csv_file_path).absolute()
         if file_path.parent != cached_files_path():
             # Check to protect against potentially malicious filesystem access.
-            logger.error(
-                "Unsupported parent path for DeploymentsReport %s file: %s",
-                self.id,
-                file_path,
+            message = (
+                "Unsupported parent path for DeploymentsReport "
+                f"{self.id} cached_csv file: {file_path}"
             )
-            return None
+            logger.error(message)
+            raise PermissionError(message)
         try:
             with file_path.open("r", newline="") as f:
                 # I hate `newline=''` but we need this for compatibility
@@ -116,13 +117,14 @@ class DeploymentsReport(BaseModel):
                 # python wants to strip the extra `\r` from `\r\n`.
                 # See also: https://docs.python.org/3.12/library/functions.html#open
                 return f.read()
-        except FileNotFoundError:
-            logger.warning(
-                "Cached CSV file for DeploymentsReport %s not found at %s",
+        except FileNotFoundError as e:
+            logger.exception(e)
+            logger.error(
+                "Cached CSV file for DeploymentsReport %s not found at '%s'",
                 self.id,
                 self.cached_csv_file_path,
             )
-            return None
+            raise
 
     @cached_csv.setter
     def cached_csv(self, data):

--- a/quipucords/tests/api/deployments_report/test_deployments_report.py
+++ b/quipucords/tests/api/deployments_report/test_deployments_report.py
@@ -242,7 +242,8 @@ def test_get_deployments_report_cached_csv_unsupported_path(faker, caplog):
         f"Unsupported parent path for DeploymentsReport {deployments_report.id}"
     )
     caplog.set_level(logging.ERROR)
-    assert deployments_report.cached_csv is None
+    with pytest.raises(PermissionError):
+        unexpected_data = deployments_report.cached_csv  # noqa: F841
     assert expected_error in caplog.messages[-1]
 
 
@@ -261,7 +262,8 @@ def test_get_deployments_report_cached_fingerprints_unsupported_path(faker, capl
         f"Unsupported parent path for DeploymentsReport {deployments_report.id}"
     )
     caplog.set_level(logging.ERROR)
-    assert deployments_report.cached_fingerprints is None
+    with pytest.raises(PermissionError):
+        unexpected_data = deployments_report.cached_fingerprints  # noqa: F841
     assert expected_error in caplog.messages[-1]
 
 
@@ -270,12 +272,14 @@ def test_get_deployments_report_cached_csv_not_found(faker, caplog):
     """Test getting cached_csv when its path does not find a file."""
     not_found_path = f"{cached_files_path()}/{faker.slug()}.csv"
     deployments_report = DeploymentReportFactory(cached_csv_file_path=not_found_path)
-    expected_warning = (
-        f"Cached CSV file for DeploymentsReport {deployments_report.id} not found"
+    expected_error = (
+        f"Cached CSV file for DeploymentsReport {deployments_report.id} "
+        f"not found at '{not_found_path}'"
     )
-    caplog.set_level(logging.WARNING)
-    assert deployments_report.cached_csv is None
-    assert expected_warning in caplog.messages[-1]
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(FileNotFoundError):
+        unexpected_data = deployments_report.cached_csv  # noqa: F841
+    assert expected_error in caplog.messages[-1]
 
 
 @pytest.mark.django_db
@@ -289,13 +293,14 @@ def test_get_deployments_report_cached_fingerprints_not_found(faker, caplog):
         cached_fingerprints_file_path=not_found_path,
         _set_cached_fingerprints__skip=True,
     )
-    expected_warning = (
+    expected_error = (
         f"Cached fingerprints file for DeploymentsReport {deployments_report.id} "
-        "not found"
+        f"not found at '{not_found_path}'"
     )
-    caplog.set_level(logging.WARNING)
-    assert deployments_report.cached_fingerprints is None
-    assert expected_warning in caplog.messages[-1]
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(FileNotFoundError):
+        unexpected_data = deployments_report.cached_fingerprints  # noqa: F841
+    assert expected_error in caplog.messages[-1]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
After reflecting on the initial change introduced by 8729eb4d, we decided that we would prefer to log errors and fail bigger if we fail to read data from DeploymentsReport cached_fingerprints or cached_csv. This can happen if the cached files were moved after they were written or if the process trying to access the data does not have access to the files. The latter could easily happen in a misconfigured container orchestration.

Following this change, if you perform a successful scan but then manually destroy, move, or make unreadable its cached files, the next time you try to download the report, you should encounter a 500 Internal Server Error. Returning a 500 error is appropriate here because there is nothing the client can do to fix the issue, and it requires some investigation and unspecified fixes on the server side.

In the UI, this may error manifest like this:
![Screenshot 2024-06-27 at 3 18 22 PM](https://github.com/quipucords/quipucords/assets/1472326/a280d717-ed79-4dc3-acab-a22a04296ab2)

Unfortunately, the current UI is not very clever in its handling of 500 errors.

In the server logs, you may see errors logged (plus stack traces) like this:
```
[ERROR 2024-06-27T19:21:46 pid=84056 tid=123145384759296 api/deployments_report/model.py:cached_fingerprints:79] [Errno 2] No such file or directory: '/Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-11-1719432083.0758321.json'
[ERROR 2024-06-27T19:21:46 pid=84056 tid=123145384759296 api/deployments_report/model.py:cached_fingerprints:80] Cached fingerprints file for DeploymentsReport 11 not found at '/Users/brasmith/projects/quipucords/var/cached_reports/deployments-report-11-1719432083.0758321.json'
[ERROR 2024-06-27T19:21:46 pid=84056 tid=123145384759296 /Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.12/lib/python3.12/site-packages/django/utils/log.py:log_response:241] Internal Server Error: /api/v1/reports/11/
```


Relates to JIRA: DISCOVERY-703