### PR TITLE
DISCOVERY-419: use bare executable names in roles

### DIFF
--- a/docs/sudo_cmd_list.txt
+++ b/docs/sudo_cmd_list.txt
@@ -1,19 +1,9 @@
-export LANG=C LC_ALL=C TERM=dumb; /usr/bin/systemctl list-unit-files --no-pager
+export LANG=C LC_ALL=C TERM=dumb; systemctl list-unit-files --no-pager
+export LANG=C LC_ALL=C TERM=dumb; systemctl status 'jws*-tomcat.service' 2>/dev/null | grep "Apache Tomcat Web" | grep -o 'jws[0-9]\+'
 export LANG=C LC_ALL=C;
 subscription-manager identity 2>/dev/null |
 grep 'system identity:' |
 sed 's/system identity:\s*//'
-export LANG=C LC_ALL=C; /sbin/chkconfig --list
-export LANG=C LC_ALL=C; /sbin/ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
-export LANG=C LC_ALL=C; /sbin/ip address show
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s bios-vendor 2>/dev/null
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s bios-version 2>/dev/null
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s system-uuid 2>/dev/null
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t 4 | egrep 'Designation|Status'
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t chassis 2>/dev/null | grep "Asset Tag"
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t system 2>/dev/null | grep "Product Name"
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode 2>/dev/null | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
-export LANG=C LC_ALL=C; /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
 export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*activemq-\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
 export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*camel-core\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
 export LANG=C LC_ALL=C; FOUND=""; for jar in `find {{search_directories}} -type f -xdev -name \*cxf-rt\*redhat\*.jar 2>/dev/null | grep fuse | sed -n 's/.*\(redhat-[0-9]\{6\}\).*/\1/p' | sort -u`; do if [ ! -z "${jar}" ]; then if [ ! -z "$FOUND" ]; then FOUND="$FOUND; $jar"; else FOUND=${jar}; fi; fi; done; echo ${FOUND}
@@ -23,13 +13,33 @@ export LANG=C LC_ALL=C; cat '{{ item }}/README.txt' 2>/dev/null
 export LANG=C LC_ALL=C; cat '{{ item }}/modules/layers.conf' 2>/dev/null
 export LANG=C LC_ALL=C; cat '{{ item }}/version.txt' 2>/dev/null
 export LANG=C LC_ALL=C; cat /etc/passwd
-export LANG=C LC_ALL=C; command -v /usr/sbin/dmidecode
+export LANG=C LC_ALL=C; chkconfig --list
+export LANG=C LC_ALL=C; command -v chkconfig
+export LANG=C LC_ALL=C; command -v dmidecode
+export LANG=C LC_ALL=C; command -v ifconfig
+export LANG=C LC_ALL=C; command -v ip
+export LANG=C LC_ALL=C; command -v java
+export LANG=C LC_ALL=C; command -v locate
 export LANG=C LC_ALL=C; command -v subscription-manager
+export LANG=C LC_ALL=C; command -v systemctl
+export LANG=C LC_ALL=C; command -v unzip
+export LANG=C LC_ALL=C; command -v virt-what
+export LANG=C LC_ALL=C; command -v yum
+export LANG=C LC_ALL=C; dmidecode -s bios-vendor 2>/dev/null
+export LANG=C LC_ALL=C; dmidecode -s bios-version 2>/dev/null
+export LANG=C LC_ALL=C; dmidecode -s system-uuid 2>/dev/null
+export LANG=C LC_ALL=C; dmidecode -t 4 | egrep 'Designation|Status'
+export LANG=C LC_ALL=C; dmidecode -t chassis 2>/dev/null | grep "Asset Tag"
+export LANG=C LC_ALL=C; dmidecode -t system 2>/dev/null | grep "Product Name"
+export LANG=C LC_ALL=C; dmidecode 2>/dev/null | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
+export LANG=C LC_ALL=C; dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
 export LANG=C LC_ALL=C; echo "user has sudo" 2>/dev/null
 export LANG=C LC_ALL=C; find {{search_directories}} -xdev -type f -name jboss-modules.jar 2> /dev/null | xargs -n 1 --no-run-if-empty dirname | sort -u
 export LANG=C LC_ALL=C; find {{search_directories}} -xdev -type f -name karaf.jar 2> /dev/null | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 --no-run-if-empty readlink --canonicalize | sort -u
 export LANG=C LC_ALL=C; for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*" 2>/dev/null); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
-export LANG=C LC_ALL=C; if [ -f /sbin/ifconfig ] ; then /sbin/ifconfig -a; else hostname -I 2>/dev/null; fi
+export LANG=C LC_ALL=C; if command -v ifconfig >/dev/null ; then ifconfig -a; else hostname -I 2>/dev/null; fi
+export LANG=C LC_ALL=C; ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
+export LANG=C LC_ALL=C; ip address show
 export LANG=C LC_ALL=C; java -jar "{{ item }}"/jboss-modules.jar -version 2>/dev/null
 export LANG=C LC_ALL=C; java -jar '{{ item }}/jboss-as/bin/run.jar' --version
 export LANG=C LC_ALL=C; locate JBossEULA.txt | sed -n -e "s/\(.*\)\/jboss-as\/\(.*\)/\1/gp" | uniq
