### PR TITLE
feature: regenerate cached fingerprint and cached csv if missing when requested

### DIFF
--- a/quipucords/api/deployments_report/tasks.py
+++ b/quipucords/api/deployments_report/tasks.py
@@ -1,0 +1,30 @@
+"""Celery tasks for async DeploymentsReports processes."""
+
+import logging
+
+import celery
+
+from api.deployments_report.model import DeploymentsReport
+from api.deployments_report.util import create_deployments_csv
+from api.deployments_report.view import build_cached_json_report
+
+logger = logging.getLogger(__name__)
+
+
+@celery.shared_task()
+def generate_and_save_cached_csv(deployments_report_id: int):
+    """Generate the save cached csv data for the given deployment report ID."""
+    try:
+        deployments_report = DeploymentsReport.objects.get(id=deployments_report_id)
+        deployments_report.cached_csv_file_path = None
+        deployments_report.save()
+        deployments_json = build_cached_json_report(deployments_report)
+        create_deployments_csv(deployments_json)
+    except Exception as e:  # noqa: BLE001
+        # Catch all exceptions because this Celery task should exit cleanly
+        # regardless of whether it succeeds. We might arrive here if the
+        # DeploymentsReport also lacks the cached fingerprints data which
+        # is required for building the CSV data.
+        logger.exception(e)
+        return False
+    return True

--- a/quipucords/api/deployments_report/view.py
+++ b/quipucords/api/deployments_report/view.py
@@ -39,7 +39,17 @@ def deployments(request, report_id=None):
             },
             status=status.HTTP_424_FAILED_DEPENDENCY,
         )
-    deployments_json = build_cached_json_report(deployments_report)
+
+    try:
+        deployments_json = build_cached_json_report(deployments_report)
+    except FileNotFoundError:
+        return Response(
+            {
+                "detail": f"Deployment report {deployments_report.report.id}"
+                " could not be created. See server logs."
+            },
+            status=status.HTTP_424_FAILED_DEPENDENCY,
+        )
     return Response(deployments_json)
 
 

