### PR TITLE
chore: Use full token generated by secrets lib

### DIFF
--- a/quipucords/quipucords/user.py
+++ b/quipucords/quipucords/user.py
@@ -17,7 +17,7 @@ class InvalidPasswordError(ValidationError):
 def make_random_password():
     """Create a random password for a User."""
     length = settings.QUIPUCORDS_MINIMUM_PASSWORD_LENGTH
-    return secrets.token_hex(length)[:length]
+    return secrets.token_hex(length)
 
 
 def validate_password(password: str, user: User | None = None):

--- a/quipucords/tests/quipucords/test_user.py
+++ b/quipucords/tests/quipucords/test_user.py
@@ -22,9 +22,8 @@ class TestUserRandomPasswords:
 
     def test_make_random_password_size(self):
         """Test user random password is minimum size."""
-        assert (
-            len(make_random_password()) == settings.QUIPUCORDS_MINIMUM_PASSWORD_LENGTH
-        )
+        pass_length = len(make_random_password())
+        assert pass_length == settings.QUIPUCORDS_MINIMUM_PASSWORD_LENGTH * 2
 
     def test_make_random_password_includes_allowed_characters(self):
         """Test user random password includes only allowed characters."""


### PR DESCRIPTION
We use `secrets.token_hex()` to generate a random password for user. Our default password policy specifies that passwords can't contain only numeric characters.

`token_hex()` returns string that contains hexadecimal numbers, so it may contain numeric characters by pure chance. The default upstream function output length is 20 characters, and testing showed that you need to generate about 12 000 passwords before you get one that contains numbers only.

However, we also decided to generate passwords of minimum length allowed by password policy (upstream 10 characters). In such setup, you needed only about 100 passwords before you got one that contains only numbers.

That was the root cause of intermittent failures in CI. Technically the issue is not fixed yet, but should be exceedingly rare.