### PR TITLE
build: include old UI version with the container *TEMPORARILY*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,12 @@ RUN dnf remove ${BUILD_PACKAGES} -y && \
     dnf clean all
 
 # Fetch UI code
+# TODO FIXME REMOVE THE UI CODE!
+# This bundles an old version of the UI while we are release a new version separately.
+# After we have released the "new" UI code and proven it to be stable, we must remove
+# these commands that bundle the old UI code with the quipucords image.
 COPY Makefile .
-ARG UI_RELEASE="latest"
+ARG UI_RELEASE="1.8.0"
 RUN --mount=type=secret,id=gh_api_token make fetch-ui -e QUIPUCORDS_UI_RELEASE=${UI_RELEASE}
 
 # Create /deploy


### PR DESCRIPTION
After https://github.com/quipucords/quipucords-ui/pull/525 merged, quipucords image builds started failing because quipucords is not designed for the "new" UI code. This change TEMPORARILY pins the previous stable UI tag while we finish the rollout of the new UI code.

Relates to JIRA: DISCOVERY-867
Relates to JIRA: DISCOVERY-868