### PR TITLE
ci(konflux): dynamically set version labels

### DIFF
--- a/.tekton/discovery-server-pull-request.yaml
+++ b/.tekton/discovery-server-pull-request.yaml
@@ -6,6 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    # custom tasks defined in this repo https://pipelinesascode.com/docs/guide/resolver/#tasks-or-pipelines-inside-the-repository
+    pipelinesascode.tekton.dev/task: '[.tekton/task/generate-version-labels.yaml]'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
@@ -187,6 +189,17 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    # ===========================================================================
+    # Custom task that generates version labels
+    - name: generate-version-labels
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      runAfter:
+        - clone-repository
+      taskRef:
+        name: generate-version-labels
+    # ===========================================================================
     - name: prefetch-dependencies
       params:
       - name: input
@@ -249,8 +262,14 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      # Customization added to allow using the version extracted from package.json
+      # as version label
+      - name: LABELS
+        value:
+          - $(tasks.generate-version-labels.results.labels[*])
       runAfter:
       - prefetch-dependencies
+      - generate-version-labels
       taskRef:
         params:
         - name: name

--- a/.tekton/discovery-server-push.yaml
+++ b/.tekton/discovery-server-push.yaml
@@ -5,6 +5,8 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/quipucords/quipucords?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    # custom tasks defined in this repo https://pipelinesascode.com/docs/guide/resolver/#tasks-or-pipelines-inside-the-repository
+    pipelinesascode.tekton.dev/task: '[.tekton/task/generate-version-labels.yaml]'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
@@ -184,6 +186,17 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    # ===========================================================================
+    # Custom task that generates version labels
+    - name: generate-version-labels
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      runAfter:
+        - clone-repository
+      taskRef:
+        name: generate-version-labels
+    # ===========================================================================
     - name: prefetch-dependencies
       params:
       - name: input
@@ -246,8 +259,14 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      # Customization added to allow using the version extracted from package.json
+      # as version label
+      - name: LABELS
+        value:
+          - $(tasks.generate-version-labels.results.labels[*])
       runAfter:
       - prefetch-dependencies
+      - generate-version-labels
       taskRef:
         params:
         - name: name

--- a/.tekton/task/generate-version-labels.yaml
+++ b/.tekton/task/generate-version-labels.yaml
@@ -1,0 +1,49 @@
+---
+# Custom task based on upstream tekton and konflux docs.
+# Given this is pipeline requires using trusted artifacts, some boilerplate is required
+# https://konflux-ci.dev/docs/advanced-how-tos/using-trusted-artifacts/#migrate-to-trusted-artifacts
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: generate-version-labels
+spec:
+  description: |
+    Custom task that generates dynamic labels based on "pyproject.toml" version. This produce the labels
+    "version" and "version_minor".
+  params:
+    - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+      name: SOURCE_ARTIFACT
+      type: string
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  volumes:
+    # New volume to store a copy of the source code accessible only to this Task.
+    - name: workdir
+      emptyDir: {}
+  results:
+    - name: labels
+      description: The rendered labels
+      type: array
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: generate-version-labels
+      image: quay.io/konflux-ci/yq:latest@sha256:85a04f04bb1b84e0ea5aedd74962e9516694a3575b47bc3f9c004dd0fc3e0fa7
+      workingDir: /var/workdir/source
+      script: |
+        echo "Extracting full version (X.Y.Z) from pyproject.toml"
+        VERSION=$(yq -r '.tool.poetry.version' pyproject.toml)
+        echo "version=${VERSION}"
+
+        echo "Computing minor version (X.Y only)"
+        VERSION_MINOR=$(yq -r '.tool.poetry.version | split(".").[:2] | join(".")' pyproject.toml)
+        echo "version_minor=${VERSION_MINOR}"
+
+        echo "Writing results..."
+        # version and version_minor are the labels expected in downstream RPA configuration
+        echo [\"version=${VERSION}\", \"version_minor=${VERSION_MINOR}\"] | tee "$(results.labels.path)"


### PR DESCRIPTION
Dynamically create "version" and "version_minor" labels based on pyproject.toml
version. These labels are expected on downstream `ReleasePlanAdmission`.

Relates to JIRA: DISCOVERY-708