### PR TITLE
feat: add aggregate report to reports tarball

### DIFF
--- a/quipucords/api/aggregate_report/model.py
+++ b/quipucords/api/aggregate_report/model.py
@@ -89,6 +89,20 @@ class AggregateReport:
     openshift_node_instances: int = 0
 
 
+def reformat_aggregate_report_to_dict(aggregated: AggregateReport) -> dict:
+    """Reformat an AggregateReport into a slightly more readable dict."""
+    results, diagnostics = {}, {}
+    for key, value in asdict(aggregated).items():
+        if key.startswith("missing_") or key.startswith("inspect_result_status_"):
+            diagnostics[key] = value
+        else:
+            results[key] = value
+    return {
+        "results": results,
+        "diagnostics": diagnostics,
+    }
+
+
 def get_aggregate_report_by_report_id(report_id: int) -> dict | None:
     """
     Get the aggregate report data for the given report ID.
@@ -97,7 +111,8 @@ def get_aggregate_report_by_report_id(report_id: int) -> dict | None:
     """
     try:
         report = Report.objects.get(pk=report_id)
-        return asdict(build_aggregate_report(report.id))
+        aggregated = build_aggregate_report(report.id)
+        return reformat_aggregate_report_to_dict(aggregated)
     except Report.DoesNotExist:
         return None
 

--- a/quipucords/api/reports/reports_gzip_renderer.py
+++ b/quipucords/api/reports/reports_gzip_renderer.py
@@ -28,10 +28,15 @@ class ReportsGzipRenderer(renderers.BaseRenderer):
         if not bool(reports_dict):
             return None
         report_id = reports_dict.get("report_id")
+
         # Collect Json Data
+        aggregate_json = reports_dict.get("aggregate_json")
         details_json = reports_dict.get("details_json")
         deployments_json = reports_dict.get("deployments_json")
-        if any(value is None for value in [report_id, details_json, deployments_json]):
+        if any(
+            value is None
+            for value in [report_id, aggregate_json, details_json, deployments_json]
+        ):
             return None
 
         # Collect CSV Data
@@ -41,6 +46,7 @@ class ReportsGzipRenderer(renderers.BaseRenderer):
             return None
 
         # create the file names
+        aggregate_json_name = create_filename("aggregate", "json", report_id)
         details_json_name = create_filename("details", "json", report_id)
         deployments_json_name = create_filename("deployments", "json", report_id)
         details_csv_name = create_filename("details", "csv", report_id)
@@ -49,6 +55,7 @@ class ReportsGzipRenderer(renderers.BaseRenderer):
 
         # map the file names to the file data
         files_data = {
+            aggregate_json_name: encode_content(aggregate_json, "json"),
             details_json_name: encode_content(details_json, "json"),
             deployments_json_name: encode_content(deployments_json, "json"),
             details_csv_name: encode_content(details_csv, "csv"),

--- a/quipucords/api/reports/view.py
+++ b/quipucords/api/reports/view.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
 
+from api.aggregate_report.model import get_aggregate_report_by_report_id
 from api.deployments_report.view import build_cached_json_report
 from api.models import DeploymentsReport, Report
 from api.reports.reports_gzip_renderer import ReportsGzipRenderer
@@ -50,6 +51,8 @@ def reports(request, report_id):
         )
     deployments_json = build_cached_json_report(deployments_report)
     reports_dict["deployments_json"] = deployments_json
+    aggregate_json = get_aggregate_report_by_report_id(report_id)
+    reports_dict["aggregate_json"] = aggregate_json
     return Response(reports_dict)
 
 

--- a/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
+++ b/quipucords/tests/api/aggregate_report/test_aggregate_report_model.py
@@ -1,6 +1,5 @@
 """Test the aggregate report model generation."""
 
-from dataclasses import asdict
 from datetime import date
 
 import pytest
@@ -10,6 +9,7 @@ from api.aggregate_report.model import (
     AggregateReport,
     build_aggregate_report,
     get_aggregate_report_by_report_id,
+    reformat_aggregate_report_to_dict,
 )
 from api.deployments_report.model import DeploymentsReport, Product, SystemFingerprint
 from api.inspectresult.model import InspectResult