@@ -38,6 +48,7 @@ export LANG=C LC_ALL=C; locate camel-core | grep fuse | sed -n 's/.*\(redhat-[0-
 export LANG=C LC_ALL=C; locate cxf-rt | grep fuse | sed -n 's/^.*\(redhat-[0-9]\{6\}\).*/\1/p'
 export LANG=C LC_ALL=C; locate jboss-modules.jar | xargs -n 1 --no-run-if-empty dirname
 export LANG=C LC_ALL=C; locate karaf.jar | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 --no-run-if-empty readlink --canonicalize
+export LANG=C LC_ALL=C; locate tomcat?/bin/startup.sh | awk -F 'tomcat' '{print $1}' | head -1
 export LANG=C LC_ALL=C; ls --full-time /root/anaconda-ks.cfg 2>/dev/null | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'
 export LANG=C LC_ALL=C; ls -1 "{{ item }}" 2>/dev/null
 export LANG=C LC_ALL=C; ls -1 "{{ item }}"/bin 2>/dev/null

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -120,20 +120,16 @@
   ignore_errors: yes
 
 - name: gather internal_have_systemctl_cmd
-  raw: export LANG=C LC_ALL=C; whereis systemctl
-  register: internal_whereis_systemctl_cmd
+  raw: export LANG=C LC_ALL=C; command -v systemctl
+  register: internal_have_systemctl_cmd
+  become: yes
   ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_systemctl
   set_fact:
-    internal_have_systemctl: false
+    internal_have_systemctl: "{{ internal_have_systemctl_cmd.get('rc') == 0 }}"
   ignore_errors: yes
-
-- name: set internal_have_systemctl
-  set_fact:
-    internal_have_systemctl: true
-  ignore_errors: yes
-  when: (internal_whereis_systemctl_cmd.get('rc') == 0 and internal_whereis_systemctl_cmd.get('stdout_lines')[-1] != 'systemctl:')
 
 - name: gather internal_have_chkconfig_cmd
   raw: export LANG=C LC_ALL=C; command -v chkconfig

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -190,7 +190,9 @@
 - name: gather internal_have_unzip_cmd
   raw: export LANG=C LC_ALL=C; command -v unzip
   register: internal_have_unzip_cmd
+  become: yes
   ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_unzip
   set_fact:

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -27,14 +27,14 @@
     internal_have_dmidecode: "{{ internal_have_dmidecode_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
-- name: gather internal_have_tune2fs_cmd
+- name: gather internal_have_tune2fs_user_cmd
   raw: export LANG=C LC_ALL=C; command -v tune2fs
-  register: internal_have_tune2fs_cmd
+  register: internal_have_tune2fs_user_cmd
   ignore_errors: yes
 
-- name: set internal_have_tune2fs
+- name: set internal_have_tune2fs_user
   set_fact:
-    internal_have_tune2fs: "{{ internal_have_tune2fs_cmd.get('rc') == 0 }}"
+    internal_have_tune2fs_user: "{{ internal_have_tune2fs_user_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
 - name: gather internal_have_yum_cmd

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -16,7 +16,7 @@
   ignore_errors: yes
 
 - name: gather internal_have_dmidecode_cmd
-  raw: export LANG=C LC_ALL=C; command -v /usr/sbin/dmidecode
+  raw: export LANG=C LC_ALL=C; command -v dmidecode
   register: internal_have_dmidecode_cmd
   become: yes
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -203,11 +203,11 @@
     internal_have_unzip: "{{ internal_have_unzip_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
-- name: gather internal_have_rct_cmd
+- name: gather internal_have_rct_user_cmd
   raw: export LANG=C LC_ALL=C; command -v rct
-  register: internal_have_rct_cmd
+  register: internal_have_rct_user_cmd
   ignore_errors: yes
 
-- name: set internal_have_rct
+- name: set internal_have_rct_user
   set_fact:
-    internal_have_rct: "{{ internal_have_rct_cmd.get('rc') == 0 }}"
+    internal_have_rct_user: "{{ internal_have_rct_user_cmd.get('rc') == 0 }}"

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -50,7 +50,9 @@
 - name: gather internal_have_java_cmd
   raw: export LANG=C LC_ALL=C; command -v java
   register: internal_have_java_cmd
+  become: yes
   ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_java
   set_fact:

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -93,8 +93,10 @@
 
 - name: gather internal_have_virt_what_cmd
   raw: export LANG=C LC_ALL=C; command -v virt-what
