### PR TITLE
refactor: remove unreachable code

### DIFF
--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -94,11 +94,8 @@ def fingerprint_network_infrastructure_type(fact: dict) -> tuple[str, str]:
     virt_what: list[str] | None = deepget(fact, "virt_what__value")
     hostnamectl_chassis: str | None = deepget(fact, "hostnamectl__value__chassis")
 
-    if virt_what and "bare metal" in virt_what:
-        raw_fact_key = "virt_what"
-        fact_value = SystemFingerprint.BARE_METAL
-    elif virt_what:
-        # We assume *anything* other than "bare metal" means virtualized.
+    if virt_what:
+        # We assume *anything* in virt-what's stdout means virtualized.
         raw_fact_key = "virt_what"
         fact_value = SystemFingerprint.VIRTUALIZED
     elif fact.get("subman_virt_is_guest", False):

--- a/quipucords/scanner/network/normalizer.py
+++ b/quipucords/scanner/network/normalizer.py
@@ -25,11 +25,8 @@ def infrastructure_type_normalizer(
     virt_what: list[str] | None = deepget(virt_what, "value")
     hostnamectl_chassis: str | None = deepget(hostnamectl, "value__chassis")
 
-    if virt_what and "bare metal" in virt_what:
-        raw_fact_key = "virt_what"
-        fact_value = SystemFingerprint.BARE_METAL
-    elif virt_what:
-        # We assume *anything* other than "bare metal" means virtualized.
+    if virt_what:
+        # We assume *anything* in virt-what's stdout means virtualized.
         raw_fact_key = "virt_what"
         fact_value = SystemFingerprint.VIRTUALIZED
     elif subman_virt_is_guest:

--- a/quipucords/tests/fingerprinter/test_fingerprint_task.py
+++ b/quipucords/tests/fingerprinter/test_fingerprint_task.py
@@ -599,16 +599,7 @@ def test_process_network_source(
 @pytest.mark.parametrize(
     "facts, expected_raw_fact_key, expected_infrastructure_type",
     (
-        (  # virt_what "bare metal" trumps anything else
-            {
-                "virt_what": {"value": ["bare metal"]},  # physical
-                "subman_virt_is_guest": True,  # virtual
-                "hostnamectl": {"value": {"chassis": "vm"}},  # virtual
-            },
-            "virt_what",
-            SystemFingerprint.BARE_METAL,
-        ),
-        (  # non-empty virt_what still trumps anything else
+        (  # non-empty virt_what trumps anything else
             {
                 "virt_what": {"value": ["potato"]},  # "virtual" I guess
                 "subman_virt_is_guest": False,  # unknown

--- a/quipucords/tests/scanner/network/test_normalizer.py
+++ b/quipucords/tests/scanner/network/test_normalizer.py
@@ -62,16 +62,7 @@ def test_normalizer(mocker, raw_facts, expected_normalized_facts):
 @pytest.mark.parametrize(
     "facts, expected_value, expected_raw_fact_keys",
     (
-        (  # virt_what "bare metal" trumps anything else
-            {
-                "virt_what": {"value": ["bare metal"]},  # physical
-                "subman_virt_is_guest": True,  # virtual
-                "hostnamectl": {"value": {"chassis": "vm"}},  # virtual
-            },
-            SystemFingerprint.BARE_METAL,
-            ["virt_what"],
-        ),
-        (  # non-empty virt_what still trumps anything else
+        (  # non-empty virt_what trumps anything else
             {
                 "virt_what": {"value": ["potato"]},  # "virtual" I guess
                 "subman_virt_is_guest": False,  # unknown

--- a/quipucords/tests/utils/raw_facts_generator.py
+++ b/quipucords/tests/utils/raw_facts_generator.py
@@ -35,7 +35,7 @@ HOSTNAMECTL_CHASSIS_TYPES = [
 # These are only some of the possible virt-what outputs.
 # Found by just looking at virt-what script's echo commands.
 # See: less $(command -v virt-what)
-VIRT_WHAT_TYPES = ["bare metal", "kvm", "qemu", "podman", "redhat", "xen", "hyperv"]
+VIRT_WHAT_TYPES = ["kvm", "qemu", "podman", "redhat", "xen", "hyperv"]
 
 
 def raw_facts_generator(source_type, n, as_native_types=True):


### PR DESCRIPTION
When we refactored and removed the old virt_what_type fact from Ansible in 325b23db, we forgot that the old code invented the "bare metal" response, and virt-what never actually emits that value. So, this code became unreachable and useless.

Relates to JIRA: DISCOVERY-427