--- a/quipucords/api/management/commands/regenerate_missing_report_cache_files.py
+++ b/quipucords/api/management/commands/regenerate_missing_report_cache_files.py
@@ -1,0 +1,130 @@
+"""Regenerate missing DeploymentsReport cache files."""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from api.deployments_report.model import DeploymentsReport
+from api.deployments_report.tasks import generate_and_save_cached_csv
+from utils.misc import is_valid_cache_file
+
+
+class Command(BaseCommand):
+    """Django management command to regenerate missing DeploymentsReport cache files."""
+
+    help = "Regenerate missing DeploymentsReport cache files"
+
+    def write_info(self, message):
+        """Write info message to stdout."""
+        self.stdout.write(message)
+
+    def write_warning(self, message):
+        """Write warning message to stdout."""
+        self.stdout.write(self.style.WARNING(message))
+
+    def write_success(self, message):
+        """Write success message to stdout."""
+        self.stdout.write(self.style.SUCCESS(message))
+
+    def find_reports_with_missing_cached_data(self) -> tuple[set, set]:
+        """
+        Find reports with missing cached data and return their IDs.
+
+        Returned tuple contains 1) the set of IDs with missing fingerprints
+        and 2) the set of IDs with missing CSV data.
+        """
+        missing_fingerprints_ids = set()
+        missing_csv_ids = set()
+        deployments_reports = DeploymentsReport.objects.filter(
+            status=DeploymentsReport.STATUS_COMPLETE
+        ).values("id", "cached_fingerprints_file_path", "cached_csv_file_path")
+        self.write_info(
+            f"Found {len(deployments_reports)} completed DeploymentsReports to check."
+        )
+        for deployments_report in deployments_reports:
+            # Note: We check for presence of value before checking is_valid_cache_file.
+            # If the value is None, then the file was never written, and we do not care.
+
+            if deployments_report[
+                "cached_fingerprints_file_path"
+            ] and not is_valid_cache_file(
+                deployments_report["cached_fingerprints_file_path"]
+            ):
+                self.write_warning(
+                    f"{deployments_report['cached_fingerprints_file_path']} is missing "
+                    f"for DeploymentsReport {deployments_report['id']}."
+                )
+                missing_fingerprints_ids.add(deployments_report["id"])
+
+            if deployments_report["cached_csv_file_path"] and not is_valid_cache_file(
+                deployments_report["cached_csv_file_path"]
+            ):
+                self.write_warning(
+                    f"{deployments_report['cached_csv_file_path']} is missing "
+                    f"for DeploymentsReport {deployments_report['id']}."
+                )
+                missing_csv_ids.add(deployments_report["id"])
+
+        return missing_fingerprints_ids, missing_csv_ids
+
+    def generate_fingerprints(
+        self, deployments_report_ids: set[int]
+    ) -> tuple[list, list]:
+        """Generate cached fingerprints for the given deployments report IDs."""
+        success_ids = []
+        failure_ids = []
+        deployments_report_ids = sorted(list(deployments_report_ids))
+        for _id in deployments_report_ids:
+            deployments_report = DeploymentsReport.objects.get(pk=_id)
+            self.write_info(f"Rerunning fingerprint task for {deployments_report}")
+            try:
+                deployments_report._rerun_latest_fingerprint(wait=True)
+                success_ids.append(_id)
+            except Exception as e:  # noqa: BLE001
+                self.stdout.write(self.style.ERROR(str(e)))
+                failure_ids.append(_id)
+
+        return success_ids, failure_ids
+
+    def generate_csvs(self, deployments_report_ids: set[int]) -> tuple[list, list]:
+        """Generate cached CSV files for the given deployments report IDs."""
+        success_ids = []
+        failure_ids = []
+        for _id in sorted(list(deployments_report_ids)):
+            success = generate_and_save_cached_csv(_id)
+            success_ids.append(_id) if success else failure_ids.append(_id)
+
+        return success_ids, failure_ids
+
+    def handle(self, *args, **options):
+        """Handle this command."""
+        missing_fingerprints_ids, missing_csv_ids = (
+            self.find_reports_with_missing_cached_data()
+        )
+
+        fingerprint_successes, fingerprint_failures = self.generate_fingerprints(
+            missing_fingerprints_ids
+        )
+        csv_successes, csv_failures = self.generate_csvs(missing_csv_ids)
+
+        for _id in fingerprint_successes:
+            self.write_success(
+                f"Generated cached_fingerprints_file_path for DeploymentsReport {_id}"
+            )
+        for _id in fingerprint_failures:
+            self.write_warning(
+                "Failed to generate cached_fingerprints_file_path for "
+                f"DeploymentsReport {_id}"
+            )
+        for _id in csv_successes:
+            self.write_success(
+                f"Generated cached_csv_file_path for DeploymentsReport {_id}"
+            )
+        for _id in csv_failures:
+            self.write_warning(
+                f"Failed to generate cached_csv_file_path for DeploymentsReport {_id}"
+            )
+
+        if fingerprint_failures or csv_failures:
+            raise CommandError(
+                f"Failed to generate {len(fingerprint_failures)} fingerprint files. "
+                f"Failed to generate {len(csv_failures)} CSV files. "
+            )

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -379,6 +379,7 @@ class ScanJob(BaseModel):
             fingerprint_task.prerequisites.set(prerequisites)
 
             self.tasks.add(fingerprint_task)
