### PR TITLE
fix: set job status to FAILED when its task fails

### DIFF
--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -62,6 +62,16 @@ class ScanJob(BaseModel):
 
     objects = ScanJobQuerySet.as_manager()
 
+    def __str__(self):
+        """Get a rudimentary string representation."""
+        return (
+            f"{self.__class__.__name__}("
+            f"id={self.id}, "
+            f"scan_type={self.scan_type}, "
+            f"status={self.status}"
+            ")"
+        )
+
     class Meta:
         """Metadata for model."""
 

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -73,6 +73,18 @@ class ScanTask(BaseModel):
         TaskConnectionResult, null=True, on_delete=models.SET_NULL
     )
 
+    def __str__(self):
+        """Get a rudimentary string representation."""
+        return (
+            f"{self.__class__.__name__}("
+            f"id={self.id}, "
+            f"scan_type={self.scan_type}, "
+            f"status={self.status}, "
+            f"job_id={self.job_id}, "
+            f"sequence_number={self.sequence_number}"
+            ")"
+        )
+
     @cached_property
     def scan_job_task_count(self):
         """

--- a/quipucords/api/source/model.py
+++ b/quipucords/api/source/model.py
@@ -54,6 +54,16 @@ class Source(BaseModel):
         "api.ScanJob", null=True, on_delete=models.SET_NULL, related_name="+"
     )
 
+    def __str__(self):
+        """Get a rudimentary string representation."""
+        return (
+            f"{self.__class__.__name__}("
+            f"id={self.id}, "
+            f"source_type={self.source_type}, "
+            f"name={self.name}"
+            ")"
+        )
+
     @property
     def options(self):
         """Return the v1 compatible options attribute for the source object."""

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -92,6 +92,8 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
         # Note: It should be very unlikely for this exception handling to be triggered.
         # runner.run should already handle *most* exception types, and only a bug or
         # truly unforeseen exception type should end up in here.
+        # Some networking errors (host timeout, bad cert) may end up here.
+        # TODO Evaluate removing this `except` in favor of higher level error handling.
         failed_task = runner.scan_task
         context_message = (
             "Unexpected failure occurred. See context below.\n"
@@ -118,6 +120,7 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
         runner.scan_task.status_complete(status_message)
     elif task_status == ScanTask.FAILED:
         runner.scan_task.status_fail(status_message)
+        runner.scan_job.status_fail(status_message)
     else:
         error_message = (
             f"ScanTask {runner.scan_task.sequence_number:d} failed."

--- a/quipucords/tests/api/scanjob/test_scanjob.py
+++ b/quipucords/tests/api/scanjob/test_scanjob.py
@@ -2008,3 +2008,13 @@ def test_delete_inspect_results_bound_to_other_scanjobs(
     scanjob.delete_inspect_results()
     assert InspectResult.objects.filter(inspect_group__tasks__job=scanjob).count() == 0
     assert not InspectResult.objects.filter(id=inspect_res_id).exists()
+
+
+@pytest.mark.django_db
+def test_scanjob_model_str():
+    """Test the __str__ method."""
+    scan_job = ScanJobFactory()
+    scan_job_str = f"{scan_job}"
+    assert f"id={scan_job.id}" in scan_job_str
+    assert f"scan_type={scan_job.scan_type}" in scan_job_str
+    assert f"status={scan_job.status}" in scan_job_str

--- a/quipucords/tests/api/scantask/test_scantask.py
+++ b/quipucords/tests/api/scantask/test_scantask.py
@@ -285,3 +285,13 @@ def test_log_scan_message_problematic(scan_job, caplog, faker):
     assert len(caplog.messages) == 2
     assert "Missing source" in caplog.messages[0]
     assert message in caplog.messages[1]
+
+
+@pytest.mark.django_db
+def test_scantask_model_str():
+    """Test the __str__ method."""
+    scan_task = ScanTaskFactory()
+    scan_task_str = f"{scan_task}"
+    assert f"id={scan_task.id}" in scan_task_str
+    assert f"scan_type={scan_task.scan_type}" in scan_task_str
+    assert f"status={scan_task.status}" in scan_task_str

--- a/quipucords/tests/api/source/test_source.py
+++ b/quipucords/tests/api/source/test_source.py
@@ -14,6 +14,7 @@ from api.models import Credential, Scan, ScanTask, Source
 from api.serializers import SourceSerializer
 from api.source.view import format_source
 from constants import DataSources
+from tests.factories import SourceFactory
 from tests.scanner.test_util import create_scan_job
 
 ACCEPT_JSON_HEADER = {"Accept": "application/json"}
@@ -3324,3 +3325,13 @@ class TestSourceV2:
         }
         response = self.update_source(client_logged_in, updated_data, initial["id"])
         assert response.ok
+
+
+@pytest.mark.django_db
+def test_source_model_str():
+    """Test the __str__ method."""
+    source = SourceFactory()
+    source_str = f"{source}"
+    assert f"id={source.id}" in source_str
+    assert f"source_type={source.source_type}" in source_str
+    assert f"name={source.name}" in source_str

--- a/quipucords/tests/scanner/job/test_run_task_runner.py
+++ b/quipucords/tests/scanner/job/test_run_task_runner.py
@@ -1,0 +1,23 @@
+"""Tests for scanner.job.run_task_runner."""
+
+import pytest
+
+from api.scantask.model import ScanTask
+from scanner import job
+
+
+@pytest.mark.django_db
+def test_run_task_runner_task_fails(mocker, faker):
+    """Test run_task_runner sets task and job statuses when the run fails."""
+    expected_message = faker.sentence()
+    expected_status = ScanTask.FAILED
+
+    mock_runner = mocker.Mock()
+    mock_runner.run.return_value = (expected_message, expected_status)
+    mock_scan_task = mock_runner.scan_task
+    mock_scan_job = mock_runner.scan_job
+
+    runner_status = job.run_task_runner(runner=mock_runner)
+    assert runner_status == expected_status
+    mock_scan_task.status_fail.assert_called_once_with(expected_message)
+    mock_scan_job.status_fail.assert_called_once_with(expected_message)


### PR DESCRIPTION
This should resolve some issues where a scan job would appear to be stuck running forever (spinner graphic in web UI) despite its task having already failed and having no other activity.

This PR also includes an unrelated commit that adds basic `__str__` method to several of our model classes to aid future issue investigation and debugging. For example `ScanTask object (27188)` becomes `ScanTask(id=27188, scan_type=connect, status=failed, job_id=25735, sequence_number=1)`.

Relates to JIRA: DISCOVERY-800
Relates to JIRA: DISCOVERY-838