+  become: yes
   register: internal_have_virt_what_cmd
   ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_virt_what
   set_fact:

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -171,21 +171,27 @@
     internal_have_ifconfig_user: "{{ internal_have_ifconfig_user_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
-- name: gather internal_whereis_ip_cmd
-  raw: export LANG=C LC_ALL=C; command -v /sbin/ip
-  register:  internal_whereis_ip_cmd
+- name: gather internal_have_ip_cmd
+  raw: export LANG=C LC_ALL=C; command -v ip
+  register: internal_have_ip_cmd
+  become: yes
   ignore_errors: yes
-
-- name: set internal_have_ip default
-  set_fact:
-    internal_have_ip: false
-  ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_ip
   set_fact:
-    internal_have_ip: true
+    internal_have_ip: "{{ internal_have_ip_cmd.get('rc') == 0 }}"
   ignore_errors: yes
-  when: "internal_whereis_ip_cmd.get('rc') == 0"
+
+- name: gather internal_have_ip_user_cmd
+  raw: export LANG=C LC_ALL=C; command -v ip
+  register: internal_have_ip_user_cmd
+  ignore_errors: yes
+
+- name: set internal_have_ip_user
+  set_fact:
+    internal_have_ip_user: "{{ internal_have_ip_user_cmd.get('rc') == 0 }}"
+  ignore_errors: yes
 
 - name: gather internal_have_unzip_cmd
   raw: export LANG=C LC_ALL=C; command -v unzip

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -39,8 +39,10 @@
 
 - name: gather internal_have_yum_cmd
   raw: export LANG=C LC_ALL=C; command -v yum
+  become: yes
   register: internal_have_yum_cmd
   ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_yum
   set_fact:

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -103,8 +103,10 @@
 
 - name: gather internal_have_locate_cmd
   raw: export LANG=C LC_ALL=C; command -v locate
+  become: yes
   register: internal_have_locate_cmd
   ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: test locate command
   raw: export LANG=C LC_ALL=C; locate echo
@@ -114,14 +116,8 @@
 
 - name: set internal_have_locate
   set_fact:
-    internal_have_locate: false
+    internal_have_locate: "{{ internal_have_locate_cmd.get('rc') == 0 and internal_test_locate.get('rc') == 0 }}"
   ignore_errors: yes
-
-- name: set internal_have_locate
-  set_fact:
-    internal_have_locate: true
-  ignore_errors: yes
-  when: (internal_have_locate_cmd.get('rc') == 0 and internal_test_locate.get('rc') == 0)
 
 - name: gather internal_have_systemctl_cmd
   raw: export LANG=C LC_ALL=C; whereis systemctl

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -83,14 +83,14 @@
     internal_have_subscription_manager: "{{ internal_have_subscription_manager_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
-- name: gather internal_have_virsh_cmd
+- name: gather internal_have_virsh_user_cmd
   raw: export LANG=C LC_ALL=C; command -v virsh
-  register: internal_have_virsh_cmd
+  register: internal_have_virsh_user_cmd
   ignore_errors: yes
 
-- name: set internal_have_virsh
+- name: set internal_have_virsh_user
   set_fact:
-    internal_have_virsh: "{{ internal_have_virsh_cmd.get('rc') == 0 }}"
+    internal_have_virsh_user: "{{ internal_have_virsh_user_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
 - name: gather internal_have_virt_what_cmd

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -137,21 +137,17 @@
   ignore_errors: yes
   when: (internal_whereis_systemctl_cmd.get('rc') == 0 and internal_whereis_systemctl_cmd.get('stdout_lines')[-1] != 'systemctl:')
 
-- name: gather internal_whereis_chkconfig_cmd
-  raw: export LANG=C LC_ALL=C; whereis chkconfig
-  register: internal_whereis_chkconfig_cmd
+- name: gather internal_have_chkconfig_cmd
+  raw: export LANG=C LC_ALL=C; command -v chkconfig
+  register: internal_have_chkconfig_cmd
+  become: yes
   ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_chkconfig
   set_fact:
-    internal_have_chkconfig: false
+    internal_have_chkconfig: "{{ internal_have_chkconfig_cmd.get('rc') == 0 }}"
   ignore_errors: yes
-
-- name: set internal_have_chkconfig
-  set_fact:
-    internal_have_chkconfig: true
-  ignore_errors: yes
-  when: (internal_whereis_chkconfig_cmd.get('rc') == 0 and internal_whereis_chkconfig_cmd.get('stdout_lines')[-1] != 'chkconfig:')
 
 - name: gather internal_whereis_ifconfig_cmd
   raw: export LANG=C LC_ALL=C; whereis ifconfig

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -149,21 +149,27 @@
     internal_have_chkconfig: "{{ internal_have_chkconfig_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
-- name: gather internal_whereis_ifconfig_cmd
-  raw: export LANG=C LC_ALL=C; whereis ifconfig
-  register:  internal_whereis_ifconfig_cmd
+- name: gather internal_have_ifconfig_cmd
+  raw: export LANG=C LC_ALL=C; command -v ifconfig
+  register:  internal_have_ifconfig_cmd
+  become: yes
   ignore_errors: yes
