### PR TITLE
refactor: remove unnecessary cleanup_unsupported_partial_results and supports_partial_results

### DIFF
--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -125,8 +125,6 @@ class FingerprintTaskRunner(ScanTaskRunner):
     failures (host/ip).
     """
 
-    supports_partial_results = False
-
     @staticmethod
     def format_certs(redhat_certs):
         """Strip the .pem from each cert in the list.

--- a/quipucords/scanner/ansible/connect.py
+++ b/quipucords/scanner/ansible/connect.py
@@ -16,8 +16,6 @@ logger = getLogger(__name__)
 class ConnectTaskRunner(AnsibleTaskRunner):
     """Connection phase task runner for ansible scanner."""
 
-    supports_partial_results = False
-
     def execute_task(self, manager_interrupt):
         """
         Execute the task and save the results.

--- a/quipucords/scanner/ansible/inspect.py
+++ b/quipucords/scanner/ansible/inspect.py
@@ -20,8 +20,6 @@ logger = getLogger(__name__)
 class InspectTaskRunner(AnsibleTaskRunner):
     """Inspection phase task runner for ansible scanner."""
 
-    supports_partial_results = False
-
     HOST_FIELDS = [
         "name",
         "id",

--- a/quipucords/scanner/network/connect.py
+++ b/quipucords/scanner/network/connect.py
@@ -122,8 +122,6 @@ class ConnectTaskRunner(ScanTaskRunner):
     failures (host/ip).
     """
 
-    supports_partial_results = False
-
     def execute_task(self, manager_interrupt: Value):
         """Scan network range and attempt connections.
 

--- a/quipucords/scanner/network/inspect.py
+++ b/quipucords/scanner/network/inspect.py
@@ -49,8 +49,6 @@ class InspectTaskRunner(ScanTaskRunner):
     failures (host/ip).
     """
 
-    supports_partial_results = True
-
     def __init__(self, scan_job, scan_task):
         """Set context for task execution.
 

--- a/quipucords/scanner/openshift/runner.py
+++ b/quipucords/scanner/openshift/runner.py
@@ -11,8 +11,6 @@ from scanner.runner import ScanTaskRunner
 class OpenShiftTaskRunner(ScanTaskRunner, metaclass=ABCMeta):
     """Base OpenShift task runner."""
 
-    supports_partial_results = False
-
     @classmethod
     def _get_connection_info(cls, scan_task: ScanTask):
         host = scan_task.source.get_hosts()[0]

--- a/quipucords/scanner/rhacs/connect.py
+++ b/quipucords/scanner/rhacs/connect.py
@@ -19,8 +19,6 @@ logger = getLogger(__name__)
 class ConnectTaskRunner(RHACSTaskRunner):
     """Connection phase task runner for RHACS scanner."""
 
-    supports_partial_results = False
-
     def execute_task(self, manager_interrupt):
         """
         Execute the task and save the results.

--- a/quipucords/scanner/rhacs/inspect.py
+++ b/quipucords/scanner/rhacs/inspect.py
@@ -21,8 +21,6 @@ logger = getLogger(__name__)
 class InspectTaskRunner(RHACSTaskRunner):
     """Inspection phase task runner for RHACS scanner."""
 
-    supports_partial_results = False
-
     REQUEST_KWARGS = {
         "raise_for_status": True,
         "timeout": settings.QPC_INSPECT_TASK_TIMEOUT,

--- a/quipucords/scanner/satellite/runner.py
+++ b/quipucords/scanner/satellite/runner.py
@@ -17,8 +17,6 @@ from scanner.satellite.factory import create
 class SatelliteTaskRunner(ScanTaskRunner, metaclass=ABCMeta):
     """Genetic Satellite ScanTaskRunner."""
 
-    supports_partial_results = False
-
     EXPECTED_EXCEPTIONS = (
         SatelliteAuthError,
         SatelliteError,

--- a/quipucords/scanner/vcenter/connect.py
+++ b/quipucords/scanner/vcenter/connect.py
@@ -69,8 +69,6 @@ class ConnectTaskRunner(ScanTaskRunner):
     and gathers the set of available virtual systems.
     """
 
-    supports_partial_results = False
-
     def _store_connect_data(self, connected, credential, source):
         # Update the scan counts
         self.scan_task.update_stats(

--- a/quipucords/scanner/vcenter/inspect.py
+++ b/quipucords/scanner/vcenter/inspect.py
@@ -49,8 +49,6 @@ class InspectTaskRunner(ScanTaskRunner):
     and gathers the set of available virtual systems.
     """
 
-    supports_partial_results = False
-
     def execute_task(self, manager_interrupt):
         """Scan vcenter range and attempt scan."""
         source = self.scan_task.source


### PR DESCRIPTION
This ScanTaskRunner method was useful when quipucords supported pausing and resuming scans, but since we removed the pause/resume functionality, there should be no partial data to clean up, and these old methods and properties are now useless.