### PR TITLE
chore: get rid of the deprecated legacy UI views

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,15 +48,6 @@ RUN pip install -r requirements.txt
 RUN dnf remove ${BUILD_PACKAGES} -y && \
     dnf clean all
 
-# Fetch UI code
-# TODO FIXME REMOVE THE UI CODE!
-# This bundles an old version of the UI while we are release a new version separately.
-# After we have released the "new" UI code and proven it to be stable, we must remove
-# these commands that bundle the old UI code with the quipucords image.
-COPY Makefile .
-ARG UI_RELEASE="1.8.0"
-RUN --mount=type=secret,id=gh_api_token make fetch-ui -e QUIPUCORDS_UI_RELEASE=${UI_RELEASE}
-
 # Create /deploy
 COPY deploy  /deploy
 

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -195,8 +195,6 @@ TEMPLATES = [
     },
 ]
 
-LOGIN_REDIRECT_URL = "/client/"
-
 WSGI_APPLICATION = "quipucords.wsgi.application"
 
 DEFAULT_PAGINATION_CLASS = "api.common.pagination.StandardResultsSetPagination"
@@ -312,9 +310,7 @@ TIME_ZONE = "UTC"
 
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
-STATIC_URL = "/client/"
-
-STATICFILES_DIRS = [BASE_DIR / "client"]
+STATIC_URL = "/api/static/"
 
 STORAGES = {
     "staticfiles": {

--- a/quipucords/quipucords/urls.py
+++ b/quipucords/quipucords/urls.py
@@ -17,38 +17,9 @@ Including another URLconf
 
 from django.conf.urls import include
 from django.contrib import admin
-from django.contrib.auth import views as auth_views
-from django.urls import path, re_path
-from django.views.generic import RedirectView
-from django.views.generic.base import TemplateView
+from django.urls import path
 
 urlpatterns = [
-    path("login/", auth_views.LoginView.as_view(), name="login"),
-    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
-    path("", RedirectView.as_view(url="/login", permanent=False), name="home"),
-    # ui routing
-    re_path(
-        r"^(client/(sources|scans|credentials|)(/|)(index.html|))$",
-        TemplateView.as_view(template_name="client/index.html"),
-        name="client",
-    ),
-    # docs files
-    re_path(
-        r"^client/docs(/|)(index.html|use.html|)$",
-        RedirectView.as_view(url="/client/docs/use.html", permanent=False),
-        name="docs",
-    ),
-    re_path(
-        r"^client/docs(/|)(install.html|)$",
-        RedirectView.as_view(url="/client/docs/install.html", permanent=False),
-        name="docs",
-    ),
-    # static files (*.css, *.js, *.jpg etc.)
-    re_path(
-        r"^(?!/?client/)(?P<path>.*\..*)$",
-        RedirectView.as_view(url="/client/%(path)s", permanent=False),
-        name="client",
-    ),
 ]


### PR DESCRIPTION
With the new and standalone UI released we can finally get rid of UI views, templates, js, css and other static files from that UI.

With this change, Django development server can FINALLY run in true standalone mode, without the argument --nostatic.

Please remember to remove these unneeded files from local storage:
```
rm -rf quipucords/client
rm -rf quipucords/quipucords/templates
rm -rf quipucords/staticfiles
```

~~EDIT: This PR removes Django admin and adds an autogenerated schema view (mostly for v2 endpoints).~~

Relates to JIRA: DISCOVERY-777
~~Relates to JIRA: DISCOVERY-726~~
