### PR TITLE
refactor: add codecov.yml config to override defaults

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: 70..90
+
+  status:
+    patch:
+      default:
+        target: 80%
+        threshold: 5
+    project:
+      default: false
+      quipucords:
+        target: auto
+        threshold: 5
+        paths:
+          - "quipucords/"


### PR DESCRIPTION
I _feel like_ quipucords used to have non-default codecov configs somewhere, probably in codecov's web interface, and I _suspect_ those might have just disappeared some time ago when they upgraded their system (likely when they changed token use requirements).  🤷  Regardless, we should set our own config with the repo for complete visibility.

This config basically says:

* For the diff, require 80% coverage to pass the PR check.
* For the overall project, target the previous/parent commit's recorded coverage, but allow it to dip by 5% before it fails the PR check.
* The "range" value is purely aesthetic, IIUC. Files under 70% show as red, under 90% as yellow, and over 90% as green when viewed on codecov's website.