@@ -340,7 +340,7 @@ def test_get_aggregate_report_by_report_id(
     """Test that if the Report exists, a proper report is generated."""
     report, expected_aggregate_report = report_and_expected_aggregate
     aggregate = get_aggregate_report_by_report_id(report.id)
-    assert aggregate == asdict(expected_aggregate_report)
+    assert aggregate == reformat_aggregate_report_to_dict(expected_aggregate_report)
 
 
 @pytest.mark.django_db

--- a/quipucords/tests/api/reports/test_reports.py
+++ b/quipucords/tests/api/reports/test_reports.py
@@ -38,6 +38,7 @@ from api.reports.model import Report
 from api.scantask.model import ScanTask
 from constants import SCAN_JOB_LOG, DataSources
 from tests.constants import (
+    FILENAME_AGGREGATE_JSON,
     FILENAME_DEPLOYMENTS_CSV,
     FILENAME_DEPLOYMENTS_JSON,
     FILENAME_DETAILS_CSV,
@@ -49,6 +50,7 @@ from tests.report_utils import extract_files_from_tarball
 from tests.utils import raw_facts_generator
 
 TARBALL_ALWAYS_EXPECTED_FILENAMES = {
+    FILENAME_AGGREGATE_JSON,
     FILENAME_SHA256SUM,
     FILENAME_DEPLOYMENTS_CSV,
     FILENAME_DEPLOYMENTS_JSON,

--- a/quipucords/tests/constants.py
+++ b/quipucords/tests/constants.py
@@ -9,6 +9,7 @@ from tests.env import BaseURI, EnvVar, as_bool
 PROJECT_ROOT_DIR = Path(__file__).absolute().parent.parent.parent
 
 CLEANUP_DOCKER_LAYERS = False
+FILENAME_AGGREGATE_JSON = "aggregate.json"
 FILENAME_DEPLOYMENTS_CSV = "deployments.csv"
 FILENAME_DEPLOYMENTS_JSON = "deployments.json"
 FILENAME_DETAILS_CSV = "details.csv"


### PR DESCRIPTION
Also, reformat an AggregateReport into a slightly more readable dict. The JSON now contains two top-level keys `results` and `diagnostics` with all the previous keys sorted into one or the other.

Example output:

```json
{
  "results": {
    "ansible_hosts_all": 0,
    "ansible_hosts_in_database": 0,
    "ansible_hosts_in_jobs": 0,
    "instances_hypervisor": 0,
    "instances_not_redhat": 1,
    "instances_physical": 0,
    "instances_unknown": 1,
    "instances_virtual": 3,
    "jboss_eap_cores_physical": 0,
    "jboss_eap_cores_virtual": 1.0,
    "jboss_eap_instances": 1,
    "jboss_ws_cores_physical": 0,
    "jboss_ws_cores_virtual": 0,
    "jboss_ws_instances": 0,
    "openshift_cores": 0,
    "openshift_operators_by_name": {},
    "openshift_operators_by_kind": {},
    "os_by_name_and_version": {
      "Linux": {
        "6.1.92-99.174.amzn2023.aarch64": 1
      },
      "Red Hat Enterprise Linux Server": {
        "7.6 (Maipo)": 1
      },
      "Red Hat Enterprise Linux": {
        "9.2 (Plow)": 2,
        "8.4 (Ootpa)": 1
      }
    },
    "socket_pairs": 4,
    "system_creation_date_average": "2023-02-07",
    "vmware_hosts": 0,
    "vmware_vm_to_host_ratio": 0,
    "vmware_vms": 0,
    "openshift_cluster_instances": 0,
    "openshift_node_instances": 0
  },
  "diagnostics": {
    "inspect_result_status_failed": 0,
    "inspect_result_status_success": 5,
    "inspect_result_status_unknown": 0,
    "inspect_result_status_unreachable": 0,
    "missing_cpu_core_count": 0,
    "missing_cpu_socket_count": 0,
    "missing_name": 0,
    "missing_pem_files": 1,
    "missing_system_creation_date": 0,
    "missing_system_purpose": 1
  }
}
```

Relates to JIRA: DISCOVERY-759