### PR TITLE
refactor: enable timezone-aware datetimes everywhere

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -4,7 +4,7 @@ These models are used in the REST definitions.
 """
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.conf import settings
 from django.db import models, transaction
@@ -222,7 +222,7 @@ class ScanJob(BaseModel):
         if self.start_time is None:
             elapsed_time = 0
         else:
-            elapsed_time = (datetime.utcnow() - self.start_time).total_seconds()
+            elapsed_time = (datetime.now(UTC) - self.start_time).total_seconds()
         return elapsed_time
 
     @transaction.atomic
@@ -376,7 +376,7 @@ class ScanJob(BaseModel):
 
         :returns: bool True if successfully updated, else False
         """
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(UTC)
         target_status = ScanTask.RUNNING
         has_error = self.validate_status_change(target_status, [ScanTask.PENDING])
         if has_error:
@@ -446,7 +446,7 @@ class ScanJob(BaseModel):
 
         :returns: bool True if successfully updated, else False
         """
-        self.end_time = datetime.utcnow()
+        self.end_time = datetime.now(UTC)
         target_status = ScanTask.CANCELED
         has_error = self.validate_status_change(
             target_status,
@@ -476,7 +476,7 @@ class ScanJob(BaseModel):
 
         :returns: bool True if successfully updated, else False
         """
-        self.end_time = datetime.utcnow()
+        self.end_time = datetime.now(UTC)
         target_status = ScanTask.COMPLETED
         has_error = self.validate_status_change(target_status, [ScanTask.RUNNING])
         if has_error:
@@ -495,7 +495,7 @@ class ScanJob(BaseModel):
         :param message: The error message associated with failure
         :returns: bool True if successfully updated, else False
         """
-        self.end_time = datetime.utcnow()
+        self.end_time = datetime.now(UTC)
         target_status = ScanTask.FAILED
         has_error = self.validate_status_change(target_status, [ScanTask.RUNNING])
         if has_error:

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -4,7 +4,7 @@ These models are used in the REST definitions.
 """
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import cached_property
 
 from django.db import models, transaction
@@ -221,7 +221,7 @@ class ScanTask(BaseModel):
         if self.start_time is None:
             elapsed_time = 0
         else:
-            elapsed_time = (datetime.utcnow() - self.start_time).total_seconds()
+            elapsed_time = (datetime.now(UTC) - self.start_time).total_seconds()
         return elapsed_time
 
     # All task types
@@ -314,7 +314,7 @@ class ScanTask(BaseModel):
     # All task types
     def status_start(self):
         """Change status to RUNNING."""
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(UTC)
         self.status = ScanTask.RUNNING
         self.status_message = _(messages.ST_STATUS_MSG_RUNNING)
         self.save()
@@ -340,7 +340,7 @@ class ScanTask(BaseModel):
     # All task types
     def status_cancel(self):
         """Change status to CANCELED."""
-        self.end_time = datetime.utcnow()
+        self.end_time = datetime.now(UTC)
         self.status = ScanTask.CANCELED
         self.status_message = _(messages.ST_STATUS_MSG_CANCELED)
         self.save()
@@ -351,7 +351,7 @@ class ScanTask(BaseModel):
     def status_complete(self, message=None):
         """Change status to COMPLETED."""
         self.refresh_from_db()
-        self.end_time = datetime.utcnow()
+        self.end_time = datetime.now(UTC)
         self.status = ScanTask.COMPLETED
         if message:
             self.status_message = message
