### PR TITLE
fix(serializers): reject empty username on editing

### DIFF
--- a/quipucords/api/credential/serializer.py
+++ b/quipucords/api/credential/serializer.py
@@ -231,7 +231,7 @@ class SshCredentialSerializerV2(CredentialSerializerV2):
             "ssh_key": ENCRYPTED_FIELD_KWARGS,
             "ssh_keyfile": {"read_only": True},
             "ssh_passphrase": ENCRYPTED_FIELD_KWARGS,
-            "username": {"required": True},
+            "username": {"required": True, "allow_blank": False},
         }
 
     def validate(self, attrs: dict):


### PR DESCRIPTION
Username is mandatory field for network credentials, no matter if you authenticate with password or SSH key. We correctly rejected new credentials without username, but allowed PATCH requests that would set username to empty string.

Also, add unit tests for network / openshift / ansible credentials; the scenario covers editing credential to set name / username / password to empty string. Right now backend still allows to set network credential password to empty string - we discussed that on Slack and decided to not mess with complex internals for now. See also [DISCOVERY-860](https://issues.redhat.com/browse/DISCOVERY-860) for a number of scenarios we should eventually support.