### PR TITLE
refactor(fingerprinter): make all type coercions EXPLICIT

### DIFF
--- a/quipucords/api/common/util.py
+++ b/quipucords/api/common/util.py
@@ -48,37 +48,6 @@ def convert_to_int(value):
     return int(value)
 
 
-def is_float(value):
-    """Check if a value is convertable to float.
-
-    :param value: The value to convert
-    :returns: bool indicating if it can be converted
-    """
-    if isinstance(value, float):
-        return True
-    if isinstance(value, int):
-        return False
-    if not isinstance(value, str):
-        return False
-
-    try:
-        float(value)
-        return True
-    except ValueError:
-        return False
-
-
-def convert_to_float(value):
-    """Convert value to float if possible.
-
-    :param value: The value to convert
-    :returns: The int or None if not convertable
-    """
-    if not is_float(value):
-        return None
-    return float(value)
-
-
 def is_boolean(value):
     """Check if a value is a bool cast as string.
 
@@ -103,6 +72,19 @@ def convert_to_boolean(value):
     if is_boolean(value):
         return value.lower() == "true"
     return False
+
+
+def convert_to_bool_or_none(value):
+    """Convert a string "True" or "False" to boolean.
+
+    If value already is a boolean, returns it untouched.
+    Otherwise, return None.
+    """
+    if isinstance(value, bool):
+        return value
+    if is_boolean(value):
+        return value.lower() == "true"
+    return None
 
 
 def check_for_existing_name(queryset, name, error_message, search_id=None):

--- a/quipucords/fingerprinter/formatters.py
+++ b/quipucords/fingerprinter/formatters.py
@@ -31,3 +31,12 @@ def convert_architecture(architecture):
     if not architecture_map.get(architecture):
         return architecture
     return architecture_map.get(architecture)
+
+
+def str_or_none(value):
+    """Normalize value to be a string (or None when "empty")."""
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return str(value).strip()

--- a/quipucords/fingerprinter/formatters.py
+++ b/quipucords/fingerprinter/formatters.py
@@ -1,8 +1,15 @@
 """Fingerprint formatters."""
 
+import datetime
+from contextlib import suppress
+from logging import getLogger
+from typing import Any
+
+logger = getLogger(__name__)
+
 
 def format_mac_addresses(mac_addresses):
-    """Format mac addresess."""
+    """Format mac addresses."""
     if isinstance(mac_addresses, list):
         mac_addresses = list(map(lambda x: x.lower(), mac_addresses))
     return mac_addresses
@@ -33,10 +40,62 @@ def convert_architecture(architecture):
     return architecture_map.get(architecture)
 
 
-def str_or_none(value):
+def str_or_none(value) -> str | None:
     """Normalize value to be a string (or None when "empty")."""
     if value is None:
         return None
     if isinstance(value, str) and value.strip() == "":
         return None
     return str(value).strip()
+
+
+def float_or_none(value) -> float | None:
+    """Convert value to float."""
+    with suppress(ValueError, TypeError):
+        return float(value)
+    return None
+
+
+def int_or_none(value) -> int | None:
+    """Convert value to int."""
+    try:
+        return int(value)
+    except TypeError:
+        return None
+    except ValueError:
+        ...
+
+    with suppress(ValueError, TypeError):
+        return int(float_or_none(value))
+
+    return None
+
+
+def list_or_none(value: Any) -> list | None:
+    """Normalize value as list or return None."""
+    if isinstance(value, list):
+        return value
+
+
+def dict_or_none(value: Any) -> dict | None:
+    """Normalize value as dict or return None."""
+    if isinstance(value, dict):
+        return value
+
+
+def list_of_dicts(value: Any) -> list[dict]:
+    """Normalize value as a list of dicts."""
+    if isinstance(value, list) and all(
+        isinstance(inner_val, dict) for inner_val in value
+    ):
+        return value
+    return []
+
+
+def date_or_none(value: Any) -> datetime.date | None:
+    """Normalize value as date or return None."""
+    if isinstance(value, datetime.datetime):
+        return value.date()
+    if isinstance(value, datetime.date):
+        return value
+    return None

--- a/quipucords/scanner/network/normalizer.py
+++ b/quipucords/scanner/network/normalizer.py
@@ -5,7 +5,7 @@ import ipaddress
 from api.deployments_report.model import SystemFingerprint
 from constants import DataSources
 from fingerprinter import formatters
-from scanner.normalizer import BaseNormalizer, FactMapper, NormalizedResult, str_or_none
+from scanner.normalizer import BaseNormalizer, FactMapper, NormalizedResult
 from utils import deepget
 
 
@@ -81,9 +81,11 @@ class Normalizer(BaseNormalizer):
         "ifconfig_mac_addresses", formatters.format_mac_addresses
     )
     ip_addresses = FactMapper("ifconfig_ip_addresses", ip_address_normalizer)
-    bios_uuid = FactMapper("dmi_system_uuid", str_or_none)
-    insights_id = FactMapper("insights_client_id", str_or_none)
-    subscription_manager_id = FactMapper("subscription_manager_id", str_or_none)
+    bios_uuid = FactMapper("dmi_system_uuid", formatters.str_or_none)
+    insights_id = FactMapper("insights_client_id", formatters.str_or_none)
+    subscription_manager_id = FactMapper(
+        "subscription_manager_id", formatters.str_or_none
+    )
     number_of_cpus = FactMapper("cpu_core_count", int)
     number_of_sockets = FactMapper("cpu_socket_count", int)
     cores_per_socket = FactMapper("cpu_core_per_socket", int)
@@ -92,13 +94,13 @@ class Normalizer(BaseNormalizer):
         ["virt_what", "subman_virt_is_guest", "hostnamectl"],
         infrastructure_type_normalizer,
     )
-    infrastructure_vendor = FactMapper("virt_type", str_or_none)
-    os_release = FactMapper("etc_release_release", str_or_none)
-    arch = FactMapper("uname_processor", str_or_none)
-    cloud_provider = FactMapper("cloud_provider", str_or_none)
+    infrastructure_vendor = FactMapper("virt_type", formatters.str_or_none)
+    os_release = FactMapper("etc_release_release", formatters.str_or_none)
+    arch = FactMapper("uname_processor", formatters.str_or_none)
+    cloud_provider = FactMapper("cloud_provider", formatters.str_or_none)
     system_purpose = FactMapper("system_purpose_json", dict)
     network_interfaces = FactMapper(
         None, network_interfaces, dependencies=["ip_addresses"]
     )
     # ----- non canonical/system profile facts ---
-    etc_machine_id = FactMapper("etc_machine_id", str_or_none)
+    etc_machine_id = FactMapper("etc_machine_id", formatters.str_or_none)

--- a/quipucords/scanner/normalizer.py
+++ b/quipucords/scanner/normalizer.py
@@ -220,10 +220,3 @@ class NormalizedResult:
     value: Any
     raw_fact_keys: list
     has_error: bool = False
-
-
-def str_or_none(value):
-    """Normalize value to be a string (or None when "empty")."""
-    if not value:
-        return None
-    return str(value)

--- a/quipucords/tests/fingerprinter/test_formatters.py
+++ b/quipucords/tests/fingerprinter/test_formatters.py
@@ -1,0 +1,41 @@
+"""Test fingerprint formatters."""
+
+import datetime as dt
+
+import pytest
+
+from fingerprinter import formatters
+
+
+@pytest.mark.parametrize(
+    "value,expected_value,formatter",
+    (
+        ("text", "text", formatters.str_or_none),
+        (" text  ", "text", formatters.str_or_none),
+        ("", None, formatters.str_or_none),
+        ("  ", None, formatters.str_or_none),
+        (1, 1, formatters.int_or_none),
+        ("1", 1, formatters.int_or_none),
+        ("1.1", 1, formatters.int_or_none),
+        ("1.1 ", 1, formatters.int_or_none),
+        ("some text", None, formatters.int_or_none),
+        ("some text", None, formatters.float_or_none),
+        ("1.1 ", 1.1, formatters.float_or_none),
+        ("1999-01-01", None, formatters.date_or_none),
+        pytest.param(
+            dt.date.fromisoformat("1999-01-01"),
+            dt.date(1999, 1, 1),
+            formatters.date_or_none,
+            id="date-obj",
+        ),
+        pytest.param(
+            dt.datetime.fromisoformat("1999-01-01T00:00:00"),
+            dt.date(1999, 1, 1),
+            formatters.date_or_none,
+            id="datetime-obj",
+        ),
+    ),
+)
+def test_formatter(value, expected_value, formatter):
+    """Test formatters."""
+    assert formatter(value) == expected_value

--- a/quipucords/tests/utils/raw_facts_generator.py
+++ b/quipucords/tests/utils/raw_facts_generator.py
@@ -131,12 +131,28 @@ def _network_raw_facts():
             if _faker.pybool()
             else None,
             "uname_hostname": _faker.uuid4() if _faker.pybool() else None,
+            "redhat_packages_gpg_num_rh_packages": _faker.pyint(
+                min_value=0, max_value=100
+            )
+            if _faker.pybool()
+            else None,
+            "redhat_packages_certs": fake_redhat_packages_certs()
+            if _faker.pybool()
+            else None,
         }
     )
 
     # use integer division as a float will be invalid in fingerprint validation
     facts["cpu_core_per_socket"] = facts["cpu_core_count"] // facts["cpu_socket_count"]
     return facts
+
+
+def fake_redhat_packages_certs():
+    """Return a string representing the fact "redhat_packages_certs"."""
+    return ";".join(
+        str(_faker.pyint(min_value=1, max_value=500))
+        for _ in range(_faker.pyint(min_value=1, max_value=10))
+    )
 
 
 def fake_virt_what(values=None, return_code=None) -> dict:


### PR DESCRIPTION
Explicit is better than implicit. This should fix a RIDICULOUS bug that caused os_version "8.10" to become "8.1".

For the record, type coercions were all based on SystemFingerprint fields as follows:

Integer fields:
- cpu_count
- cpu_socket_count
- cpu_core_per_socket
- system_user_count
- vm_host_socket_count
- vm_host_core_count
- redhat_package_count
- system_memory_bytes

Float fields:
- cpu_core_count

Boolean fields:
- cpu_hyperthreading
- is_redhat

Relates to JIRA: DISCOVERY-783