### PR TITLE
fix: connect scan should fail if no hosts are reachable

### DIFF
--- a/quipucords/scanner/network/connect.py
+++ b/quipucords/scanner/network/connect.py
@@ -230,6 +230,7 @@ def _connect(  # noqa: PLR0913, PLR0912, PLR0915
         f" with use_paramiko: {use_paramiko} and {forks:d} forks"
     )
     scan_task.log_message(log_message)
+    any_successful_connection = False
     for idx, group_name in enumerate(group_names):
         group_ips = (
             inventory.get("all").get("children").get(group_name).get("hosts").keys()
@@ -292,6 +293,7 @@ def _connect(  # noqa: PLR0913, PLR0912, PLR0915
         delete_ssh_keyfiles(inventory)
 
         final_status = runner_obj.status
+        any_successful_connection |= scan_task.systems_scanned >= 1
         if final_status == "canceled":
             msg = log_messages.NETWORK_PLAYBOOK_STOPPED % (
                 "CONNECT",
@@ -313,6 +315,8 @@ def _connect(  # noqa: PLR0913, PLR0912, PLR0915
             else:
                 msg = log_messages.NETWORK_CONNECT_FAIL % (final_status, error)
                 return msg, scan_task.FAILED
+    if not any_successful_connection:
+        return "No successful connections", scan_task.FAILED
     return None, scan_task.COMPLETED
 
 

--- a/quipucords/scanner/network/utils.py
+++ b/quipucords/scanner/network/utils.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from api.vault import decrypt_data_as_unicode
 
 
-def _credential_vars(credential):
+def _credential_vars(credential: dict) -> dict:
     """Build a dictionary containing cred information."""
     ansible_dict = {}
     username = credential.get("username")
@@ -42,7 +42,7 @@ def _credential_vars(credential):
     return ansible_dict
 
 
-def _construct_vars(connection_port, credential=None):
+def _construct_vars(connection_port, credential: dict = None) -> dict:
     """Get the Ansible host vars that implement a credential.
 
     :param connection_port: The connection port
@@ -60,13 +60,13 @@ def _construct_vars(connection_port, credential=None):
 
 
 def construct_inventory(
-    hosts,
+    hosts: list,
     connection_port,
-    concurrency_count,
+    concurrency_count: int,
     *,
-    credential=None,
-    exclude_hosts=None,
-):
+    credential: dict = None,
+    exclude_hosts: list | None = None,
+) -> tuple[list[str], dict]:
     """Create a dictionary inventory for Ansible to execute with.
 
     :param hosts: The collection of hosts (or hosts/credential tuples)

--- a/quipucords/tests/scanner/network/test_network_connect.py
+++ b/quipucords/tests/scanner/network/test_network_connect.py
@@ -50,6 +50,85 @@ class MockResultStore:
         return list(self._remaining_hosts)
 
 
+def build_ansible_run_inventory(
+    source: Source,
+    scan_job: "ScanJob",  # noqa: F821
+) -> tuple[list[str], dict]:
+    """Build inventory for Ansible run, simulating _connect function's inner logic."""
+    group_names, inventory = construct_inventory(
+        hosts=source.hosts,
+        credential={},  # required dict arg, but value is irrelevant for testing
+        connection_port=42069,  # required int arg, but value is irrelevant for testing
+        concurrency_count=scan_job.options.get(
+            "max_concurrency", Scan.DEFAULT_MAX_CONCURRENCY
+        ),
+        exclude_hosts=source.exclude_hosts,
+    )
+    return group_names, inventory
+
+
+def build_ansible_run_side_effect(  # noqa: PLR0913
+    source: Source,
+    cred: Credential,
+    result_store: ConnectResultStore,
+    group_names: list[str],
+    inventory: dict,
+    host_statuses: dict = None,
+    runner_obj_statuses: list = None,
+) -> list[callable]:
+    """
+    Build a value to assign to a mocked `ansible_run.run`'s `side_effect`.
+
+    The underlying logic here is surprisingly complex; so, here's an explanation:
+
+    When we are testing `_connect` either directly or indirectly, we need to alter the
+    behavior of a mocked `ansible_run.run` invoked inside `_connect`. The real `run`
+    takes args (`event_handler`, `cancel_callback`) that it internally calls at certain
+    stages of execution, and we rely on some of the side effects of those being called.
+    For example, when the real `run` succeeds for a host, it calls `event_handler` which
+    results in a `ConnectResultCallback.task_on_ok` call that writes an update to our
+    database through `ConnectResultStore.record_result` to `ScanTask.increment_stats`.
+    Why do we care about the value `ScanTask.increment_stats` would write to the DB?
+    Moving up the stack back to the `_connect` function itself, later logic checks those
+    written stats to determine if there were any successful connections, and that result
+    can determine the overall status returned by `_connect` which we are testing.
+
+    Why are we returning a generator of new functions as the `.side_effect`? When we
+    test `_connect` or anything that invokes it, if the source has more than one host,
+    internally the `_connect` function may split the inventory and invoke `run` several
+    times. By assigning a function generator to the mocked `run.side_effect`, we get
+    the appropriate and distinct database-writing side effects for each `run` call, and
+    we can expect the appropriate return value from `_connect` that is derived from
+    those updated database records.
+    """
+    if host_statuses is None:
+        host_statuses = {}
+
+    def run_side_effect(hosts: list[str], *args, **kwargs):
+        """Record result as a side effect like ansible_runner.run normally would do."""
+        for host in hosts:
+            result_store.record_result(
+                host,
+                source,
+                cred,
+                host_statuses.get(host, SystemConnectionResult.SUCCESS),
+            )
+        mock_runner_obj = Mock()
+        if runner_obj_statuses:
+            mock_runner_obj.status = runner_obj_statuses.pop(0)
+        else:
+            mock_runner_obj.status = "successful"
+        return mock_runner_obj
+
+    def side_effect_generator(_group_names: list[str], _inventory: dict):
+        """Generate side effects for each time `ansible_runner.run` is called."""
+        for group_name in _group_names:
+            hosts = _inventory["all"]["children"][group_name]["hosts"].keys()
+            yield run_side_effect(hosts)
+
+    return side_effect_generator(group_names, inventory)
+
+
 @pytest.mark.django_db
 class TestNetworkConnectTaskRunner:
     """Tests against the ConnectTaskRunner class and functions."""
@@ -354,12 +433,98 @@ class TestNetworkConnectTaskRunner:
         mock_run.assert_called()
 
     @patch("ansible_runner.run")
-    def test_connect_runner(self, mock_run):
-        """Test running a connect scan with mocked connection."""
-        mock_run.return_value.status = "successful"
+    def test_connect_runner_one_host_success(self, mock_run):
+        """Test running a connect scan with one host."""
         scanner = ConnectTaskRunner(self.scan_job, self.scan_task)
-        result_store = MockResultStore(["1.2.3.4"])
+        result_store = ConnectResultStore(self.scan_task)
+
+        group_names, inventory = build_ansible_run_inventory(self.source, self.scan_job)
+        assert len(group_names) == 1  # 1 not-excluded host -> 1 group
+
+        mock_run.side_effect = build_ansible_run_side_effect(
+            self.source, self.cred, result_store, group_names, inventory
+        )
         _, result = scanner.run_with_result_store(result_store)
+        assert mock_run.call_count == len(group_names)
+        assert result == ScanTask.COMPLETED
+
+    @patch("ansible_runner.run")
+    def test_connect_runner_multiple_host_groups_success(self, mock_run):
+        """Test connect scan returns complete with three hosts over two groups."""
+        scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
+        result_store = ConnectResultStore(self.scan_task3)
+
+        group_names, inventory = build_ansible_run_inventory(
+            self.source3, self.scan_job3
+        )
+        assert len(group_names) == 2  # 3 hosts, max_concurrency 2 -> 2 groups
+
+        mock_run.side_effect = build_ansible_run_side_effect(
+            self.source3, self.cred, result_store, group_names, inventory
+        )
+        _, result = scanner.run_with_result_store(result_store)
+        assert mock_run.call_count == len(group_names)
+        assert result == ScanTask.COMPLETED
+
+    @patch("ansible_runner.run")
+    def test_connect_runner_all_hosts_unreachable(self, mock_run):
+        """Test connect scan returns failure when all hosts are unreachable."""
+        scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
+        result_store = ConnectResultStore(self.scan_task3)
+
+        group_names, inventory = build_ansible_run_inventory(
+            self.source3, self.scan_job3
+        )
+        assert len(group_names) == 2  # 3 hosts, max_concurrency 2 -> 2 groups
+
+        host_statuses = {
+            host: SystemConnectionResult.UNREACHABLE for host in self.source3.hosts
+        }
+        runner_obj_statuses = ["failed", "failed"]
+        mock_run.side_effect = build_ansible_run_side_effect(
+            self.source3,
+            self.cred,
+            result_store,
+            group_names,
+            inventory,
+            host_statuses,
+            runner_obj_statuses,
+        )
+        _, result = scanner.run_with_result_store(result_store)
+        assert mock_run.call_count == len(group_names)
+        assert result == ScanTask.FAILED
+
+    @patch("ansible_runner.run")
+    def test_connect_runner_some_hosts_unreachable(self, mock_run):
+        """Test connect scan returns complete when only some hosts are unreachable."""
+        scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
+        result_store = ConnectResultStore(self.scan_task3)
+
+        group_names, inventory = build_ansible_run_inventory(
+            self.source3, self.scan_job3
+        )
+        assert len(group_names) == 2  # 3 hosts, max_concurrency 2 -> 2 groups
+
+        hosts = self.source3.hosts[::]
+        host_statuses = {hosts.pop(): SystemConnectionResult.SUCCESS}
+        host_statuses.update(
+            {host: SystemConnectionResult.UNREACHABLE for host in hosts}
+        )
+        runner_obj_statuses = ["failed", "failed"]
+        # Why are both groups failed? The group with the successful host also has one
+        # that fails, and Ansible runner considers that an overall failure. ¯\_(ツ)_/¯
+
+        mock_run.side_effect = build_ansible_run_side_effect(
+            self.source3,
+            self.cred,
+            result_store,
+            group_names,
+            inventory,
+            host_statuses,
+            runner_obj_statuses,
+        )
+        _, result = scanner.run_with_result_store(result_store)
+        assert mock_run.call_count == len(group_names)
         assert result == ScanTask.COMPLETED
 
     # Similar tests as above modified for source2 (Does not have exclude hosts)
@@ -492,15 +657,6 @@ class TestNetworkConnectTaskRunner:
                 self.concurrency,
             )
             mock_run.assert_called()
-
-    @patch("ansible_runner.run")
-    def test_connect_runner_src2(self, mock_run):
-        """Test running a connect scan with mocked connection."""
-        mock_run.return_value.status = "successful"
-        scanner = ConnectTaskRunner(self.scan_job3, self.scan_task3)
-        result_store = MockResultStore(["1.2.3.4"])
-        _, result = scanner.run_with_result_store(result_store)
-        assert result == ScanTask.COMPLETED
 
     @patch("ansible_runner.run")
     def test_connect_paramiko(self, mock_run):


### PR DESCRIPTION
This resolves a longstanding issue where the UI would present an apparent success status for a network-type connection scan even if all of the hosts in the source were unreachable. Previously, we would only fail if an individual ansible run (hosts are split into groups, and run is invoked once for each group) returned an edge-case final status like "timeout".

Relates to JIRA: DISCOVERY-823
