### PR TITLE
fix: delete InspectResults only related to the current task

### DIFF
--- a/quipucords/api/reports/model.py
+++ b/quipucords/api/reports/model.py
@@ -28,7 +28,11 @@ class Report(BaseModel):
 
     @cached_property
     def sources(self):
-        """Drop in replacement for the now defunct "sources" JSONField."""
+        """
+        Drop in replacement for the now defunct "sources" JSONField.
+
+        Returns a InspectGroupQuerySet.
+        """
         return (
             InspectGroup.objects.with_raw_facts()
             .filter(tasks__job__report_id=self.id)

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -276,9 +276,17 @@ class ScanJob(BaseModel):
         inspect_tasks = self._create_inspection_tasks(conn_tasks)
         self._create_fingerprint_task(conn_tasks, inspect_tasks)
 
-    def delete_inspect_results(self):
-        """Delete InspectResults exclusively related to this ScanJob."""
-        InspectResult.objects.filter(inspect_group__tasks__job_id=self.id).exclude(
+    def delete_inspect_results(self, scan_task_id=None):
+        """
+        Delete InspectResults exclusively related to this ScanJob.
+
+        Optionally filter to delete only the InspectResults related to
+        the given ScanTask ID.
+        """
+        filters = Q(inspect_group__tasks__job_id=self.id)
+        if scan_task_id:
+            filters = filters & Q(inspect_group__tasks__in=[scan_task_id])
+        InspectResult.objects.filter(filters).exclude(
             inspect_group__tasks__in=ScanTask.objects.exclude(job_id=self.id)
         ).delete()
 

--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -304,7 +304,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
         return status_message, status
 
     @staticmethod
-    def _format_count_message(fingerprint_map, total_only=False):
+    def _format_count_message(fingerprint_map: dict, total_only=False) -> str:
         if not total_only:
             message = ", ".join(
                 f"{source_type}={len(fingerprints)}"
@@ -319,7 +319,7 @@ class FingerprintTaskRunner(ScanTaskRunner):
     def _log_message_with_count(
         self,
         message,
-        fingerprints_per_type,
+        fingerprints_per_type: dict,
         log_level=logging.INFO,
         total_only=False,
     ):
@@ -333,10 +333,10 @@ class FingerprintTaskRunner(ScanTaskRunner):
             log_level=log_level,
         )
 
-    def _process_sources(self, report):
+    def _process_sources(self, report) -> list:
         """Process facts and convert to fingerprints.
 
-        :param details_report: Report containing raw facts
+        :param report: Report containing raw facts
         :returns: list of fingerprints for all systems (all scans)
         """
         # fingerprints per source type

--- a/quipucords/scanner/runner.py
+++ b/quipucords/scanner/runner.py
@@ -39,7 +39,9 @@ class ScanTaskRunner(metaclass=ABCMeta):
             if self.scan_task.scan_type == ScanTask.SCAN_TYPE_CONNECT:
                 self.scan_task.connection_result.systems.all().delete()
             elif self.scan_task.scan_type == ScanTask.SCAN_TYPE_INSPECT:
-                self.scan_task.job.delete_inspect_results()
+                self.scan_task.job.delete_inspect_results(
+                    scan_task_id=self.scan_task.id
+                )
             elif self.scan_task.scan_type == ScanTask.SCAN_TYPE_FINGERPRINT:
                 report = self.scan_job.report
                 if report:


### PR DESCRIPTION
This resolves a race condition when running quipucords with Celery enabled and running parallel scan tasks for multiple sources in the same scan job could result in one task prematurely deleting the results from the other task which would later crash the fingerprint logic.

See Slack discussion here for additional context and partial reproduction steps: https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1720472739484699

> I hit an unexpected error a few minutes ago when I was trying to run a multi-source scan containing 1 network, 1 ansible, 1 openshift, 1 vcenter, and 1 satellite source. Scanning each source individually beforehand worked just fine, but scanning them all together crashed out during fingerprinting. When I removed the ansible source from the group, the combined scan with the other 4 completed successfully.

…

> The offending delete is called from each source's scan task in the scan job, but what it does is delete all inspection results related to the scan job, not the source-specific scan task. I believe that results in the cleanup that's intended only for Task B to unwittingly delete the results from Task A. I suspect this could happen with any multi-source scan, but I'm seeing it happen with Ansible+Satellite specifically because the Ansible inspect completes very quickly but the Satellite scan is very slow, and the "cleanup" on the slow Satellite scan is also nuking data from the Ansible task (this is very likely the bug!). (I haven't tried it yet with a slow network scan; I will add that to my list soon.)

…

> More evidence is piling up that this is a race condition, the result of that naive code and unfortunate timing. Recall that it "just worked" when I ran a scan with an Ansible and an OpenShift or a vCenter source.  I stuck a `time.sleep(10)` in OpenShift's and vCenter's ConnectTaskRunner.execute_task methods, and they both now trigger this problem in the same way.