+            return fingerprint_task
 
     def status_start(self):
         """Change status from PENDING to RUNNING.

--- a/quipucords/fingerprinter/runner.py
+++ b/quipucords/fingerprinter/runner.py
@@ -134,7 +134,18 @@ class FingerprintTaskRunner(ScanTaskRunner):
 
     def execute_task(self):
         """Execute fingerprint task."""
-        deployment_report = DeploymentsReport(report_version=create_report_version())
+        # If a DeploymentsReport already exists for this job/report, use that.
+        # One may already exist if we are simply rerunning the fingerprint task,
+        # but we need to clear any invalid cached file paths before proceeding.
+        if self.scan_job.report and self.scan_job.report.deployment_report:
+            deployment_report = self.scan_job.report.deployment_report
+            if not deployment_report.cached_fingerprints_file_exists:
+                deployment_report.cached_fingerprints_file_path = None
+            if not deployment_report.cached_csv_file_exists:
+                deployment_report.cached_csv_file_path = None
+        else:
+            deployment_report = DeploymentsReport()
+        deployment_report.report_version = create_report_version()
         deployment_report.save()
 
         self.scan_job.report.deployment_report = deployment_report

--- a/quipucords/quipucords/celery.py
+++ b/quipucords/quipucords/celery.py
@@ -20,7 +20,7 @@ app = Celery("quipucords")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django apps.
-task_packages = ["scanner", "scanner.satellite.six"]
+task_packages = ["scanner", "scanner.satellite.six", "api.deployments_report.tasks"]
 app.autodiscover_tasks(task_packages)
 
 

--- a/quipucords/tests/api/deployments_report/test_tasks.py
+++ b/quipucords/tests/api/deployments_report/test_tasks.py
@@ -1,0 +1,32 @@
+"""Tests for api.deployments_report.tasks."""
+
+import logging
+
+import pytest
+
+from api.deployments_report.tasks import generate_and_save_cached_csv
+from tests.factories import DeploymentReportFactory
+from utils.misc import is_valid_cache_file
+
+
+@pytest.mark.django_db
+def test_generate_and_save_cached_csv():
+    """Test generate_and_save_cached_csv generates the file and updates the model."""
+    deployments_report = DeploymentReportFactory.create(number_of_fingerprints=1)
+    assert not is_valid_cache_file(deployments_report.cached_csv_file_path)
+    assert generate_and_save_cached_csv(deployments_report.id)
+    deployments_report.refresh_from_db()
+    assert deployments_report.cached_csv_file_path is not None
+    assert is_valid_cache_file(deployments_report.cached_csv_file_path)
+
+
+@pytest.mark.django_db
+def test_generate_and_save_cached_csv_failure(mocker, caplog):
+    """Test generate_and_save_cached_csv logs and suppresses unexpected exceptions."""
+    caplog.set_level(logging.ERROR)
+    deployments_report = DeploymentReportFactory.create(number_of_fingerprints=1)
+    mock_build = mocker.patch("api.deployments_report.tasks.build_cached_json_report")
+    message = "Nobody expects the Spanish Inquisition!"
+    mock_build.side_effect = Exception(message)
+    assert not generate_and_save_cached_csv(deployments_report.id)
+    assert message in caplog.messages

--- a/quipucords/tests/scanner/job/test_job_celery_based.py
+++ b/quipucords/tests/scanner/job/test_job_celery_based.py
@@ -9,11 +9,13 @@ carefully whether you want the live worker or CELERY_TASK_ALWAYS_EAGER as
 you update or add more tests.
 """
 
+from pathlib import Path
 from unittest.mock import ANY, patch
 
 import pytest
 from django.test import override_settings
 
+from api.deployments_report.tasks import generate_and_save_cached_csv
 from api.models import Report, ScanJob, ScanTask
 from constants import DataSources
 from scanner import job, tasks
@@ -275,6 +277,59 @@ def test_fingerprint_job_greenpath(fingerprint_only_scanjob):
     deployments_report = fingerprint_only_scanjob.report.deployment_report
     assert deployments_report.id
     assert deployments_report.system_fingerprints.count() == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.dbcompat