-
-- name: set internal_have_ifconfig default
-  set_fact:
-    internal_have_ifconfig: false
-  ignore_errors: yes
+  when: 'user_has_sudo'
 
 - name: set internal_have_ifconfig
   set_fact:
-    internal_have_ifconfig: true
+    internal_have_ifconfig: "{{ internal_have_ifconfig_cmd.get('rc') == 0 }}"
   ignore_errors: yes
-  when: "internal_whereis_ifconfig_cmd.get('rc') == 0 and internal_whereis_ifconfig_cmd.get('stdout_lines')[-1] != 'ifconfig:'"
+
+- name: gather internal_have_ifconfig_user_cmd
+  raw: export LANG=C LC_ALL=C; command -v ifconfig
+  register:  internal_have_ifconfig_user_cmd
+  ignore_errors: yes
+
+- name: set internal_have_ifconfig_user
+  set_fact:
+    internal_have_ifconfig_user: "{{ internal_have_ifconfig_user_cmd.get('rc') == 0 }}"
+  ignore_errors: yes
 
 - name: gather internal_whereis_ip_cmd
   raw: export LANG=C LC_ALL=C; command -v /sbin/ip

--- a/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/check_dependencies/tasks/main.yml
@@ -61,14 +61,14 @@
     internal_have_java: "{{ internal_have_java_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
-- name: gather internal_have_rpm_cmd
+- name: gather internal_have_rpm_user_cmd
   raw: export LANG=C LC_ALL=C; command -v rpm
-  register: internal_have_rpm_cmd
+  register: internal_have_rpm_user_cmd
   ignore_errors: yes
 
-- name: set internal_have_rpm
+- name: set internal_have_rpm_user
   set_fact:
-    internal_have_rpm: "{{ internal_have_rpm_cmd.get('rc') == 0 }}"
+    internal_have_rpm_user: "{{ internal_have_rpm_user_cmd.get('rc') == 0 }}"
   ignore_errors: yes
 
 - name: gather internal_have_subscription_manager_cmd

--- a/quipucords/scanner/network/runner/roles/cloud_provider/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/cloud_provider/tasks/main.yml
@@ -6,7 +6,7 @@
 
 # Azure cloud facts
 - name: gather dmi.chassis.asset_tag fact
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t chassis 2>/dev/null | grep "Asset Tag"
+  raw: export LANG=C LC_ALL=C; dmidecode -t chassis 2>/dev/null | grep "Asset Tag"
   register: internal_dmi_chassis_asset_tag_cmd
   ignore_errors: yes
   become: yes
@@ -24,7 +24,7 @@
 
 # ## Alibaba cloud facts
 - name: gather dmi.system.product_name fact
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t system 2>/dev/null | grep "Product Name"
+  raw: export LANG=C LC_ALL=C; dmidecode -t system 2>/dev/null | grep "Product Name"
   register: internal_dmi_system_product_name_cmd
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/cpu/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/cpu/tasks/main.yml
@@ -70,7 +70,7 @@
   ignore_errors: yes
 
 - name: gather cpu.socket_count fact
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -t 4 | egrep 'Designation|Status'
+  raw: export LANG=C LC_ALL=C; dmidecode -t 4 | egrep 'Designation|Status'
   register: internal_cpu_socket_count_dmi_cmd
   become: yes
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/date/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/date/tasks/main.yml
@@ -45,7 +45,7 @@
   raw: export LANG=C LC_ALL=C; fs_date=$(tune2fs -l $(mount | egrep '/ type' | grep -o '/dev.* on' | sed -e 's/\on//g') 2>/dev/null | grep 'Filesystem created' | sed 's/Filesystem created:\s*//g'); if [[ $fs_date ]]; then date +'%F' -d "$fs_date"; else echo "" ; fi
   register: internal_date_filesystem_create
   ignore_errors: yes
-  when: 'internal_have_tune2fs'
+  when: 'internal_have_tune2fs_user'
 
 - name: set date_filesystem_create fact
   set_fact:

--- a/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/dmi/tasks/main.yml
@@ -5,7 +5,7 @@
     internal_host_started_processing_role: "dmi"
 
 - name: gather dmi.bios-vendor fact
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s bios-vendor 2>/dev/null
+  raw: export LANG=C LC_ALL=C; dmidecode -s bios-vendor 2>/dev/null
   register: internal_dmi_bios_vendor_cmd
   ignore_errors: yes
   become: yes
@@ -26,7 +26,7 @@
   when: '"stdout_lines" not in internal_dmi_bios_vendor_cmd'
 
 - name: gather dmi.bios-version fact
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s bios-version 2>/dev/null
+  raw: export LANG=C LC_ALL=C; dmidecode -s bios-version 2>/dev/null
   register: internal_dmi_bios_version_cmd
   ignore_errors: yes
   become: yes
