### PR TITLE
feat: use hostnamectl to fingerprint infrastructure_type

### DIFF
--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -82,6 +82,30 @@ NAME_RELATED_FACTS = ["name", "vm_dns_name", "virtual_host_name"]
 COMBINED_KEY = "combined_fingerprints"
 
 
+def fingerprint_network_infrastructure_type(fact):
+    """Determine if running on VM or bare metal."""
+    virt_what_type = fact.get("virt_what_type")
+    if virt_what_type == "bare metal":
+        raw_fact_key = "virt_what_type"
+        fact_value = SystemFingerprint.BARE_METAL
+    elif fact.get("virt_type"):
+        raw_fact_key = "virt_type"
+        fact_value = SystemFingerprint.VIRTUALIZED
+    elif fact.get("subman_virt_is_guest", False):
+        # We don't know virt_type, but subscription-manager says it's a guest.
+        # So, we assume it's virtualized. See also: DISCOVERY-243.
+        raw_fact_key = "subman_virt_is_guest"
+        fact_value = SystemFingerprint.VIRTUALIZED
+    elif virt_what_type:
+        # virt_what_type is not "bare metal" or None, but we have no other details.
+        raw_fact_key = "virt_what_type"
+        fact_value = SystemFingerprint.UNKNOWN
+    else:
+        raw_fact_key = "virt_what_type/virt_type"
+        fact_value = SystemFingerprint.UNKNOWN
+    return raw_fact_key, fact_value
+
+
 class FingerprintTaskRunner(ScanTaskRunner):
     """ConnectTaskRunner system connection capabilities.
 
@@ -1086,26 +1110,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
             fact_value=last_checkin,
         )
 
-        # Determine if running on VM or bare metal
-        virt_what_type = fact.get("virt_what_type")
-        if virt_what_type == "bare metal":
-            raw_fact_key = "virt_what_type"
-            fact_value = SystemFingerprint.BARE_METAL
-        elif fact.get("virt_type"):
-            raw_fact_key = "virt_type"
-            fact_value = SystemFingerprint.VIRTUALIZED
-        elif fact.get("subman_virt_is_guest", False):
-            # We don't know virt_type, but subscription-manager says it's a guest.
-            # So, we assume it's virtualized. See also: DISCOVERY-243.
-            raw_fact_key = "subman_virt_is_guest"
-            fact_value = SystemFingerprint.VIRTUALIZED
-        elif virt_what_type:
-            # virt_what_type is not "bare metal" or None, but we have no other details.
-            raw_fact_key = "virt_what_type"
-            fact_value = SystemFingerprint.UNKNOWN
-        else:
-            raw_fact_key = "virt_what_type/virt_type"
-            fact_value = SystemFingerprint.UNKNOWN
+        raw_fact_key, fact_value = fingerprint_network_infrastructure_type(fact)
         self._add_fact_to_fingerprint(
             source,
             raw_fact_key,

--- a/quipucords/tests/fingerprinter/test_runner.py
+++ b/quipucords/tests/fingerprinter/test_runner.py
@@ -1,0 +1,77 @@
+"""Test the fingerprinter.runner module."""
+
+import pytest
+from faker import Faker
+
+from api.deployments_report.model import SystemFingerprint
+from fingerprinter import runner
+
+_faker = Faker()
+
+
+@pytest.mark.parametrize(
+    "facts,expected_raw_fact_key,expected_fact_value",
+    (
+        (
+            {"virt_what_type": "bare metal"},
+            "virt_what_type",
+            SystemFingerprint.BARE_METAL,
+        ),
+        (
+            {"virt_what_type": _faker.slug(), "virt_type": True},
+            "virt_type",
+            SystemFingerprint.VIRTUALIZED,
+        ),
+        (
+            {
+                "virt_what_type": _faker.slug(),
+                "virt_type": False,
+                "subman_virt_is_guest": True,
+            },
+            "subman_virt_is_guest",
+            SystemFingerprint.VIRTUALIZED,
+        ),
+        (
+            {
+                "virt_what_type": _faker.slug(),
+                "virt_type": False,
+                "hostnamectl": {"value": {"chassis": "vm"}},
+            },
+            "hostnamectl",
+            SystemFingerprint.VIRTUALIZED,
+        ),
+        (
+            {
+                "virt_what_type": _faker.slug(),
+                "virt_type": False,
+                "hostnamectl": {"value": {"chassis": "potato"}},
+            },
+            "hostnamectl",
+            SystemFingerprint.BARE_METAL,
+        ),
+        (
+            {
+                "virt_what_type": _faker.slug(),
+                "virt_type": False,
+                "hostnamectl_chassis": {},
+            },
+            "virt_what_type",
+            SystemFingerprint.UNKNOWN,
+        ),
+        (
+            {
+                "virt_type": False,
+                "hostnamectl_chassis": {},
+            },
+            "virt_what_type/virt_type",
+            SystemFingerprint.UNKNOWN,
+        ),
+    ),
+)
+def test_fingerprint_network_infrastructure_type(
+    facts, expected_raw_fact_key, expected_fact_value
+):
+    """Test fingerprinting infrastructure_type from network scan facts."""
+    raw_fact_key, fact_value = runner.fingerprint_network_infrastructure_type(facts)
+    assert raw_fact_key == expected_raw_fact_key
+    assert fact_value == expected_fact_value

--- a/quipucords/tests/utils/raw_facts_generator.py
+++ b/quipucords/tests/utils/raw_facts_generator.py
@@ -17,6 +17,21 @@ VCENTER_RANDOM_CLUSTER_NAMES = [
     _faker.hostname() for _ in range(_faker.pyint(min_value=5, max_value=10))
 ]
 
+# These options were documented in https://issues.redhat.com/browse/DISCOVERY-428
+# as found from the latest `hostnamectl` man page.
+HOSTNAMECTL_CHASSIS_TYPES = [
+    "desktop",
+    "laptop",
+    "convertible",
+    "server",
+    "tablet",
+    "handset",
+    "watch",
+    "embedded",
+    "vm",
+    "container",
+]
+
 
 def raw_facts_generator(source_type, n, as_native_types=True):
     """Generate 'n' raw facts for a given source type."""
@@ -84,6 +99,7 @@ def _network_raw_facts():
         "dmi_system_uuid": _faker.uuid4(),
         "etc_machine_id": _faker.uuid4(),
         "etc_release_release": fake_rhel(),
+        "hostnamectl": fake_hostnamectl(),
         "ifconfig_ip_addresses": [_faker.ipv4()],
         "ifconfig_mac_addresses": [_faker.mac_address()],
         "insights_client_id": _faker.uuid4(),
@@ -120,6 +136,20 @@ def _network_raw_facts():
     # use integer division as a float will be invalid in fingerprint validation
     facts["cpu_core_per_socket"] = facts["cpu_core_count"] // facts["cpu_socket_count"]
     return facts
+
+
+def fake_hostnamectl() -> dict:
+    """Return an object representing a minimal hostnamectl fact."""
+    return {
+        "value": {
+            # Many other interesting values are typically returned by hostnamectl,
+            # such as "architecture", "virtualization", and "operating_system",
+            # but at the time of this writing, we only care about "chassis".
+            "chassis": _faker.random_element(HOSTNAMECTL_CHASSIS_TYPES),
+        },
+        "error_msg": None,
+        "return_code": 0,
+    }
 
 
 def _vcenter_raw_facts():


### PR DESCRIPTION
This is a followup to https://github.com/quipucords/quipucords/pull/2685 which only added `hostnamectl` to fact collection but did not yet use its values in fingerprinting.