### PR TITLE
fix: patch a misshandle on ssh keyfiles

### DIFF
--- a/quipucords/constants.py
+++ b/quipucords/constants.py
@@ -18,3 +18,4 @@ ENCRYPTED_DATA_MASK = "********"
 SCAN_JOB_LOG = "scan-job-{scan_job_id}-{output_type}.txt"
 # minimum accepted version for imported reports
 MINIMUM_REPORT_VERSION = (1, 0, 0)
+GENERATED_SSH_KEYFILE = "generated_ssh_keyfile"

--- a/quipucords/scanner/network/connect.py
+++ b/quipucords/scanner/network/connect.py
@@ -1,5 +1,7 @@
 """ScanTask used for network connection discovery."""
 
+from __future__ import annotations
+
 import logging
 
 import ansible_runner
@@ -159,13 +161,13 @@ class ConnectTaskRunner(ScanTaskRunner):
 
             try:
                 scan_message, scan_result = _connect(
-                    self.scan_task,
-                    remaining_hosts,
-                    result_store,
-                    credential,
-                    connection_port,
-                    forks,
-                    use_paramiko,
+                    scan_task=self.scan_task,
+                    hosts=remaining_hosts,
+                    result_store=result_store,
+                    credential=credential,
+                    connection_port=connection_port,
+                    forks=forks,
+                    use_paramiko=use_paramiko,
                 )
                 if scan_result != ScanTask.COMPLETED:
                     return scan_message, scan_result
@@ -191,7 +193,8 @@ class ConnectTaskRunner(ScanTaskRunner):
         return None, ScanTask.COMPLETED
 
 