@@ -369,7 +369,7 @@ class ScanTask(BaseModel):
 
         :param message: The error message associated with failure
         """
-        self.end_time = datetime.utcnow()
+        self.end_time = datetime.now(UTC)
         self.status = ScanTask.FAILED
         self.status_message = message
         self.log_message(self.status_message, log_level=logging.ERROR)

--- a/quipucords/api/user/authentication.py
+++ b/quipucords/api/user/authentication.py
@@ -20,7 +20,7 @@ class QuipucordsExpiringTokenAuthentication(TokenAuthentication):
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed("User inactive or deleted")
 
-        utc_now = datetime.datetime.utcnow()
+        utc_now = datetime.datetime.now(datetime.UTC)
 
         hours = settings.QPC_TOKEN_EXPIRE_HOURS
         if token.created < utc_now - datetime.timedelta(hours=hours):

--- a/quipucords/api/user/token_view.py
+++ b/quipucords/api/user/token_view.py
@@ -21,7 +21,7 @@ class QuipucordsExpiringAuthToken(ObtainAuthToken):
         user = serializer.validated_data["user"]
         auth_token, created = Token.objects.get_or_create(user=user)
 
-        utc_now = datetime.datetime.utcnow()
+        utc_now = datetime.datetime.now(datetime.UTC)
         valid_token_window = utc_now - datetime.timedelta(
             hours=settings.QPC_TOKEN_EXPIRE_HOURS
         )
@@ -29,7 +29,7 @@ class QuipucordsExpiringAuthToken(ObtainAuthToken):
             # refresh the token
             auth_token.delete()
             auth_token = Token.objects.create(user=user)
-            auth_token.created = datetime.datetime.utcnow()
+            auth_token.created = datetime.datetime.now(datetime.UTC)
             auth_token.save()
 
         return Response({"token": auth_token.key})

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -305,11 +305,10 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
-
 USE_I18N = True
 
-USE_TZ = False
+USE_TZ = True
+TIME_ZONE = "UTC"
 
 
 # Static files (CSS, JavaScript, Images)

--- a/quipucords/scanner/vcenter/inspect.py
+++ b/quipucords/scanner/vcenter/inspect.py
@@ -1,7 +1,7 @@
 """ScanTask used for vcenter inspection task."""
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import cached_property
 
 from django.db import transaction
@@ -157,7 +157,7 @@ class InspectTaskRunner(ScanTaskRunner):
         :param props: Array of Dynamic Properties
         :param host_dict: Dictionary of host properties
         """
-        now = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
         facts = raw_facts_template()
         for prop in props:

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -1309,8 +1309,12 @@ class TestCredentialSerialization:
         results = []
         for input_data, output, _id in self.INPUT_OUTPUT_ID:
             credential = CredentialFactory(**input_data)
-            output["created_at"] = credential.created_at.isoformat()
-            output["updated_at"] = credential.updated_at.isoformat()
+            output["created_at"] = credential.created_at.strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
+            output["updated_at"] = credential.updated_at.strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
             results.append(output)
         # sorting results to match default credentials api sorting
         results = sorted(results, key=lambda x: x["name"])

--- a/quipucords/tests/api/credential/test_serializer.py
+++ b/quipucords/tests/api/credential/test_serializer.py
@@ -542,7 +542,7 @@ class TestBaseCredentialSerializer:
             if isinstance(value, str) and Credential.is_encrypted(value):
                 return ENCRYPTED_DATA_MASK
             elif isinstance(value, datetime.datetime):
-                return value.strftime("%Y-%m-%dT%H:%M:%S.%f")
+                return value.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             return value
 
         credentials = CredentialFactory.create_batch(10)

--- a/quipucords/tests/api/scan/test_scan.py
+++ b/quipucords/tests/api/scan/test_scan.py
@@ -2,7 +2,7 @@
 
 import random
 import re
-from datetime import timedelta
+from datetime import UTC, timedelta
 
 import pytest
 from rest_framework import status
@@ -564,7 +564,7 @@ class TestScanList:
     @pytest.fixture
     def expected_scans(self, faker, mocker):
         """Return a 'json' with 2 Scan objects."""
-        start_time1 = faker.date_time()
+        start_time1 = faker.date_time(tzinfo=UTC)
         scan1 = ScanFactory(
             name="SCAN1",
             scan_type=ScanTask.SCAN_TYPE_CONNECT,

--- a/quipucords/tests/api/scanjob/test_scanjob.py
+++ b/quipucords/tests/api/scanjob/test_scanjob.py
@@ -1811,7 +1811,7 @@ class TestScanJobViewSetV2:
         assert response.ok
         assert response.json() == {
             "id": scanjob.id,
-            "end_time": scanjob.end_time.isoformat(),
+            "end_time": scanjob.end_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "report_id": scanjob.report_id,
             "scan_id": scanjob.scan.id,
             "scan_type": scanjob.scan_type,
@@ -1822,7 +1822,7 @@ class TestScanJobViewSetV2:
                     "source_type": source.source_type,
                 }
             ],
-            "start_time": scanjob.start_time.isoformat(),
+            "start_time": scanjob.start_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "status": scanjob.status,
             "status_message": scanjob.status_message,
             "systems_count": 10,
