### PR TITLE
fix: network connect timeout should multiply by number of ips in the current group, not the number of groups

### DIFF
--- a/quipucords/scanner/network/connect.py
+++ b/quipucords/scanner/network/connect.py
@@ -265,7 +265,7 @@ def _connect(  # noqa: PLR0913, PLR0912, PLR0915
 
         # Create parameters for ansible runner. For more info, see:
         # https://ansible.readthedocs.io/projects/runner/en/stable/intro/#env-settings-settings-for-runner-itself
-        job_timeout = int(settings.NETWORK_CONNECT_JOB_TIMEOUT) * len(group_names)
+        job_timeout = int(settings.NETWORK_CONNECT_JOB_TIMEOUT) * len(group_ips)
         runner_settings = {
             "idle_timeout": job_timeout,  # Ansible default = 600 sec
             "job_timeout": job_timeout,  # Ansible default = 3600 sec


### PR DESCRIPTION
Thanks @mirekdlugosz for spotting this!

Caused by bff7ee94

Relates to JIRA: DISCOVERY-723