### PR TITLE
fix: unexpected report count inflation caused by regenerating missing cache files

### DIFF
--- a/quipucords/api/deployments_report/tasks.py
+++ b/quipucords/api/deployments_report/tasks.py
@@ -3,17 +3,49 @@
 import logging
 
 import celery
-
-from api.deployments_report.model import DeploymentsReport
-from api.deployments_report.util import create_deployments_csv
-from api.deployments_report.view import build_cached_json_report
+from django.db import transaction
 
 logger = logging.getLogger(__name__)
 
 
 @celery.shared_task()
+@transaction.atomic
+def generate_cached_fingerprints(deployments_report_id: int):
+    """Generate cached fingerprints based on saved SystemFingerprint objects."""
+    from api.deployments_report.model import DeploymentsReport, SystemFingerprint
+
+    try:
+        from api.deployments_report.serializer import SystemFingerprintSerializer
+
+        deployments_report = DeploymentsReport.objects.get(id=deployments_report_id)
+        deployments_report.cached_csv_file_path = None  # cached CSV may now be invalid
+        deployments_report.cached_fingerprints = SystemFingerprintSerializer(
+            SystemFingerprint.objects.filter(deployment_report=deployments_report),
+            many=True,
+        ).data
+        deployments_report.save()
+    except Exception as e:  # noqa: BLE001
+        # Catch all exceptions because this Celery task should exit cleanly
+        # regardless of whether it succeeds. We might arrive here if the
+        # DeploymentsReport no longer exists; maybe it was deleted between when
+        # this task was requested and when it executed asynchronously.
+        logger.exception(
+            "Failed to generate cached fingerprints for DeploymentsReport %s: %s",
+            deployments_report_id,
+            e,
+        )
+        return False
+    return True
+
+
+@celery.shared_task()
+@transaction.atomic
 def generate_and_save_cached_csv(deployments_report_id: int):
     """Generate the save cached csv data for the given deployment report ID."""
+    from api.deployments_report.model import DeploymentsReport
+    from api.deployments_report.util import create_deployments_csv
+    from api.deployments_report.view import build_cached_json_report
+
     try:
         deployments_report = DeploymentsReport.objects.get(id=deployments_report_id)
         deployments_report.cached_csv_file_path = None

--- a/quipucords/api/deployments_report/tasks.py
+++ b/quipucords/api/deployments_report/tasks.py
@@ -57,6 +57,10 @@ def generate_and_save_cached_csv(deployments_report_id: int):
         # regardless of whether it succeeds. We might arrive here if the
         # DeploymentsReport also lacks the cached fingerprints data which
         # is required for building the CSV data.
-        logger.exception(e)
+        logger.exception(
+            "Failed to generate cached fingerprints for DeploymentsReport %s: %s",
+            deployments_report_id,
+            e,
+        )
         return False
     return True

--- a/quipucords/api/deployments_report/view.py
+++ b/quipucords/api/deployments_report/view.py
@@ -53,10 +53,10 @@ def deployments(request, report_id=None):
     return Response(deployments_json)
 
 
-def build_cached_json_report(deployments_report):
+def build_cached_json_report(deployments_report: DeploymentsReport) -> dict:
     """Create a count report based on the fingerprints and the group.
 
-    :param report: the DeploymentsReport used to group count
+    :param deployments_report: the DeploymentsReport used to group count
     :returns: json report data
     :raises: Raises validation error group_count on non-existent field.
     """

--- a/quipucords/api/management/commands/regenerate_missing_report_cache_files.py
+++ b/quipucords/api/management/commands/regenerate_missing_report_cache_files.py
@@ -74,10 +74,9 @@ class Command(BaseCommand):
         """Generate cached fingerprints for the given deployments report IDs."""
         success_ids = []
         failure_ids = []
-        for _id in sorted(list(deployments_report_ids)):
-            success_ids.append(_id) if generate_cached_fingerprints(
-                _id
-            ) else failure_ids.append(_id)
+        for _id in sorted(deployments_report_ids):
+            success = generate_cached_fingerprints(_id)
+            success_ids.append(_id) if success else failure_ids.append(_id)
 
         return success_ids, failure_ids
 
@@ -85,7 +84,7 @@ class Command(BaseCommand):
         """Generate cached CSV files for the given deployments report IDs."""
         success_ids = []
         failure_ids = []