@@ -1844,7 +1844,7 @@ class TestScanJobViewSetV2:
             "results": [
                 {
                     "id": scanjob.id,
-                    "end_time": scanjob.end_time.isoformat(),
+                    "end_time": scanjob.end_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     "report_id": scanjob.report_id,
                     "scan_id": scanjob.scan.id,
                     "scan_type": scanjob.scan_type,
@@ -1855,7 +1855,7 @@ class TestScanJobViewSetV2:
                             "source_type": source.source_type,
                         }
                     ],
-                    "start_time": scanjob.start_time.isoformat(),
+                    "start_time": scanjob.start_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     "status": scanjob.status,
                     "status_message": scanjob.status_message,
                     "systems_count": 10,

--- a/quipucords/tests/api/source/test_source.py
+++ b/quipucords/tests/api/source/test_source.py
@@ -1,7 +1,7 @@
 """Test the API application."""
 
 import random
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -223,7 +223,7 @@ class TestSource:
 
     def test_format_source(self):
         """Test the format source method."""
-        start = datetime.now()
+        start = datetime.now(UTC)
         source = Source(
             name="source1",
             hosts=["1.2.3.4"],
@@ -231,7 +231,7 @@ class TestSource:
             port=22,
         )
         source.save()
-        end = datetime.now()
+        end = datetime.now(UTC)
         scan_job, scan_task = create_scan_job(source)
         scan_task.update_stats(
             "", sys_count=10, sys_scanned=9, sys_failed=1, sys_unreachable=0
@@ -1817,7 +1817,7 @@ class TestSourceV2:
 
     def test_format_source(self):
         """Test the format source method."""
-        start = datetime.now()
+        start = datetime.now(UTC)
         source = Source(
             name="source1",
             hosts=["1.2.3.4"],
@@ -1825,7 +1825,7 @@ class TestSourceV2:
             port=22,
         )
         source.save()
-        end = datetime.now()
+        end = datetime.now(UTC)
         scan_job, scan_task = create_scan_job(source)
         scan_task.update_stats(
             "", sys_count=10, sys_scanned=9, sys_failed=1, sys_unreachable=0

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -5,6 +5,7 @@
 # completely for this file to avoid repetition.
 # ruff: noqa: N805
 
+import datetime
 import random
 
 import factory
@@ -217,8 +218,10 @@ class ReportFactory(DjangoModelFactory):
 class ScanJobFactory(DjangoModelFactory):
     """Factory for ScanJob."""
 
-    start_time = factory.Faker("past_datetime")
-    end_time = factory.Faker("date_time_between", start_date="-15d")
+    start_time = factory.Faker("past_datetime", tzinfo=datetime.timezone.utc)
+    end_time = factory.Faker(
+        "date_time_between", start_date="-15d", tzinfo=datetime.timezone.utc
+    )
 
     class Meta:
         """Factory options."""
@@ -293,8 +296,10 @@ class ScanTaskFactory(DjangoModelFactory):
     """Factory for ScanTask."""
 
     scan_type = models.ScanTask.SCAN_TYPE_INSPECT
-    start_time = factory.Faker("past_datetime")
-    end_time = factory.Faker("date_time_between", start_date="-15d")
+    start_time = factory.Faker("past_datetime", tzinfo=datetime.timezone.utc)
+    end_time = factory.Faker(
+        "date_time_between", start_date="-15d", tzinfo=datetime.timezone.utc
+    )
 
     source = factory.SubFactory("tests.factories.SourceFactory")
     job = factory.SubFactory("tests.factories.ScanJobFactory")

--- a/quipucords/tests/scanner/vcenter/test_vc_inspect.py
+++ b/quipucords/tests/scanner/vcenter/test_vc_inspect.py
@@ -1,6 +1,6 @@
 """Test the vcenter inspect capabilities."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from multiprocessing import Value
 from unittest.mock import ANY, Mock, patch
 
@@ -161,7 +161,7 @@ class TestVCenterInspectTaskRunnerTest:
     @patch("scanner.vcenter.inspect.datetime")
     def test_parse_vm_props(self, mock_dt):
         """Test the parse_vm_props method."""
-        mock_dt.utcnow.return_value = datetime(2000, 1, 1, 4, 20)
+        mock_dt.now.return_value = datetime(2000, 1, 1, 4, 20, tzinfo=UTC)
 
         ip_addresses, mac_addresses = ["1.2.3.4"], ["00:50:56:9e:09:8c"]
 


### PR DESCRIPTION
and replace deprecated datetime.datetime.utcnow, which is what prompted this change:

> DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).