### PR TITLE
fix: send "-C" arg to `yum` to avoid slow cache updates

### DIFF
--- a/docs/sudo_cmd_list.txt
+++ b/docs/sudo_cmd_list.txt
@@ -74,4 +74,4 @@ export LANG=C LC_ALL=C; test -e "{{ item }}"
 export LANG=C LC_ALL=C; unzip -p "{{ item }}"/jboss-modules.jar META-INF/MANIFEST.MF 2>/dev/null
 export LANG=C LC_ALL=C; unzip -p '{{ item }}/jboss-as/bin/run.jar' META-INF/MANIFEST.MF
 export LANG=C LC_ALL=C; virt-what
-export LANG=C LC_ALL=C; yum repolist enabled 2> /dev/null
+export LANG=C LC_ALL=C; yum -C repolist enabled 2> /dev/null

--- a/quipucords/scanner/network/processing/jws.py
+++ b/quipucords/scanner/network/processing/jws.py
@@ -4,7 +4,7 @@ from scanner.network.processing import process
 
 
 class ProcessJWSInstalledWithRpm(process.Processor):
-    """Process the results of 'yum grouplist jws3 jws3plus jws5...'."""
+    """Process the results of 'yum -C grouplist jws3 jws3plus jws5...'."""
 
     KEY = "jws_installed_with_rpm"
     RETURN_CODE_ANY = True

--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -57,7 +57,7 @@
 
 # ------------------------------ DETECT JWS/EWS -------------------------------
 - name: check jws presence with yum
-  raw: "export LANG=C LC_ALL=C; yum grouplist {{item}} 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-99]'"
+  raw: "export LANG=C LC_ALL=C; yum -C grouplist {{item}} 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-99]'"
   register: internal_jws_installed_with_rpm
   with_items:
     - jws3

--- a/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/redhat_packages/tasks/main.yml
@@ -80,7 +80,7 @@
   ignore_errors: yes
 
 - name: gather enabled repositories
-  raw: export LANG=C LC_ALL=C; yum repolist enabled 2> /dev/null
+  raw: export LANG=C LC_ALL=C; yum -C repolist enabled 2> /dev/null
   register: internal_yum_enabled_repolist
   become: yes
   ignore_errors: yes


### PR DESCRIPTION
What does `-C` do here? From the `man yum` page:

    -C, --cacheonly
       Run entirely from system cache, don't update the cache and use
       it even in case it is expired.

       DNF  uses a separate cache for each user under which it executes.
       The cache for the root user is called the system cache. This switch
       allows a regular user read-only access to the system cache, which
       usually is more fresh than the user's and thus he does not have to
       wait for metadata sync.

Specifically, we are interested in the "don't update the cache" part because pulling updates from the remote repos could be slow or impossible, and we don't need those updates anyway. Whatever is already present on the local system should be good enough for us.

See also this discussion: https://redhat-internal.slack.com/archives/C06CZ28NRHT/p1725469217515939