+def test_fingerprint_job_via_rerun_latest_fingerprint(fingerprint_only_scanjob):
+    """
+    Test that a fingerprint-only scanjob can be RE-run successfully.
+
+    This test is very similar to the preceding "test_fingerprint_job_greenpath" test,
+    and the initial setup is the same, but this test adds coverage for the case when
+    the fingerprint job is run again as a result of cached fingerprints files going
+    missing some time after the initial fingerprint job completed.
+    """
+    assert not fingerprint_only_scanjob.report.deployment_report, (
+        "scanjob seems to be already completed"
+    )
+    job_runner = job.ScanJobRunner(fingerprint_only_scanjob)
+    assert isinstance(job_runner, job.CeleryBasedScanJobRunner)
+    with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
+        async_result = job_runner.run()
+        async_result.get()
+
+    fingerprint_only_scanjob.refresh_from_db()
+    assert fingerprint_only_scanjob.status == ScanTask.COMPLETED
+
+    # We should have "cached" fingerprint data now.
+    deployments_report = fingerprint_only_scanjob.report.deployment_report
+    assert deployments_report.cached_fingerprints_file_exists
+    # cached_csv is not populated automatically by fingerprinting alone.
+    generate_and_save_cached_csv(deployments_report.id)
+    deployments_report.refresh_from_db()
+    assert deployments_report.cached_csv_file_exists
+
+    # Destroy the underlying cache files to force the fields to clear
+    # when the fingerprint task starts up again.
+    Path(deployments_report.cached_fingerprints_file_path).unlink()
+    Path(deployments_report.cached_csv_file_path).unlink()
+
+    # Rerun the fingerprint task via DeploymentsReport._rerun_latest_fingerprint.
+    with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
+        deployments_report._rerun_latest_fingerprint(wait=True)
+
+    fingerprint_only_scanjob.refresh_from_db()
+    assert fingerprint_only_scanjob.status == ScanTask.COMPLETED
+
+    # Check the cached fields and files again.
+    deployments_report.refresh_from_db()
+    assert deployments_report.cached_fingerprints_file_path is not None
+    assert deployments_report.cached_fingerprints_file_exists
+    # And remember that fingerprinting alone does not generate the CSV data,
+    # but it should clear the path when it sees that the file is missing.
+    assert deployments_report.cached_csv_file_path is None
+    assert not deployments_report.cached_csv_file_exists
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)

--- a/quipucords/tests/utils/test_is_valid_cache_file.py
+++ b/quipucords/tests/utils/test_is_valid_cache_file.py
@@ -1,0 +1,43 @@
+"""Tests for utils.misc.is_valid_cache_file."""
+
+from pathlib import Path
+
+from utils.misc import is_valid_cache_file
+
+
+def test_file_exists_none_false():
+    """None path is not a file."""
+    assert not is_valid_cache_file(None)
+
+
+def test_file_exists_not_a_file_false(tmpdir):
+    """Directory path is not a file."""
+    assert not is_valid_cache_file(tmpdir)
+
+
+def test_file_exists_bogus_path_false(faker):
+    """Bogus path is not a file."""
+    assert not is_valid_cache_file(str(faker.slug()))
+
+
+def test_file_exists_empty_file_false(tmpdir, faker):
+    """Empty file is not a valid cache file."""
+    empty_path = Path(tmpdir) / faker.slug()
+    empty_path.touch()
+    assert not is_valid_cache_file(str(empty_path))
+
+
+def test_file_exists_unreadable_file_false(tmpdir, faker):
+    """Empty file is not a valid cache file."""
+    unreadable_path = Path(tmpdir) / faker.slug()
+    unreadable_path.write_text(faker.slug())
+    unreadable_path.chmod(0o000)
+    assert not is_valid_cache_file(str(unreadable_path))
+
+
+def test_file_exists_normal_file_true(tmpdir, faker):
+    """Normal nonzero-length readable file is a valid cache file."""
+    file_path = Path(tmpdir) / faker.slug()
+    file_path.touch()
+    file_path.write_text(faker.slug())
+    assert is_valid_cache_file(str(file_path))