-        for _id in sorted(list(deployments_report_ids)):
+        for _id in sorted(deployments_report_ids):
             success = generate_and_save_cached_csv(_id)
             success_ids.append(_id) if success else failure_ids.append(_id)
 

--- a/quipucords/tests/api/deployments_report/test_deployments_report.py
+++ b/quipucords/tests/api/deployments_report/test_deployments_report.py
@@ -25,7 +25,6 @@ from api.deployments_report.model import (
     time as time_module,
 )
 from api.deployments_report.util import sanitize_row
-from api.scantask.model import ScanTask
 from constants import DataSources
 from tests.factories import DeploymentReportFactory
 from tests.report_utils import extract_files_from_tarball
@@ -228,7 +227,9 @@ def test_get_deployments_report_cached_csv_not_set():
 @pytest.mark.django_db
 def test_get_deployments_report_cached_files_missing(client_logged_in, faker, mocker):
     """Test getting a report with missing files responds with 424, triggers rerun."""
-    mock_rerun = mocker.patch.object(DeploymentsReport, "_rerun_latest_fingerprint")
+    mock_generate = mocker.patch(
+        "api.deployments_report.tasks.generate_cached_fingerprints"
+    )
     bogus_csv_path = str(cached_files_path() / faker.slug())
     bogus_fingerprints_path = str(cached_files_path() / faker.slug())
     deployments_report = DeploymentReportFactory(
@@ -240,7 +241,7 @@ def test_get_deployments_report_cached_files_missing(client_logged_in, faker, mo
         reverse("v1:reports-deployments", args=(deployments_report.report.id,))
     )
     assert response.status_code == status.HTTP_424_FAILED_DEPENDENCY
-    mock_rerun.assert_called_once()
+    mock_generate.delay.assert_called_once_with(deployments_report.id)
 
 
 @pytest.mark.django_db
@@ -316,7 +317,9 @@ def test_get_deployments_report_cached_csv_not_found(faker, caplog, mocker):
     """Test getting cached_csv when its path does not find a file."""
     not_found_path = f"{cached_files_path()}/{faker.slug()}.csv"
     deployments_report = DeploymentReportFactory(cached_csv_file_path=not_found_path)
-    mocker.patch.object(deployments_report, "_rerun_latest_fingerprint")
+    mock_generate = mocker.patch(
+        "api.deployments_report.tasks.generate_and_save_cached_csv"
+    )
     expected_error = (
         f"Cached CSV file for DeploymentsReport {deployments_report.id} "
         f"not found at '{not_found_path}'"
@@ -324,7 +327,7 @@ def test_get_deployments_report_cached_csv_not_found(faker, caplog, mocker):
     caplog.set_level(logging.ERROR)
     with pytest.raises(FileNotFoundError):
         unexpected_data = deployments_report.cached_csv  # noqa: F841
-    deployments_report._rerun_latest_fingerprint.assert_called_once()
+    mock_generate.delay.assert_called_once()
     assert expected_error in caplog.messages[-1]
 
 
@@ -339,7 +342,9 @@ def test_get_deployments_report_cached_fingerprints_not_found(faker, caplog, moc
         cached_fingerprints_file_path=not_found_path,
         _set_cached_fingerprints__skip=True,
     )
-    mocker.patch.object(deployments_report, "_rerun_latest_fingerprint")
+    mock_generate = mocker.patch(
+        "api.deployments_report.tasks.generate_cached_fingerprints"
+    )
     expected_error = (
         f"Cached fingerprints file for DeploymentsReport {deployments_report.id} "
         f"not found at '{not_found_path}'"
@@ -347,7 +352,7 @@ def test_get_deployments_report_cached_fingerprints_not_found(faker, caplog, moc
     caplog.set_level(logging.ERROR)
     with pytest.raises(FileNotFoundError):
         unexpected_data = deployments_report.cached_fingerprints  # noqa: F841
-    deployments_report._rerun_latest_fingerprint.assert_called_once()
+    mock_generate.delay.assert_called_once()
     assert expected_error in caplog.messages[-1]
 
 
@@ -454,60 +459,3 @@ def test_delete_deployments_report_ignores_missing_files(
 
     deployments_report_with_cached_files.delete()
     # Nothing left to assert; just be happy it raised no exceptions!
-
-
-@pytest.mark.django_db
-def test_rerun_latest_fingerprint_missing_calls_celery_task(
-    deployments_report, tmpdir, faker, mocker
-):
-    """Test calling _rerun_latest_fingerprint invokes expected Celery task."""
-    cvs_file_path = Path(tmpdir) / faker.slug()
-    cvs_file_path.write_text("hello,world")
-    fingerprints_file_path = Path(tmpdir) / faker.slug()
-    fingerprints_file_path.write_text('{"hello":"world"}')
-    mocker.patch("api.deployments_report.model.cached_files_path", return_value=tmpdir)
-    deployments_report.cached_csv_file_path = cvs_file_path
-    deployments_report.cached_fingerprints_file_path = fingerprints_file_path
-    deployments_report.save()
-
-    mock_tasks = mocker.patch("scanner.tasks")
-
-    # A fingerprint ScanTask needs to exist, and it normally would exist in a real
-    # flow of the running service, but our simplified factory does not create one.
-    deployments_report.report.scanjob._create_fingerprint_task(
-        conn_tasks=[], inspect_tasks=list(deployments_report.report.scanjob.tasks.all())
-    )
-
-    # Default call expects the Celery task to "delay" for async processing.
-    deployments_report._rerun_latest_fingerprint()
-    mock_tasks.fingerprint.delay.assert_called_once()
-
-    mock_tasks.reset_mock()
-    # Call with "wait=True" expects to get the Celery task result synchronously.
-    deployments_report._rerun_latest_fingerprint(wait=True)
-    mock_tasks.fingerprint.delay.assert_called_once()
-    mock_tasks.fingerprint.delay.return_value.get.assert_called_once()
-
-
-@pytest.mark.django_db
-def test_rerun_latest_fingerprint_missing_fingerprint_task_exception(
-    deployments_report, tmpdir, faker, mocker
-):
-    """
-    Test calling _rerun_latest_fingerprint fails if no fingerprint task.
-
-    This test covers a use case that normally should *not be possible*.
-    The "cached file path" fields on DeploymentsReport are None by default,
-    and they normally are only set as part of the fingerprint task.
-    If the fingerprint task does not exist, but the fields are not None,
-    then something very strange and unexpected has happened.
-    """
-    cvs_file_path = Path(tmpdir) / faker.slug()
-    fingerprints_file_path = Path(tmpdir) / faker.slug()
-    mocker.patch("api.deployments_report.model.cached_files_path", return_value=tmpdir)
-    deployments_report.cached_csv_file_path = cvs_file_path
-    deployments_report.cached_fingerprints_file_path = fingerprints_file_path
-    deployments_report.save()
-
-    with pytest.raises(ScanTask.DoesNotExist):
-        deployments_report._rerun_latest_fingerprint()

--- a/quipucords/tests/api/deployments_report/test_tasks.py
+++ b/quipucords/tests/api/deployments_report/test_tasks.py
@@ -1,12 +1,52 @@
 """Tests for api.deployments_report.tasks."""
 
 import logging
+from pathlib import Path
 
 import pytest
 
-from api.deployments_report.tasks import generate_and_save_cached_csv
+from api.aggregate_report.model import get_aggregate_report_by_report_id
+from api.deployments_report.tasks import (
+    generate_and_save_cached_csv,
+    generate_cached_fingerprints,
+)
+from api.reports.model import Report
 from tests.factories import DeploymentReportFactory
 from utils.misc import is_valid_cache_file
+
+
+@pytest.mark.django_db
+def test_generate_cached_fingerprints():
+    """Test generate_cached_fingerprints generates the file and updates the model."""
+    deployments_report = DeploymentReportFactory.create(number_of_fingerprints=1)
+    report = Report.objects.get(deployment_report=deployments_report)
+    assert is_valid_cache_file(deployments_report.cached_fingerprints_file_path)
+    old_cached_fingerprints = deployments_report.cached_fingerprints
+    old_aggregate_report = get_aggregate_report_by_report_id(report.id)
+    for _ in range(3):  # to verify repeated regens do not have unexpected side effects
+        Path(deployments_report.cached_fingerprints_file_path).unlink()
+        assert not is_valid_cache_file(deployments_report.cached_fingerprints_file_path)
+        assert generate_cached_fingerprints(deployments_report.id)
+        deployments_report.refresh_from_db()
+        assert deployments_report.cached_fingerprints_file_path is not None
+        assert is_valid_cache_file(deployments_report.cached_fingerprints_file_path)
+        new_cached_fingerprints = deployments_report.cached_fingerprints
+        assert new_cached_fingerprints == old_cached_fingerprints
+        new_aggregate_report = get_aggregate_report_by_report_id(report.id)
+        assert new_aggregate_report == old_aggregate_report
+
+
+@pytest.mark.django_db
+def test_generate_cached_fingerprints_failure(caplog):
+    """Test generate_cached_fingerprints logs and suppresses unexpected exceptions."""
+    caplog.set_level(logging.ERROR)
+    deployments_report = DeploymentReportFactory.create(number_of_fingerprints=1)
+    assert is_valid_cache_file(deployments_report.cached_fingerprints_file_path)
+    deployments_report_id = deployments_report.id
+    deployments_report.delete()
+    assert not generate_cached_fingerprints(deployments_report_id)
+    assert f"DeploymentsReport {deployments_report_id}" in caplog.messages[0]
+    assert "DeploymentsReport matching query does not exist." in caplog.messages[0]
 
 
 @pytest.mark.django_db
@@ -25,7 +65,7 @@ def test_generate_and_save_cached_csv_failure(mocker, caplog):
     """Test generate_and_save_cached_csv logs and suppresses unexpected exceptions."""
     caplog.set_level(logging.ERROR)
     deployments_report = DeploymentReportFactory.create(number_of_fingerprints=1)
-    mock_build = mocker.patch("api.deployments_report.tasks.build_cached_json_report")
+    mock_build = mocker.patch("api.deployments_report.view.build_cached_json_report")
     message = "Nobody expects the Spanish Inquisition!"
     mock_build.side_effect = Exception(message)
     assert not generate_and_save_cached_csv(deployments_report.id)

--- a/quipucords/tests/api/deployments_report/test_tasks.py
+++ b/quipucords/tests/api/deployments_report/test_tasks.py
@@ -69,4 +69,5 @@ def test_generate_and_save_cached_csv_failure(mocker, caplog):
     message = "Nobody expects the Spanish Inquisition!"
     mock_build.side_effect = Exception(message)
     assert not generate_and_save_cached_csv(deployments_report.id)
-    assert message in caplog.messages
+    assert f"DeploymentsReport {deployments_report.id}" in caplog.messages[0]
+    assert message in caplog.messages[0]


### PR DESCRIPTION
This change significantly simplifies the feature originally added in https://github.com/quipucords/quipucords/pull/2793 that (re)generates missing cached fingerprint files. Instead of running a whole fingerprint-type `ScanTask` as in the original implementation, now we simply look for the related `SystemFingerprint` objects and save their serialized contents. I previously just missed the fact that `SystemFingerprint` objects exist with _effectively_ the full contents of the `cached_fingerprint` field.

Quoting an explanation I [originally posted here in Slack](https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1740426777485639?thread_ts=1740411522.844759&cid=C02QSNF1UKE):

> …the idea for my manual verification so far has been:
>
> * create a new network source, scan it, and download the tarball (1)
> * delete cached files, try to download, see error, try again, download the tarball (2)
> * delete cached files, run the management command, delete cached files again, run the management command twice more, download the tarball (3)
> * compare the three exploded files
>
> Contents of 2 and 3 are identical. Their `SHA256SUM` files match.
>
> Comparing 1 and 2 (or 1 and 3), there are very slight differences, but I think they are acceptable.  Most files are truly identical (`aggregate.json`, `deployments.csv`, `details.csv`, `details.json`). However, the regenerated `deployments.json` is slightly more verbose and includes some fields with `null` values that were absent from the original version of the download. This is because the original file is written using the source data during the original fingerprinting operation that is the input to the `SystemProfile` model. When I regenerate the cached files, the original version of the data is gone, but the transformed version still lives in `SystemProfile` objects. My regenerated files use the `SystemProfileSerializer` output which is nearly identical to its input, but that serializer's output includes some optional fields that may not have been present in the original input (and thus the original "cached" data). Since they are just extra optional fields, I believe the difference is negligible. Just a few extra key-value pairs like `"virtual_host_name": null`.

Relates to JIRA: DISCOVERY-899