@@ -47,7 +47,7 @@
   when: '"stdout_lines" not in internal_dmi_bios_version_cmd'
 
 - name: gather dmi.system-manufacturer fact
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode 2>/dev/null | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
+  raw: export LANG=C LC_ALL=C; dmidecode 2>/dev/null | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
   register: internal_dmi_system_manufacturer_cmd
   ignore_errors: yes
   become: yes
@@ -68,7 +68,7 @@
   when: '"stdout_lines" not in internal_dmi_system_manufacturer_cmd'
 
 - name: gather dmi.system-uuid fact
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode -s system-uuid 2>/dev/null
+  raw: export LANG=C LC_ALL=C; dmidecode -s system-uuid 2>/dev/null
   register: internal_dmi_system_uuid_cmd
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/ifconfig/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/ifconfig/tasks/main.yml
@@ -5,13 +5,13 @@
     internal_host_started_processing_role: "ifconfig"
 
 - name: gather ifconfig.mac-addresses fact (no sudo)
-  raw: export LANG=C LC_ALL=C; /sbin/ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
+  raw: export LANG=C LC_ALL=C; ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
   register: internal_ifconfig_mac_addresses_cmd
   ignore_errors: yes
-  when: '(not user_has_sudo) and internal_have_ifconfig'
+  when: '(not user_has_sudo) and internal_have_ifconfig_user'
 
 - name: gather ifconfig.mac-addresses fact (sudo)
-  raw: export LANG=C LC_ALL=C; /sbin/ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
+  raw: export LANG=C LC_ALL=C; ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
   register: internal_sudo_ifconfig_mac_addresses_cmd
   ignore_errors: yes
   become: yes
@@ -30,13 +30,13 @@
   when: 'user_has_sudo and "stdout_lines" in internal_sudo_ifconfig_mac_addresses_cmd'
 
 - name: gather ip-address fact (no sudo)
-  raw: export LANG=C LC_ALL=C; if [ -f /sbin/ifconfig ] ; then /sbin/ifconfig -a; else hostname -I 2>/dev/null; fi
+  raw: export LANG=C LC_ALL=C; if command -v ifconfig >/dev/null ; then ifconfig -a; else hostname -I 2>/dev/null; fi
   register: internal_ifconfig_ip_addresses_cmd
   ignore_errors: yes
   when: '(not user_has_sudo)'
 
 - name: gather ip-address fact (sudo)
-  raw: export LANG=C LC_ALL=C; if [ -f /sbin/ifconfig ] ; then /sbin/ifconfig -a; else hostname -I 2>/dev/null; fi
+  raw: export LANG=C LC_ALL=C; if command -v ifconfig >/dev/null ; then ifconfig -a; else hostname -I 2>/dev/null; fi
   register: internal_sudo_ifconfig_ip_addresses_cmd
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/installed_products/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/installed_products/tasks/main.yml
@@ -8,7 +8,7 @@
   raw: export LANG=C LC_ALL=C; find /etc/pki/product*/ -name '*pem' -exec rct cat-cert --no-content '{}' \; | grep -C2 -E '^\s+ID:'
   register: internal_installed_products
   ignore_errors: yes
-  when: 'internal_have_rct'
+  when: 'internal_have_rct_user'
 
 - name: set installed_products fact
   set_fact:

--- a/quipucords/scanner/network/runner/roles/ip/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/ip/tasks/main.yml
@@ -4,18 +4,33 @@
   set_fact:
     internal_host_started_processing_role: "ip address show"
 
-- name: gather 'ip address show' fact
-  raw: export LANG=C LC_ALL=C; /sbin/ip address show
+- name: gather 'ip address show' fact (no sudo)
+  raw: export LANG=C LC_ALL=C; ip address show
   register: internal_ip_address_show_cmd
   ignore_errors: yes
-  become: '{{user_has_sudo}}'
-  when: 'internal_have_ip'
+  when: '(not user_has_sudo) and internal_have_ip_user'
 
-- name: extract result value for 'ip address show'
+- name: gather 'ip address show' fact (sudo)
+  raw: export LANG=C LC_ALL=C; ip address show
+  register: internal_sudo_ip_address_show_cmd
+  ignore_errors: yes
+  become: yes
+  when: 'user_has_sudo and internal_have_ip'
+
+- name: extract result value for 'ip address show' (no sudo)
   set_fact:
     # NOTE: We want to process the related output in two different ways, but the current
     # quipucords Processor class behavior requires us to include it in two facts.
     ip_address_show_ipv4: "{{ internal_ip_address_show_cmd | default(None) }}"
     ip_address_show_mac: "{{ internal_ip_address_show_cmd | default(None) }}"
   ignore_errors: yes
