### PR TITLE
chore(ScanManager): remove fluff celery don't need

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,6 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core import management
 from django.test import Client as DjangoClient
-from django.test import override_settings
 
 
 @pytest.fixture(scope="session")
@@ -60,18 +59,6 @@ def default_data_dir(settings, tmp_path: Path) -> Path:
     settings.QUIPUCORDS_CACHED_REPORTS_DATA_DIR = data_dir / "cached_reports"
     settings.QUIPUCORDS_CACHED_REPORTS_DATA_DIR.mkdir(parents=True)
     return data_dir
-
-
-@pytest.fixture(autouse=True)
-def scan_manager():
-    """return a CeleryScanManager instance configured for synchronous processing."""
-    from scanner import manager
-
-    old_scan_manager = manager.SCAN_MANAGER
-    manager.reinitialize()
-    with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
-        yield manager.SCAN_MANAGER
-    manager.SCAN_MANAGER = old_scan_manager
 
 
 @pytest.fixture

--- a/quipucords/quipucords/wsgi.py
+++ b/quipucords/quipucords/wsgi.py
@@ -18,8 +18,3 @@ application = get_wsgi_application()
 from . import environment  # noqa: E402
 
 environment.startup()
-
-from scanner import manager  # noqa: E402
-
-if not manager.SCAN_MANAGER:
-    manager.reinitialize()

--- a/quipucords/tests/api/reports/test_reports.py
+++ b/quipucords/tests/api/reports/test_reports.py
@@ -24,6 +24,7 @@ import tarfile
 from io import BytesIO
 
 import pytest
+from django.test import override_settings
 from rest_framework.renderers import JSONRenderer
 from rest_framework.reverse import reverse
 
@@ -361,11 +362,12 @@ def upload_report_payload(faker):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_upload_report(upload_report_payload, client_logged_in, mocker, scan_manager):
+def test_upload_report(upload_report_payload, client_logged_in, mocker):
     """Test 'greenpath' for uploading a report."""
