### PR TITLE
fix: remove erroneous ScanJob.status assignment

### DIFF
--- a/quipucords/scanner/manager.py
+++ b/quipucords/scanner/manager.py
@@ -42,7 +42,6 @@ class CeleryScanManager:
         :returns: True if killed, False otherwise.
         """
         scan_job_id = job.id
-        job.status = ScanJob.JOB_TERMINATE_CANCEL
         job.status_cancel()
         if job.tasks is not None:
             for scan_task in job.tasks.all():


### PR DESCRIPTION
JOB_TERMINATE_CANCEL is not normally a valid/expected value for ScanJob.status. That pseudo-constant is intended to be used as a multiprocessing signal value to be sent when cancelling jobs in the old thread-based manager, not to be stored as a persistent status. When JOB_TERMINATE_CANCEL was set as the status, the UI would incorrectly show the "working" spinner graphic and still show the "stop" cancel button, implying that the job was actually still running. The backend server would also emit this seemingly nonsensical warning:

    Cannot change job state to canceled when it is 2

This bug was introduced in 5bae95cd1 and only affects the Celery-based scan manager.