-  when: '"stdout_lines" in internal_ip_address_show_cmd'
+  when: '(not user_has_sudo) and "stdout_lines" in internal_ip_address_show_cmd'
+
+- name: extract result value for 'ip address show' (sudo)
+  set_fact:
+    # NOTE: We want to process the related output in two different ways, but the current
+    # quipucords Processor class behavior requires us to include it in two facts.
+    ip_address_show_ipv4: "{{ internal_sudo_ip_address_show_cmd | default(None) }}"
+    ip_address_show_mac: "{{ internal_sudo_ip_address_show_cmd | default(None) }}"
+  ignore_errors: yes
+  when: 'user_has_sudo and "stdout_lines" in internal_sudo_ip_address_show_cmd'

--- a/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
@@ -232,7 +232,7 @@
   ignore_errors: yes
 
 - name: look for jboss systemd service
-  raw: export LANG=C LC_ALL=C TERM=dumb; /usr/bin/systemctl list-unit-files --no-pager
+  raw: export LANG=C LC_ALL=C TERM=dumb; systemctl list-unit-files --no-pager
   register: internal_jboss_eap_systemctl_unit_files
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
@@ -244,7 +244,7 @@
   ignore_errors: yes
 
 - name: look for jboss in chkconfig
-  raw: export LANG=C LC_ALL=C; /sbin/chkconfig --list
+  raw: export LANG=C LC_ALL=C; chkconfig --list
   register: internal_jboss_eap_chkconfig
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
@@ -110,7 +110,7 @@
 # KARAF_HOME (or even whether it's Fuse-on-Karaf or Fuse-on-EAP).
 
 - name: look for fuse systemd service
-  raw: export LANG=C LC_ALL=C TERM=dumb; /usr/bin/systemctl list-unit-files --no-pager
+  raw: export LANG=C LC_ALL=C TERM=dumb; systemctl list-unit-files --no-pager
   register: internal_jboss_fuse_systemctl_unit_files
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_fuse_on_karaf/tasks/main.yml
@@ -122,7 +122,7 @@
   ignore_errors: yes
 
 - name: look for fuse in chkconfig
-  raw: export LANG=C LC_ALL=C; /sbin/chkconfig --list
+  raw: export LANG=C LC_ALL=C; chkconfig --list
   register: internal_jboss_fuse_chkconfig
   ignore_errors: yes
   become: yes

--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -16,6 +16,7 @@
 - name: search for folder above tomcat home with locate
   raw: export LANG=C LC_ALL=C; locate tomcat?/bin/startup.sh | awk -F 'tomcat' '{print $1}' | head -1
   register: internal_jws_find_home_from_tomcat_file
+  become: yes
   ignore_errors: yes
   when: 'user_has_sudo and internal_have_locate and jboss_ws'
 

--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -135,8 +135,9 @@
 - name: find JWS version through systemctl
   raw: export LANG=C LC_ALL=C TERM=dumb; systemctl status 'jws*-tomcat.service' 2>/dev/null | grep "Apache Tomcat Web" | grep -o 'jws[0-9]\+'
   register: internal_jws_version_5_systemctl
+  become: yes
   ignore_errors: yes
-  when: 'internal_have_systemctl and jboss_ws'
+  when: 'user_has_sudo and internal_have_systemctl and jboss_ws'
 
   # Additional methods of finding different versions can be appended to
   # jws_version. A map of the raw stdout value to the correctly formatted

