### PR TITLE
chore: do not enable debugpy in production mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,9 @@ make lint
 
 ### Debugging
 
-You can easily attach a debugger to the running qpc-server on docker compose, which
-is also running debugpy by default.
+You can easily attach a debugger to a container running quipucords server or celery worker.
 
-For VSCode this can be easily achieved adding the following to `.vscode/launch.json`
+For VSCode this can be achieved adding the following to `.vscode/launch.json`
 
 ```json
 
@@ -50,7 +49,7 @@ For VSCode this can be easily achieved adding the following to `.vscode/launch.j
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Docker compose attach",
+            "name": "Container attach",
             "type": "python",
             "request": "attach",
             "connect": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ ENV DJANGO_SECRET_PATH=/var/data/secret.txt
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PATH="/opt/venv/bin:${PATH}"
-ENV PRODUCTION=True
 ENV PYTHONPATH=/app/quipucords
 ENV QUIPUCORDS_DATA_DIR=/var/data
-ENV QUIPUCORDS_LOG_LEVEL=INFO
 ENV QUIPUCORDS_LOG_DIRECTORY=/var/log
+ENV QUIPUCORDS_LOG_LEVEL=INFO
+ENV QUIPUCORDS_PRODUCTION=True
 
 COPY scripts/dnf /usr/local/bin/dnf
 ARG BUILD_PACKAGES="crypto-policies-scripts gcc libpq-devel python3.12-devel"

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -151,8 +151,6 @@ INSTALLED_APPS = [
 if env.bool("QUIPUCORDS_ENABLE_DJANGO_EXTENSIONS", False):
     INSTALLED_APPS.append("django_extensions")
 
-if not PRODUCTION:
-    INSTALLED_APPS.append("coverage")
 
 AUTHENTICATION_BACKENDS = [
     # AxesStandaloneBackend should be the first backend.

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -30,7 +30,7 @@ BASE_DIR = Path(__file__).absolute().parent.parent
 # DEFAULT_DATA_DIR is ./var, which is on .gitignore
 DEFAULT_DATA_DIR = Path(env.str("QUIPUCORDS_DATA_DIR", BASE_DIR.parent / "var"))
 
-PRODUCTION = env.bool("PRODUCTION", False)
+PRODUCTION = env.bool("QUIPUCORDS_PRODUCTION", True)
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # This suppresses warnings for models where an explicit primary key is not defined.
@@ -316,9 +316,6 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 STATIC_URL = "/client/"
 
 STATICFILES_DIRS = [BASE_DIR / "client"]
-
-if not PRODUCTION:
-    TESTDATA_DIR = BASE_DIR / "testdata"
 
 STORAGES = {
     "staticfiles": {

--- a/quipucords/tests/scanner/network/processing/test_hostnamectl.py
+++ b/quipucords/tests/scanner/network/processing/test_hostnamectl.py
@@ -10,7 +10,7 @@ from scanner.network.processing import hostnamectl
 from scanner.network.processing.process import ProcessedResult
 from tests.scanner.network.processing.util_for_test import ansible_result
 
-hostnamectl_files_dir = settings.TESTDATA_DIR / "hostnamectl-status"
+hostnamectl_files_dir = settings.BASE_DIR / "testdata" / "hostnamectl-status"
 
 
 def test_hostnamectl_process_success():

--- a/quipucords/utils/debugger.py
+++ b/quipucords/utils/debugger.py
@@ -10,11 +10,13 @@ env = environ.Env()
 
 DEBUGPY = env.bool("QUIPUCORDS_DEBUGPY", False)
 DEBUGPY_PORT = env.int("QUIPUCORDS_DEBUGPY_PORT", 5678)
-
+PRODUCTION = env.bool("PRODUCTION", False)
 
 def start_debugger_if_required():
     """Start a debugger session if QUIPUCORDS_DEBUGPY envvar is set."""
-    if DEBUGPY:
+    if PRODUCTION and DEBUGPY:
+        logger.debug("Debugger won't be started in production mode")
+    if DEBUGPY and not PRODUCTION:
         try:
             import debugpy
         except ImportError:

--- a/quipucords/utils/debugger.py
+++ b/quipucords/utils/debugger.py
@@ -10,7 +10,8 @@ env = environ.Env()
 
 DEBUGPY = env.bool("QUIPUCORDS_DEBUGPY", False)
 DEBUGPY_PORT = env.int("QUIPUCORDS_DEBUGPY_PORT", 5678)
-PRODUCTION = env.bool("PRODUCTION", False)
+PRODUCTION = env.bool("QUIPUCORDS_PRODUCTION", True)
+
 
 def start_debugger_if_required():
     """Start a debugger session if QUIPUCORDS_DEBUGPY envvar is set."""


### PR DESCRIPTION
- get rid of more docker references
- don't enable debugpy in "production" mode
- add QUIPUCORDS_ prefix to PRODUCTION env var