### PR TITLE
build: update base image for github arm64 job

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -25,7 +25,7 @@ jobs:
   # for changing this job name, please consult the dev team first and update
   # discovery-ci accordingly.
   build-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
[last `build-arm64` run from `main`](https://github.com/quipucords/quipucords/actions/runs/13845360122): `19m 30s` 
[latest `build-arm64` run from this branch](https://github.com/quipucords/quipucords/actions/runs/13902784235/job/38898458182?pr=2856): `5m 33s`
[last `build` (`x86_64`) run from `main`](https://github.com/quipucords/quipucords/actions/runs/13845360123): `3m 18s`

So, it's not _as fast_ as the pure `x86_64` build job, but it seems much better than the CPU emulated one. Hopefully it will get faster over time as GitHub rolls out more and faster `arm64`/`aarch64` workers.