--- a/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
@@ -8,7 +8,7 @@
   raw: export LANG=C LC_ALL=C; if [ $(rpm -qa --qf "%{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | wc -l) -gt 0 ]; then echo "Y"; else echo "N"; fi
   register: internal_redhat_packages_gpg_is_redhat_cmd
   ignore_errors: yes
-  when: internal_have_rpm
+  when: internal_have_rpm_user
 
 # Using json_query means that the filter will always succeed and
 # return a result, which simplifies later processing. If
@@ -23,7 +23,7 @@
   raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig}\n" 2> /dev/null | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | wc -l
   register: internal_redhat_packages_gpg_num_rh_packages
   ignore_errors: yes
-  when: internal_have_rpm
+  when: internal_have_rpm_user
 
 - name: set fact of number of installed red hat packages filtered by gpg keys
   set_fact:
@@ -34,7 +34,7 @@
   raw: export LANG=C LC_ALL=C; rpm -qa | wc -l
   register: internal_redhat_packages_all_count
   ignore_errors: yes
-  when: internal_have_rpm
+  when: internal_have_rpm_user
 
 - name: set fact of number of all installed rpm packages
   set_fact:
@@ -46,28 +46,28 @@
   register: internal_redhat_packages_gpg_last_installed
   ignore_errors: yes
   when:
-    internal_have_rpm and redhat_packages_gpg_is_redhat
+    internal_have_rpm_user and redhat_packages_gpg_is_redhat
 
 - name: set fact of last installed rh package filtered by gpg key
   set_fact:
     redhat_packages_gpg_last_installed: '{{ internal_redhat_packages_gpg_last_installed | json_query("stdout_lines[-1]") }}'
   ignore_errors: yes
   when:
-    internal_have_rpm and redhat_packages_gpg_is_redhat
+    internal_have_rpm_user and redhat_packages_gpg_is_redhat
 
 - name: gather the last built red hat package filtered by gpg keys
   raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{BUILDTIME} %{DSAHEADER:pgpsig}|%{RSAHEADER:pgpsig}|%{SIGGPG:pgpsig}|%{SIGPGP:pgpsig} |%{NAME}-%{VERSION} Built:%{BUILDTIME:date}\n" | grep 'Key ID 199e2f91fd431d51\|Key ID 5326810137017186\|Key ID 219180cddb42a60e\|Key ID 7514f77d8366b0d9\|Key ID 45689c882fa658e0' | sort -nr | head -n 1 | cut -d"|" -f2
   register: internal_redhat_packages_gpg_last_built
   ignore_errors: yes
   when:
-    internal_have_rpm and redhat_packages_gpg_is_redhat
+    internal_have_rpm_user and redhat_packages_gpg_is_redhat
 
 - name: set fact of last built rh package filtered by gpg key
   set_fact:
     redhat_packages_gpg_last_built: '{{ internal_redhat_packages_gpg_last_built | json_query("stdout_lines[-1]") }}'
   ignore_errors: yes
   when:
-    internal_have_rpm and redhat_packages_gpg_is_redhat
+    internal_have_rpm_user and redhat_packages_gpg_is_redhat
 
 - name: gather redhat-packages.certs fact
   raw: export LANG=C LC_ALL=C; ls /etc/pki/product/ /etc/pki/product-default/ 2> /dev/null |grep '.pem' | sort -u | tr '\n' ';'

--- a/quipucords/scanner/network/runner/roles/redhat_release/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/redhat_release/tasks/main.yml
@@ -15,7 +15,7 @@
   raw: export LANG=C LC_ALL=C; rpm -q --queryformat "%{NAME}\n%{VERSION}\n%{RELEASE}\n" --whatprovides redhat-release
   register: internal_redhat_release
   ignore_errors: yes
-  when: 'internal_have_rpm'
+  when: 'internal_have_rpm_user'
 
 - name: set redhat_release facts based on internal_redhat_release
   set_fact:

--- a/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
@@ -70,7 +70,7 @@
   raw: export LANG=C LC_ALL=C; virsh -c qemu:///system --readonly list --all | wc -l
   register: internal_virt_num_guests
   ignore_errors: yes
-  when: 'internal_have_virsh'
+  when: 'internal_have_virsh_user'
 
 - name: set virt_num_guests fact
   set_fact:
@@ -79,16 +79,16 @@
 
 - name: extract output virt.num_guests fact
   set_fact:
-    virt_num_guests: "{{ virt_num_guests['stdout_lines'][-1] if internal_have_virsh else None }}"
+    virt_num_guests: "{{ virt_num_guests['stdout_lines'][-1] if internal_have_virsh_user else None }}"
   ignore_errors: yes
 
 - name: gather virt.num_running_guests fact
   raw: export LANG=C LC_ALL=C; virsh -c qemu:///system --readonly list --uuid | wc -l
   register: internal_virt_num_running_guests
   ignore_errors: yes
-  when: 'internal_have_virsh'
+  when: 'internal_have_virsh_user'
 
 - name: extract output virt.num_running_guests fact
   set_fact:
-    virt_num_running_guests: "{{ internal_virt_num_running_guests['stdout_lines'][-1] if internal_have_virsh else None }}"
+    virt_num_running_guests: "{{ internal_virt_num_running_guests['stdout_lines'][-1] if internal_have_virsh_user else None }}"
   ignore_errors: yes

--- a/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/virt/tasks/main.yml
@@ -35,7 +35,7 @@
   ignore_errors: yes
 
 - name: set system manufacturer
-  raw: export LANG=C LC_ALL=C; /usr/sbin/dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
+  raw: export LANG=C LC_ALL=C; dmidecode | grep -A4 'System Information' | grep 'Manufacturer' | sed -n -e 's/^.*Manufacturer:\s//p'
   register: internal_sys_manufacturer_cmd
   become: yes
   ignore_errors: yes

--- a/quipucords/tests/integration/test_network_scan.py
+++ b/quipucords/tests/integration/test_network_scan.py
@@ -155,7 +155,7 @@ def expected_network_scan_facts():
             "internal_have_java",
             "internal_have_locate",
             "internal_have_rct",
-            "internal_have_rpm",
+            "internal_have_rpm_user",
             "internal_have_subscription_manager",
             "internal_have_systemctl",
             "internal_have_tune2fs_user",

--- a/quipucords/tests/integration/test_network_scan.py
+++ b/quipucords/tests/integration/test_network_scan.py
@@ -160,7 +160,7 @@ def expected_network_scan_facts():
             "internal_have_systemctl",
             "internal_have_tune2fs_user",
             "internal_have_unzip",
-            "internal_have_virsh",
+            "internal_have_virsh_user",
             "internal_have_virt_what",
             "internal_have_yum",
             "internal_host_started_processing_role",

--- a/quipucords/tests/integration/test_network_scan.py
+++ b/quipucords/tests/integration/test_network_scan.py
@@ -151,6 +151,7 @@ def expected_network_scan_facts():
             "internal_have_ifconfig",
             "internal_have_ifconfig_user",
             "internal_have_ip",
+            "internal_have_ip_user",
             "internal_have_java",
             "internal_have_locate",
             "internal_have_rct",

--- a/quipucords/tests/integration/test_network_scan.py
+++ b/quipucords/tests/integration/test_network_scan.py
@@ -158,7 +158,7 @@ def expected_network_scan_facts():
             "internal_have_rpm",
             "internal_have_subscription_manager",
             "internal_have_systemctl",
-            "internal_have_tune2fs",
+            "internal_have_tune2fs_user",
             "internal_have_unzip",
             "internal_have_virsh",
             "internal_have_virt_what",

--- a/quipucords/tests/integration/test_network_scan.py
+++ b/quipucords/tests/integration/test_network_scan.py
@@ -149,6 +149,7 @@ def expected_network_scan_facts():
             "internal_have_chkconfig",
             "internal_have_dmidecode",
             "internal_have_ifconfig",
+            "internal_have_ifconfig_user",
             "internal_have_ip",
             "internal_have_java",
             "internal_have_locate",

--- a/quipucords/tests/integration/test_network_scan.py
+++ b/quipucords/tests/integration/test_network_scan.py
@@ -154,7 +154,7 @@ def expected_network_scan_facts():
             "internal_have_ip_user",
             "internal_have_java",
             "internal_have_locate",
-            "internal_have_rct",
+            "internal_have_rct_user",
             "internal_have_rpm_user",
             "internal_have_subscription_manager",
             "internal_have_systemctl",

--- a/quipucords/tests/scanner/network/test_inspect_callback.py
+++ b/quipucords/tests/scanner/network/test_inspect_callback.py
@@ -38,7 +38,7 @@ def event_ok():
             "play": "group_0",
             "play_uuid": "6c946626-0f07-0f23-a006-000000000002",
             "play_pattern": " group_0 ",
-            "task": "set internal_have_rpm",
+            "task": "set internal_have_rpm_user",
             "task_uuid": "6c946626-0f07-0f23-a006-000000000038",
             "task_action": "set_fact",
             "resolved_action": "ansible.builtin.set_fact",
@@ -48,7 +48,7 @@ def event_ok():
             "host": "127.0.0.1",
             "remote_addr": "127.0.0.1",
             "res": {
-                "ansible_facts": {"internal_have_rpm": True},
+                "ansible_facts": {"internal_have_rpm_user": True},
                 "_ansible_no_log": None,
                 "changed": False,
             },
@@ -221,7 +221,7 @@ class TestInspectCallback:
         callback.event_callback(event_ok)
         patched_task_on_ok.assert_called_once_with(event_ok)
         # this host and facts are hardcoded on event_ok fixture
-        assert callback._ansible_facts["127.0.0.1"] == {"internal_have_rpm": True}
+        assert callback._ansible_facts["127.0.0.1"] == {"internal_have_rpm_user": True}
 
     @pytest.mark.parametrize(
         "ignore_errors,expected_messages",


### PR DESCRIPTION
The main point of the PR is:

* use `command -v` consistently inside `check_dependencies` role
* use bare executable names in all roles

A bit historical context: this fundamentally follows up to #1298 and #1309 . The main problem is that we want to run some roles conditionally (only if required tools are found), but sometimes we run roles as root and sometimes we do not. The attempt to solve it was to use hardcoded absolute paths, but this created the new issue that host might have the tool under different path. The core insight in this PR is that we should split dependencies check into root and non-root check, and then trust the path to find the right executable.

Each ansible variable is changed in separate commit. I will squash them before merging, I just thought it might be easier to review this way.

I decided to keep `internal_have_*` names for variables that require root, and use `internal_have_*_user` for variables that are run as user. The reason for that is that most of roles require root, so this way things are less noisy.

There were few variables that were only used as non-root. To keep things consistent, I have renamed them to `*_user`. Technically this is not required and I can drop these commits if people feel strongly about this.

Camayoc requires changes, introduced in https://github.com/quipucords/camayoc/pull/537 . I have run container from this PR against Camayoc branch from 537, results are in [standalone job 166](https://stage-jenkins-csb-smqe.apps.ocp-c1.prod.psi.redhat.com/view/Discovery/job/discovery-standalone/166/).

Relates to JIRA: DISCOVERY-419