### PR TITLE
feat: add "auth_type" to credentials api

### DIFF
--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -1151,6 +1151,7 @@ class TestCredentialSerialization:
                 "ssh_passphrase": "non-sense",
             },
             {
+                "auth_type": "password",
                 "id": mock.ANY,
                 "name": "network",
                 "cred_type": DataSources.NETWORK.value,
@@ -1169,6 +1170,7 @@ class TestCredentialSerialization:
                 "ssh_key": "some private SSH Key",
             },
             {
+                "auth_type": "ssh_key",
                 "id": mock.ANY,
                 "name": "network-ssh-key",
                 "cred_type": DataSources.NETWORK.value,
@@ -1186,6 +1188,7 @@ class TestCredentialSerialization:
                 "ssh_passphrase": "some private SSH Key passphrase",
             },
             {
+                "auth_type": "ssh_key",
                 "id": mock.ANY,
                 "name": "network-ssh-key-passphrase",
                 "cred_type": DataSources.NETWORK.value,
@@ -1203,6 +1206,7 @@ class TestCredentialSerialization:
                 "password": "some-password",
             },
             {
+                "auth_type": "password",
                 "id": mock.ANY,
                 "name": "satellite",
                 "cred_type": DataSources.SATELLITE.value,
@@ -1219,6 +1223,7 @@ class TestCredentialSerialization:
                 "password": "some-password",
             },
             {
+                "auth_type": "password",
                 "id": mock.ANY,
                 "name": "vcenter",
                 "cred_type": DataSources.VCENTER.value,
@@ -1234,6 +1239,7 @@ class TestCredentialSerialization:
                 "auth_token": "token",
             },
             {
+                "auth_type": "auth_token",
                 "id": mock.ANY,
                 "name": "ocp",
                 "cred_type": DataSources.OPENSHIFT.value,
@@ -1249,6 +1255,7 @@ class TestCredentialSerialization:
                 "password": "some-password",
             },
             {
+                "auth_type": "password",
                 "id": mock.ANY,
                 "name": "ocp-user-pass",
                 "cred_type": DataSources.OPENSHIFT.value,
@@ -1265,6 +1272,7 @@ class TestCredentialSerialization:
                 "password": "some-password",
             },
             {
+                "auth_type": "password",
                 "id": mock.ANY,
                 "name": "ansible",
                 "cred_type": DataSources.ANSIBLE.value,
@@ -1280,6 +1288,7 @@ class TestCredentialSerialization:
                 "auth_token": "token",
             },
             {
+                "auth_type": "auth_token",
                 "id": mock.ANY,
                 "name": "acs",
                 "cred_type": DataSources.RHACS.value,

--- a/quipucords/tests/api/credential/test_serializer.py
+++ b/quipucords/tests/api/credential/test_serializer.py
@@ -552,8 +552,10 @@ class TestBaseCredentialSerializer:
         for cred_data in serializer.data:
             assert "created_at" in cred_data
             assert "updated_at" in cred_data
+            assert "auth_type" in cred_data
             assert cred_data["created_at"] is not None
             assert cred_data["updated_at"] is not None
+            assert cred_data["auth_type"] is not None
 
         expected_data = []
         # prep a list of credentials dict as the serializer would return
@@ -565,6 +567,8 @@ class TestBaseCredentialSerializer:
             }
             cred_dict["created_at"] = _value_formatter(cred.created_at)
             cred_dict["updated_at"] = _value_formatter(cred.updated_at)
+            # auth_type is a read-only serializer field, not on the model
+            cred_dict["auth_type"] = CredentialSerializer().get_auth_type(cred)
             expected_data.append(cred_dict)
         assert serializer.data == expected_data
 


### PR DESCRIPTION
Example API responses showing the new `auth_type` field:

```sh
http 127.0.0.1:8000/api/v1/credentials/ Authorization:"Token $API_TOKEN" page_size==2 page==8
```

```json
{
    "count": 23,
    "next": "http://127.0.0.1:8000/api/v1/credentials/?page=9&page_size=2",
    "previous": "http://127.0.0.1:8000/api/v1/credentials/?page=7&page_size=2",
    "results": [
        {
            "auth_type": "password",
            "created_at": "2024-09-16T18:39:23.329554Z",
            "cred_type": "vcenter",
            "id": 27823,
            "name": "b2ebca84-f592-43ef-8f90-98c3e2910046",
            "password": "********",
            "updated_at": "2024-09-16T18:39:24.941053Z",
            "username": "87a46b00-da1e-43bc-b8fc-87371861c611"
        },
        {
            "auth_type": "ssh_keyfile",
            "become_method": "sudo",
            "become_user": "root",
            "created_at": "2024-09-16T18:39:53.259351Z",
            "cred_type": "network",
            "id": 27829,
            "name": "b3624fb3-8a89-49fd-82c2-06e8e1912069",
            "ssh_keyfile": "/Users/brasmith/.ssh/discovery-keys/brad-dev01-20230221.pem",
            "updated_at": "2024-09-16T18:39:53.259368Z",
            "username": "ba82489f-d722-4d70-8676-433a8e35b2aa"
        }
    ]
}
```

```sh
http 127.0.0.1:8000/api/v1/credentials/27791/ Authorization:"Token $API_TOKEN"
```

```json
{
    "auth_token": "********",
    "auth_type": "auth_token",
    "cred_type": "openshift",
    "id": 27791,
    "name": "openshift-20240708"
}
```