### PR TITLE
feature: conditionally disable https

### DIFF
--- a/deploy/entrypoint_web.sh
+++ b/deploy/entrypoint_web.sh
@@ -3,6 +3,8 @@
 set -e
 shopt -s inherit_errexit
 
+export QUIPUCORDS_HTTPS_ON="${QUIPUCORDS_HTTPS_ON:-1}"
+
 handle_certificates() {
     # verify if user provided certificates exist or create a self signed certificate.
     CERTS_PATH="/etc/ssl/qpc"
@@ -39,7 +41,9 @@ else
     # 1. with this simpler config we delegate to nginx to deal with https shenanigans
     # 2. we can set a higher number of workers, since there's no risk for race conditions
     #    with the celery-based manager
-    handle_certificates
+    if [[ "${QUIPUCORDS_HTTPS_ON}" == "1" ]]; then
+        handle_certificates
+    fi
     GUNICORN_CONF="/deploy/gunicorn_conf.py"
 fi
 

--- a/deploy/gunicorn_conf.py
+++ b/deploy/gunicorn_conf.py
@@ -9,6 +9,7 @@ from utils.debugger import start_debugger_if_required
 env = environ.Env()
 
 QPC_SERVER_PORT = env.int("QPC_SERVER_PORT", 8000)
+QUIPUCORDS_HTTPS_ON = env.bool("QUIPUCORDS_HTTPS_ON", True)
 
 bind = f"0.0.0.0:{QPC_SERVER_PORT}"
 workers = multiprocessing.cpu_count() * 2 + 1
@@ -18,7 +19,8 @@ loglevel = "info"
 accesslog = "-"
 
 # SSL configuration
-keyfile = "/etc/ssl/qpc/server.key"
-certfile = "/etc/ssl/qpc/server.crt"
+if QUIPUCORDS_HTTPS_ON:
+    keyfile = "/etc/ssl/qpc/server.key"
+    certfile = "/etc/ssl/qpc/server.crt"
 
 start_debugger_if_required()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       REDIS_PASSWORD: qpc
       QPC_ENABLE_CELERY_SCAN_MANAGER: 1
       QUIPUCORDS_DATA_DIR: /var
+      QUIPUCORDS_HTTPS_ON: 0
     ports:
       - "9999:8000"
     volumes:


### PR DESCRIPTION
When running discovery behind nginx and/or HA proxy, there's no need to have HTTPS turned on. The proxy should be the one handling the certificates.