-def _connect(  # noqa: PLR0913, PLR0912, PLR0915
+def _connect(  # noqa: PLR0913, PLR0915
+    *,
     scan_task: ScanTask,
     hosts,
     result_store: ConnectResultStore,

--- a/quipucords/tests/api/credential/test_credential.py
+++ b/quipucords/tests/api/credential/test_credential.py
@@ -114,14 +114,14 @@ class TestCredential:
         assert Credential.objects.get().name == "cred1"
 
     @pytest.fixture
-    def openssh_key(self, faker):
+    def openssh_key(self):
         """Return an openssh_key random OpenSSH private key."""
-        return generate_openssh_pkey(faker)
+        return generate_openssh_pkey()
 
     @pytest.fixture
-    def updated_openssh_key(self, faker):
+    def updated_openssh_key(self):
         """Return an openssh_key random OpenSSH private key."""
-        return generate_openssh_pkey(faker)
+        return generate_openssh_pkey()
 
     def test_hostcred_create_with_ssh_key(self, client_logged_in, openssh_key):
         """Ensure we can create a new host credential object with an ssh_key."""

--- a/quipucords/tests/api/credential/test_credential_model.py
+++ b/quipucords/tests/api/credential/test_credential_model.py
@@ -1,0 +1,43 @@
+"""Test credential model methods."""
+
+from pathlib import Path
+
+import pytest
+
+from api.models import Credential
+from api.vault import decrypt_data_as_unicode
+from tests.factories import CredentialFactory
+
+
+class TestGenerateSSHKeyfile:
+    """Test Credential.generate_ssh_keyfile."""
+
+    def test_with_ssh_key(self):
+        """Test the method when credential has a ssh_key."""
+        credential: Credential = CredentialFactory.build(with_ssh_key=True)
+        with credential.generate_ssh_keyfile() as ssh_keyfile:
+            assert Path(ssh_keyfile).exists()
+            expected_ssh_key_contents = (
+                decrypt_data_as_unicode(credential.ssh_key) + "\n"
+            )
+            assert Path(ssh_keyfile).read_text() == expected_ssh_key_contents
+        # ensure the key is destroyed outside of the with block
+        assert not Path(ssh_keyfile).exists()
+
+    def test_without_ssh_key(self):
+        """Test the method when credential has no ssh_key."""
+        credential: Credential = CredentialFactory.build()
+
+        with credential.generate_ssh_keyfile() as ssh_keyfile:
+            assert ssh_keyfile is None
+
+    def test_with_error(self):
+        """Ensure the generated file is destroyed even on errors on nested code."""
+        credential: Credential = CredentialFactory.build(with_ssh_key=True)
+
+        with pytest.raises(RuntimeError):
+            with credential.generate_ssh_keyfile() as ssh_keyfile:
+                raise RuntimeError
+
+        # make sure the file is destroyed
+        assert not Path(ssh_keyfile).exists()

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -16,6 +16,7 @@ from faker import Faker
 from api import models
 from api.serializers import SystemFingerprintSerializer
 from api.status import get_server_id
+from api.vault import encrypt_data_as_unicode
 from constants import DataSources
 from tests.utils import fake_rhel, raw_facts_generator
 from tests.utils.raw_facts_generator import (
@@ -349,6 +350,16 @@ class CredentialFactory(DjangoModelFactory):
 
         model = models.Credential
 
+    class Params:
+        """Factory params."""
+
+        with_ssh_key = factory.Trait(
+            ssh_key=factory.LazyFunction(
+                lambda: encrypt_data_as_unicode(generate_openssh_pkey())
+            ),
+            cred_type=DataSources.NETWORK,
+        )
+
     @factory.lazy_attribute
     def auth_token(self):
         """Set auth_token lazily."""
@@ -444,10 +455,10 @@ def generate_invalid_id(faker: factory.Faker) -> int:
     return faker.pyint(min_value=990000, max_value=999999)
 
 
-def generate_openssh_pkey(faker: factory.Faker) -> str:
+def generate_openssh_pkey() -> str:
     """Generate a random OpenSSH private key."""
     pkey = "-----BEGIN OPENSSH EXAMPLE KEY-----\n"
     for __ in range(5):
-        pkey += f"{faker.lexify('?' * 70)}\n"
+        pkey += f"{_faker.lexify('?' * 70)}\n"
     pkey += "-----END OPENSSH EXAMPLE KEY-----\n"
     return pkey

--- a/quipucords/tests/scanner/network/test_network_connect.py
+++ b/quipucords/tests/scanner/network/test_network_connect.py
@@ -216,9 +216,9 @@ class TestNetworkConnectTaskRunner:
         assert vars_dict == expected
 
     @pytest.fixture
-    def openssh_key(self, faker):
+    def openssh_key(self):
         """Return a fake OpenSSH private key."""
-        return generate_openssh_pkey(faker)
+        return generate_openssh_pkey()
 
     @pytest.fixture
     def cred_ssh(self, openssh_key):

--- a/quipucords/tests/scanner/network/test_network_connect.py
+++ b/quipucords/tests/scanner/network/test_network_connect.py
@@ -361,13 +361,13 @@ class TestNetworkConnectTaskRunner:
         connection_port = source["port"]
         with pytest.raises(AnsibleRunnerException):
             _connect(
-                self.scan_task,
-                hosts,
-                Mock(),
-                self.cred,
-                connection_port,
-                self.concurrency,
-                exclude_hosts,
+                scan_task=self.scan_task,
+                hosts=hosts,
+                result_store=Mock(),
+                credential=self.cred,
+                connection_port=connection_port,
+                forks=self.concurrency,
+                exclude_hosts=exclude_hosts,
             )
             mock_run.assert_called()
             mock_ssh_pass.assert_called()
@@ -382,13 +382,13 @@ class TestNetworkConnectTaskRunner:
         exclude_hosts = source["exclude_hosts"]
         connection_port = source["port"]
         _connect(
-            self.scan_task,
-            hosts,
-            Mock(),
-            self.cred,
-            connection_port,
-            self.concurrency,
-            exclude_hosts,
+            scan_task=self.scan_task,
+            hosts=hosts,
+            result_store=Mock(),
+            credential=self.cred,
+            connection_port=connection_port,
+            forks=self.concurrency,
+            exclude_hosts=exclude_hosts,
         )
         mock_run.assert_called()
 
@@ -402,13 +402,13 @@ class TestNetworkConnectTaskRunner:
         exclude_hosts = source["exclude_hosts"]
         connection_port = source["port"]
         _connect(
-            self.scan_task,
-            hosts,
-            Mock(),
-            self.cred,
-            connection_port,
-            self.concurrency,
-            exclude_hosts,
+            scan_task=self.scan_task,
+            hosts=hosts,
+            result_store=Mock(),
+            credential=self.cred,
+            connection_port=connection_port,
+            forks=self.concurrency,
+            exclude_hosts=exclude_hosts,
         )
         mock_run.assert_called()
 
@@ -422,13 +422,13 @@ class TestNetworkConnectTaskRunner:
         exclude_hosts = source["exclude_hosts"]
         connection_port = source["port"]
         _connect(
-            self.scan_task,
-            hosts,
-            Mock(),
-            self.cred,
-            connection_port,
-            self.concurrency,
-            exclude_hosts,
+            scan_task=self.scan_task,
+            hosts=hosts,
+            result_store=Mock(),
+            credential=self.cred,
+            connection_port=connection_port,
+            forks=self.concurrency,
+            exclude_hosts=exclude_hosts,
         )
         mock_run.assert_called()
 
@@ -611,12 +611,12 @@ class TestNetworkConnectTaskRunner:
         connection_port = source["port"]
         with pytest.raises(AnsibleRunnerException):
             _connect(
-                self.scan_task,
-                hosts,
-                Mock(),
-                self.cred,
-                connection_port,
-                self.concurrency,
+                scan_task=self.scan_task,
+                hosts=hosts,
+                result_store=Mock(),
+                credential=self.cred,
+                connection_port=connection_port,
+                forks=self.concurrency,
             )
             mock_run.assert_called()
             mock_ssh_pass.assert_called()
@@ -630,12 +630,12 @@ class TestNetworkConnectTaskRunner:
         hosts = source["hosts"]
         connection_port = source["port"]
         _connect(
-            self.scan_task,
-            hosts,
-            Mock(),
-            self.cred,
-            connection_port,
-            self.concurrency,
+            scan_task=self.scan_task,
+            hosts=hosts,
+            result_store=Mock(),
+            credential=self.cred,
+            connection_port=connection_port,
+            forks=self.concurrency,
         )
         mock_run.assert_called()
 
@@ -649,12 +649,12 @@ class TestNetworkConnectTaskRunner:
         connection_port = source["port"]
         with pytest.raises(AnsibleRunnerException):
             _connect(
-                self.scan_task,
-                hosts,
-                Mock(),
-                self.cred,
-                connection_port,
-                self.concurrency,
+                scan_task=self.scan_task,
+                hosts=hosts,
+                result_store=Mock(),
+                credential=self.cred,
+                connection_port=connection_port,
+                forks=self.concurrency,
             )
             mock_run.assert_called()
 
@@ -667,12 +667,12 @@ class TestNetworkConnectTaskRunner:
         hosts = source["hosts"]
         connection_port = source["port"]
         _connect(
-            self.scan_task,
-            hosts,
-            Mock(),
-            self.cred,
-            connection_port,
-            self.concurrency,
+            scan_task=self.scan_task,
+            hosts=hosts,
+            result_store=Mock(),
+            credential=self.cred,
+            connection_port=connection_port,
+            forks=self.concurrency,
         )
         mock_run.assert_called()
 
@@ -686,12 +686,12 @@ class TestNetworkConnectTaskRunner:
         hosts = source["hosts"]
         connection_port = source["port"]
         _connect(
-            self.scan_task,
-            hosts,
-            Mock(),
-            self.cred,
-            connection_port,
-            self.concurrency,
+            scan_task=self.scan_task,
+            hosts=hosts,
+            result_store=Mock(),
+            credential=self.cred,
+            connection_port=connection_port,
+            forks=self.concurrency,
         )
         mock_run.assert_called()
         calls = mock_run.mock_calls
@@ -709,12 +709,12 @@ class TestNetworkConnectTaskRunner:
         connection_port = source["port"]
         with pytest.raises(AnsibleRunnerException):
             _connect(
-                self.scan_task,
-                hosts,
-                Mock(),
-                self.cred,
-                connection_port,
-                self.concurrency,
+                scan_task=self.scan_task,
+                hosts=hosts,
+                result_store=Mock(),
+                credential=self.cred,
+                connection_port=connection_port,
+                forks=self.concurrency,
             )
             mock_run.assert_called()
 

--- a/quipucords/tests/scanner/network/test_network_inspect.py
+++ b/quipucords/tests/scanner/network/test_network_inspect.py
@@ -111,9 +111,9 @@ class TestNetworkInspectScanner:
         assert inventory_dict[1] == expected
 
     @pytest.fixture
-    def openssh_key(self, faker):
+    def openssh_key(self):
         """Return an openssh_key random OpenSSH private key."""
-        return generate_openssh_pkey(faker)
+        return generate_openssh_pkey()
 
     @pytest.fixture
     def cred_ssh(self, openssh_key):


### PR DESCRIPTION
Temporary SSH keyfiles were being prematurely deleted under certain conditions.

To fix the issue, the whole architecture of how temporary SSH key files were managed was modified. Now, they have a dedicated context manager that should delete them. Ansible runner MUST run nested on these dedicated contexts.

Relates to JIRA: DISCOVERY-890
Relates to JIRA: DISCOVERY-894