-    response = client_logged_in.post(
-        reverse("v1:reports-upload"), upload_report_payload
-    )
+    with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
+        response = client_logged_in.post(
+            reverse("v1:reports-upload"), upload_report_payload
+        )
     assert response.ok
     assert response.json() == {
         "job_id": mocker.ANY,

--- a/quipucords/tests/api/scan/test_scan_bulk_delete.py
+++ b/quipucords/tests/api/scan/test_scan_bulk_delete.py
@@ -24,11 +24,11 @@ from tests.factories import (
 )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestScanBulkDelete:
     """Tests the Scan bulk_delete function."""
 
-    def test_bulk_delete_specific_ids(self, client_logged_in):
+    def test_bulk_delete_specific_ids(self, client_logged_in, celery_worker):
         """Test that bulk delete deletes all requested scans."""
         scan1 = ScanFactory()
         scan2 = ScanFactory()
@@ -82,7 +82,7 @@ class TestScanBulkDelete:
         assert response_json["missing"] == [non_existent_id]
         assert not Scan.objects.filter(pk__in=[scan1.id, scan2.id]).exists()
 
-    def test_bulk_delete_ignores_errors(self, client_logged_in):
+    def test_bulk_delete_ignores_errors(self, client_logged_in, celery_worker):
         """Test bulk delete succeeds and deletes related objects."""
         scan1 = ScanFactory()
         scan2_in_use = ScanFactory()

--- a/quipucords/tests/api/source/test_source_bulk_delete.py
+++ b/quipucords/tests/api/source/test_source_bulk_delete.py
@@ -23,7 +23,7 @@ from tests.factories import (
 )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestSourceBulkDelete:
     """Tests the Source bulk_delete function."""
 
@@ -103,7 +103,7 @@ class TestSourceBulkDelete:
         assert not Source.objects.filter(pk=source.id).exists()
         assert Source.objects.filter(pk=source_in_use.id).exists()
 
-    def test_bulk_delete_all(self, client_logged_in):
+    def test_bulk_delete_all(self, client_logged_in, celery_worker):
         """Test bulk delete succeeds with magic "all" token."""
         source1 = SourceFactory()
         source1_in_use = SourceFactory()

--- a/quipucords/tests/integration/test_ansible_scan.py
+++ b/quipucords/tests/integration/test_ansible_scan.py
@@ -128,12 +128,11 @@ def expected_fingerprints():
 
 
 @pytest.mark.integration
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.usefixtures("mocked_requests")
 class TestAnsibleScan(Smoker):
     """Smoke test Ansible automation controller scanner."""
 
-    MAX_RETRIES = 10
     SOURCE_NAME = "testing source"
     SOURCE_TYPE = "ansible"
 

--- a/quipucords/tests/integration/test_openshift_scan.py
+++ b/quipucords/tests/integration/test_openshift_scan.py
@@ -169,11 +169,10 @@ def patched_openshift_client(  # noqa: PLR0913
 
 
 @pytest.mark.integration
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestOpenShiftScan(Smoker):
     """Smoke test OpenShift scan."""
 
-    MAX_RETRIES = 10
     SOURCE_NAME = "testing source"
     SOURCE_TYPE = DataSources.OPENSHIFT
 

--- a/quipucords/tests/integration/test_rhacs_scan.py
+++ b/quipucords/tests/integration/test_rhacs_scan.py
@@ -76,12 +76,11 @@ def expected_fingerprints():
 
 
 @pytest.mark.integration
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.usefixtures("mocked_requests")
 class TestRHACSScan(Smoker):
     """Smoke test RHACS scanner."""
 
-    MAX_RETRIES = 10
     SOURCE_NAME = "testing source"
     SOURCE_TYPE = "rhacs"
 

--- a/quipucords/tests/scanner/job/test_job_celery_based.py
+++ b/quipucords/tests/scanner/job/test_job_celery_based.py
@@ -185,7 +185,6 @@ def test_celery_based_job_runner(connect_scan_job):
     assert isinstance(job_runner, job.CeleryBasedScanJobRunner)
 
 
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @pytest.mark.django_db(transaction=True)
 def test_run_celery_based_job_runner_only_connect(
     mock__celery_run_task_runner,
@@ -213,7 +212,6 @@ def test_run_celery_based_job_runner_only_connect(
     mock__finalize_scan.assert_called_once()
 
 
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @pytest.mark.django_db(transaction=True)
 def test_run_celery_based_job_runner_inspect_one_job_one_source(
     mock__celery_run_task_runner,
@@ -235,7 +233,6 @@ def test_run_celery_based_job_runner_inspect_one_job_one_source(
     mock__finalize_scan.assert_called_once()
 
 
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @pytest.mark.django_db(transaction=True)
 def test_run_celery_based_job_runner_inspect_one_job_multiple_sources(
     mock__celery_run_task_runner,
@@ -266,8 +263,9 @@ def test_fingerprint_job_greenpath(fingerprint_only_scanjob):
     ), "scanjob seems to be already completed"
     job_runner = job.ScanJobRunner(fingerprint_only_scanjob)
     assert isinstance(job_runner, job.CeleryBasedScanJobRunner)
-    async_result = job_runner.run()
-    async_result.get()
+    with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
+        async_result = job_runner.run()
+        async_result.get()
 
     fingerprint_only_scanjob.refresh_from_db()
     assert fingerprint_only_scanjob.status == ScanTask.COMPLETED

--- a/quipucords/tests/scanner/satellite/test_sat_six.py
+++ b/quipucords/tests/scanner/satellite/test_sat_six.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 import requests_mock
+from django.test import override_settings
 from faker import Faker
 
 from api.models import (
@@ -514,6 +515,7 @@ class TestSatelliteSixV1:
                 side_effect=_request_host_details,
             ),
             requests_mock.Mocker() as mocker,
+            override_settings(CELERY_TASK_ALWAYS_EAGER=True),
         ):
             mocker.get(hosts_url, status_code=200, json=hosts_jsonresult)
             self.api.hosts_facts()
@@ -1094,6 +1096,7 @@ class TestSatelliteSixV2:
                 side_effect=_request_host_details,
             ),
             requests_mock.Mocker() as mocker,
+            override_settings(CELERY_TASK_ALWAYS_EAGER=True),
         ):
             url = construct_url(url=hosts_url, sat_host="1.2.3.4")
             jsonresult = {

--- a/quipucords/tests/test_celery_scan_manager.py
+++ b/quipucords/tests/test_celery_scan_manager.py
@@ -12,13 +12,6 @@ from tests.factories import ScanJobFactory, ScanTaskFactory
 class TestCeleryScanManager:
     """Test the CeleryScanManager class."""
 
-    def test_default_scan_manager_setting(self):
-        """Assert the default manager class is CeleryScanManager."""
-        manager.reinitialize()
-        assert isinstance(manager.SCAN_MANAGER, manager.CeleryScanManager)
-        assert manager.SCAN_MANAGER.__class__.__name__ == "CeleryScanManager"
-
-    @patch("scanner.manager.isinstance", return_value=True)
     @patch("scanner.manager.set_scan_job_celery_task_id")
     def test_celery_manager_interface_put(self, set_celery_task_id_mock, faker, mocker):
         """Assert CeleryScanManager implements put."""


### PR DESCRIPTION
In another step towards getting rid of the ScanManager, remove the global manager, and the need to create a single class instance. Celery doesn't need these things.

Also, remove scan_manager fixture. From now on, tests relying on celery shall either use celery_app/celery_worker fixtures or enable CELERY_TASK_ALWAYS_EAGER.