--- a/quipucords/utils/misc.py
+++ b/quipucords/utils/misc.py
@@ -1,6 +1,8 @@
 """Misc utils for quipucords."""
 
 import json
+import os
+from pathlib import Path
 
 
 def load_json_from_tarball(json_filename, tarball):
@@ -34,3 +36,17 @@ def sanitize_for_utf8_compatibility(value):
     if isinstance(value, tuple):
         return tuple(sanitize_for_utf8_compatibility(value) for value in value)
     return value
+
+
+def is_valid_cache_file(file_path: str | None) -> bool:
+    """Check if a file exists, has non-zero size, and is both readable and writable."""
+    if not file_path:
+        return False
+    path = Path(file_path).absolute()
+    return (
+        path.exists()
+        and path.is_file()
+        and path.stat().st_size > 0
+        and os.access(file_path, os.R_OK)
+        and os.access(file_path, os.W_OK)
+    )


### PR DESCRIPTION
This change automatically recreates files in the `cached_reports` directory if they are missing when any report download that needs them is requested. The initial download request may immediately return an error message (we should consider making the UI handle this more gracefully), but if you wait a few seconds for a newly spawned async task to complete and then try the download again, you should get the completed report. This works for operations in the UI and the CLI.

Additionally, this change adds a management command `regenerate_missing_report_cache_files` that attempts to identify and fix all missing `cached_reports` files. Running this command still uses Celery tasks. So, be sure you have Celery workers running when you call it or else it will hang forever while it waits for Celery task results.

Please note: Normally nothing in our system should delete `cached_reports` files while they might still be needed. The use case for this change includes installations that were recovered from a previous setup using _only_ a database backup and the requisite `secret.txt` file.

Also note: quipucords server ensures that the `cached_reports` directory exists at startup and only at startup. These instructions tell you to delete the contents of that directory, not the directory itself. If you delete the whole directory, please restart the server and Celery workers.

What follows are documented steps that I performed manually to exercise the new behaviors.

Breaking and fixing typical reports made through the UI:

- starting from new database
- add a network credential and source for known working address
- create a scan using that credential and source
- wait for scan to complete
- immediately delete contents of `cached_reports` directory (should be single JSON file)
- try to download the report
- observe error
- wait a few seconds, and try to download the report again
- verify that it downloads successfully
- repeat last 5 steps (directory should have 1 JSON file and 1 CSV file)

Breaking and fixing uploaded reports:

- downloaded the report from the previous section
- extract the details.json file
- use the CLI to upload it
    ```bash
    qpc report upload --json-file ~/Desktop/report_id_2/details.json
    ```
- check the job given in the response, expecting `"status": "completed",`
    ```bash
    qpc scan job --id 8
    ```
- delete the contents of `cached_reports` directory
- attempt to download the report
    ```bash
    qpc report download --report 3 --output-file ~/Desktop/report-3.tar.gz
    ```
- observe error
- wait a few seconds, and try to download the report again
- verify that it downloads successfully

Breaking and fixing merged reports:

- get the report IDs generated by the previous steps (e.g. 1 and 2)
- delete the contents of `cached_reports` directory
- use the CLI to merge the previous reports
    ```bash
    qpc report merge --report-ids 2 3
    ```
- check the job given in the reponse, expecting `"status": "failed"`
    ```bash
    qpc scan job --id 9
    ```
- wait a few seconds, and try the merge command again
    ```bash
    qpc report merge --report-ids 2 3
    ```
- check the job given in the reponse, expecting `"status": "completed"`
    ```bash
    qpc scan job --id 10
    ```
- download the report
    ```bash
    qpc report download --report 6 --output-file ~/Desktop/report-6.tar.gz
    ```
- verify that it downloads successfully

Using the management command to fix all broken but fixable reports:

- delete the contents of `cached_reports` directory
- use the management command
    ```bash
    python quipucords/manage.py regenerate_missing_report_cache_files
    ```
- download any of the reports as described in the previous steps
- verify that they download successfully


Relates to JIRA: DISCOVERY-887