### PR TITLE
Revert "refactor: remove connect jobs and tasks from satellite scanner"

### DIFF
--- a/quipucords/api/scan/model.py
+++ b/quipucords/api/scan/model.py
@@ -28,7 +28,7 @@ class Scan(BaseModel):
     """Configuration for the scan jobs that will run."""
 
     SCAN_TYPE_CHOICES = (
-        (ScanTask.SCAN_TYPE_CONNECT, ScanTask.SCAN_TYPE_CONNECT),  # TODO Remove this.
+        (ScanTask.SCAN_TYPE_CONNECT, ScanTask.SCAN_TYPE_CONNECT),
         (ScanTask.SCAN_TYPE_INSPECT, ScanTask.SCAN_TYPE_INSPECT),
     )
 

--- a/quipucords/api/scanjob/model.py
+++ b/quipucords/api/scanjob/model.py
@@ -20,7 +20,6 @@ from api.scan.model import Scan
 from api.scanjob.queryset import ScanJobQuerySet
 from api.scantask.model import ScanTask
 from api.source.model import Source
-from constants import DataSources
 
 logger = logging.getLogger(__name__)
 
@@ -93,20 +92,6 @@ class ScanJob(BaseModel):
             self.scan.options = value
             self.scan.save()
 
-    @property
-    def no_connect_tasks(self):
-        """
-        Determine if we should use modernized code for no connect-type jobs/tasks.
-
-        This is a temporary crutch until we have refactored all source types to remove
-        their use of connect-type jobs and tasks.
-
-        TODO Remove this function once we stop using connect-type jobs/tasks.
-        """
-        if self.tasks.filter(scan_type=ScanTask.SCAN_TYPE_CONNECT).exists():
-            return False
-        return self.sources.filter(source_type__in=[DataSources.SATELLITE]).exists()
-
     def get_extra_vars(self):
         """Return the extra vars from the related Scan."""
         if self.scan:
@@ -169,7 +154,6 @@ class ScanJob(BaseModel):
             connection_systems_unreachable,
         ) = self._calculate_counts(ScanTask.SCAN_TYPE_CONNECT)
         if self.scan_type == ScanTask.SCAN_TYPE_CONNECT or connect_only:
-            # TODO Remove SCAN_TYPE_CONNECT logic.
             systems_count = connection_systems_count
             systems_scanned = connection_systems_scanned
             systems_failed = connection_systems_failed
@@ -297,10 +281,7 @@ class ScanJob(BaseModel):
         self.log_current_status()
 
     def _create_pending_tasks(self):
-        # TODO Remove conn_tasks.
-        conn_tasks = (
-            self._create_connection_tasks() if not self.no_connect_tasks else []
-        )
+        conn_tasks = self._create_connection_tasks()
         inspect_tasks = self._create_inspection_tasks(conn_tasks)
         self._create_fingerprint_task(conn_tasks, inspect_tasks)
 
@@ -323,9 +304,6 @@ class ScanJob(BaseModel):
 
         :return: list of connection_tasks
         """
-        # TODO Remove this function when we stop using connection tasks.
-        if self.no_connect_tasks:
-            raise Exception("This should never happen.")
         conn_tasks = []
         if self.scan_type in [ScanTask.SCAN_TYPE_CONNECT, ScanTask.SCAN_TYPE_INSPECT]:
             count = 1
@@ -362,31 +340,7 @@ class ScanJob(BaseModel):
         :return: list of inspection_tasks
         """
         inspect_tasks = []
-        if (
-            not conn_tasks
-            and self.no_connect_tasks
-            and self.scan_type == ScanTask.SCAN_TYPE_INSPECT
-        ):
-            # Eventually all logic in this function routes here.
-            # The complex condition is temporary while we migrate
-            # all the different source types.
-            for index, source in enumerate(self.sources.all(), start=1):
-                inspect_task = ScanTask.objects.create(
-                    job=self,
-                    source=source,
-                    scan_type=ScanTask.SCAN_TYPE_INSPECT,
-                    status=ScanTask.PENDING,
-                    status_message=_(messages.ST_STATUS_MSG_PENDING),
-                    sequence_number=index,
-                    connection_result=TaskConnectionResult.objects.create(
-                        job_connection_result=self.connection_results
-                    ),
-                )
-
-                self.tasks.add(inspect_task)
-                inspect_tasks.append(inspect_task)
-        elif conn_tasks and self.scan_type == ScanTask.SCAN_TYPE_INSPECT:
-            # TODO Remove this.
+        if conn_tasks and self.scan_type == ScanTask.SCAN_TYPE_INSPECT:
             count = len(conn_tasks) + 1
             for conn_task in conn_tasks:
                 # Create inspect tasks

--- a/quipucords/api/scantask/model.py
+++ b/quipucords/api/scantask/model.py
@@ -23,11 +23,11 @@ logger = logging.getLogger(__name__)
 class ScanTask(BaseModel):
     """The scan task captures a single source for a scan."""
 
-    SCAN_TYPE_CONNECT = "connect"  # TODO Remove SCAN_TYPE_CONNECT.
+    SCAN_TYPE_CONNECT = "connect"
     SCAN_TYPE_INSPECT = "inspect"
     SCAN_TYPE_FINGERPRINT = "fingerprint"
     SCANTASK_TYPE_CHOICES = (
-        (SCAN_TYPE_CONNECT, SCAN_TYPE_CONNECT),  # TODO Remove SCAN_TYPE_CONNECT choice.
+        (SCAN_TYPE_CONNECT, SCAN_TYPE_CONNECT),
         (SCAN_TYPE_INSPECT, SCAN_TYPE_INSPECT),
         (SCAN_TYPE_FINGERPRINT, SCAN_TYPE_FINGERPRINT),
     )
@@ -455,7 +455,6 @@ class ScanTask(BaseModel):
                 inspect_group__in=self.inspect_groups.all()
             ).all()
         elif self.scan_type == ScanTask.SCAN_TYPE_CONNECT:
-            # TODO Remove SCAN_TYPE_CONNECT logic.
             return self.connection_result
         elif self.scan_type == ScanTask.SCAN_TYPE_FINGERPRINT:
             return self.job.report

--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -63,14 +63,12 @@ def create_report_for_scan_job(scan_job: ScanJob):
     :returns: tuple[Report,str] with the created Report (if successful)
         and error string (if not successful)
     """
-    if not scan_job.no_connect_tasks:
-        # TODO Remove this when we have removed all connect scan jobs/tasks.
-        conn_query = ScanTask.objects.filter(
-            job=scan_job, scan_type=ScanTask.SCAN_TYPE_CONNECT
-        ).aggregate(successful_connections=Sum("systems_scanned"))
+    conn_query = ScanTask.objects.filter(
+        job=scan_job, scan_type=ScanTask.SCAN_TYPE_CONNECT
+    ).aggregate(successful_connections=Sum("systems_scanned"))
 
-        if not conn_query["successful_connections"]:
-            return None, "No connection results found."
+    if not conn_query["successful_connections"]:
+        return None, "No connection results found."
 
     inspect_query = ScanTask.objects.filter(
         job=scan_job, scan_type=ScanTask.SCAN_TYPE_INSPECT

--- a/quipucords/scanner/satellite/connect.py
+++ b/quipucords/scanner/satellite/connect.py
@@ -1,29 +1,16 @@
 """ScanTask used for satellite connection task."""
-# TODO Remove this module.
 
-import warnings
-
-from api.scantask.model import ScanTask
 from scanner.satellite.runner import SatelliteTaskRunner
 
 
 class ConnectTaskRunner(SatelliteTaskRunner):
+    """ConnectTaskRunner satellite connection capabilities.
+
+    Attempts connections to a source using a credential
+    and gathers the set of available systems.
     """
-    ConnectTaskRunner legacy interface does nothing for Satellite sources.
-
-    TODO Remove this class when all source types stop using connect tasks.
-    """
-
-    def execute_task(self):
-        """Scan Satellite for system connection data."""
-        warnings.warn(
-            "ConnectTaskRunner.execute_task does nothing.", DeprecationWarning
-        )
-
-        return None, ScanTask.COMPLETED
 
     def handle_api_calls(self, api):
         """Handle api calls for connetion phase."""
-        warnings.warn(
-            "ConnectTaskRunner.handle_api_calls does nothing.", DeprecationWarning
-        )
+        api.host_count()
+        api.hosts()

--- a/quipucords/scanner/satellite/inspect.py
+++ b/quipucords/scanner/satellite/inspect.py
@@ -2,6 +2,7 @@
 
 from requests import exceptions
 
+from api.models import ScanTask
 from scanner.satellite.api import SatelliteAuthError, SatelliteError
 from scanner.satellite.runner import SatelliteTaskRunner
 
@@ -20,8 +21,16 @@ class InspectTaskRunner(SatelliteTaskRunner):
         TimeoutError,
     )
 
+    def execute_task(self):
+        """Scan satellite manager and obtain host facts."""
+        conn_task = self.scan_task.prerequisites.first()
+        if conn_task.status != ScanTask.COMPLETED:
+            error_message = (
+                f"Prerequisites scan task {conn_task.sequence_number} failed."
+            )
+            return error_message, ScanTask.FAILED
+        return super().execute_task()
+
     def handle_api_calls(self, api):
         """Handle api calls for inspection phase."""
-        api.host_count()
-        api.hosts()
         api.hosts_facts()

--- a/quipucords/scanner/satellite/six.py
+++ b/quipucords/scanner/satellite/six.py
@@ -466,7 +466,7 @@ class SatelliteSix(SatelliteInterface, metaclass=ABCMeta):
     def _request_and_record_hosts(self, credential, org_id=None):
         """Request and record hosts for the given credential and optional org filter."""
         hosts = []
-        for result in request_results(self.inspect_scan_task, self.HOSTS_URL, org_id):
+        for result in request_results(self.connect_scan_task, self.HOSTS_URL, org_id):
             host_name = result.get(NAME)
             host_id = result.get(ID)
 
@@ -482,10 +482,9 @@ class SatelliteSix(SatelliteInterface, metaclass=ABCMeta):
 
     def hosts_facts(self):
         """Obtain the managed hosts detail raw facts."""
-        systems_count = len(self.inspect_scan_task.connection_result.systems.all())
+        systems_count = len(self.connect_scan_task.connection_result.systems.all())
         if self.inspect_scan_task is None:
             raise SatelliteError("hosts_facts cannot be called for a connection scan")
-        self.inspect_scan_task.reset_stats()
         self.inspect_scan_task.update_stats(
             "INITIAL SATELLITE STATS", sys_count=systems_count
         )
@@ -529,7 +528,7 @@ class SatelliteSixV1(SatelliteSix):
 
         self.orgs = [
             result.get(ID)
-            for result in request_results(self.inspect_scan_task, ORGS_V1_URL)
+            for result in request_results(self.connect_scan_task, ORGS_V1_URL)
             if result.get(ID) is not None
         ]
         return self.orgs
@@ -541,7 +540,7 @@ class SatelliteSixV1(SatelliteSix):
         for org_id in orgs:
             params = {PAGE: 1, PER_PAGE: 100, THIN: 1}
             response, url = utils.execute_request(
-                self.inspect_scan_task,
+                self.connect_scan_task,
                 url=HOSTS_V1_URL,
                 org_id=org_id,
                 query_params=params,
@@ -551,14 +550,14 @@ class SatelliteSixV1(SatelliteSix):
                     f"Invalid response code {response.status_code} for url: {url}"
                 )
             systems_count += response.json().get("total", 0)
-            self.inspect_scan_task.update_stats(
+            self.connect_scan_task.update_stats(
                 "INITIAL SATELLITE STATS", sys_count=systems_count
             )
             return systems_count
 
     def hosts(self):
         """Obtain the managed hosts."""
-        credential = utils.get_credential(self.inspect_scan_task)
+        credential = utils.get_credential(self.connect_scan_task)
 
         hosts = list(
             itertools.chain.from_iterable(
@@ -591,21 +590,21 @@ class SatelliteSixV2(SatelliteSix):
         """Obtain the count of managed hosts."""
         params = {PAGE: 1, PER_PAGE: 10, THIN: 1}
         response, url = utils.execute_request(
-            self.inspect_scan_task, url=HOSTS_V2_URL, query_params=params
+            self.connect_scan_task, url=HOSTS_V2_URL, query_params=params
         )
         if response.status_code != requests.codes.ok:
             raise SatelliteError(
                 f"Invalid response code {response.status_code} for url: {url}"
             )
         systems_count = response.json().get("total", 0)
-        self.inspect_scan_task.update_stats(
+        self.connect_scan_task.update_stats(
             "INITIAL SATELLITE STATS", sys_count=systems_count
         )
         return systems_count
 
     def hosts(self):
         """Obtain the managed hosts."""
-        credential = utils.get_credential(self.inspect_scan_task)
+        credential = utils.get_credential(self.connect_scan_task)
         return self._request_and_record_hosts(credential)
 
     def _requests_hosts_unique(self):

--- a/quipucords/tests/factories.py
+++ b/quipucords/tests/factories.py
@@ -50,17 +50,6 @@ def system_fingerprint_source_types():
     return all_types - ignored_types
 
 
-def source_types_with_legacy_connect_scan_job():
-    """
-    Return source types that still have the legacy connect scan job.
-
-    TODO Remove this when we have removed all connect scan jobs.
-    """
-    all_types = set(DataSources.values)
-    ignored_types = {DataSources.SATELLITE}
-    return all_types - ignored_types
-
-
 class SystemFingerprintFactory(DjangoModelFactory):
     """SystemFingerprint factory."""
 
@@ -354,7 +343,7 @@ class CredentialFactory(DjangoModelFactory):
     """Factory for Credential model."""
 
     name = factory.Faker("slug")
-    cred_type = factory.Iterator(source_types_with_legacy_connect_scan_job())
+    cred_type = factory.Iterator(DataSources.values)
 
     class Meta:
         """Factory options."""
@@ -386,7 +375,7 @@ class SourceFactory(DjangoModelFactory):
     """Factory for Source model."""
 
     name = factory.Faker("slug")
-    source_type = factory.Iterator(source_types_with_legacy_connect_scan_job())
+    source_type = factory.Iterator(DataSources.values)
 
     class Meta:
         """Factory options."""

--- a/quipucords/tests/scanner/satellite/test_sat_connect.py
+++ b/quipucords/tests/scanner/satellite/test_sat_connect.py
@@ -1,0 +1,166 @@
+"""Test the satellite connect task."""
+
+from unittest.mock import ANY, patch
+
+import pytest
+from requests import exceptions
+
+from api.models import Credential, ScanTask, Source
+from constants import DataSources
+from scanner.satellite.api import (
+    SATELLITE_VERSION_6,
+    SatelliteAuthError,
+    SatelliteError,
+)
+from scanner.satellite.connect import ConnectTaskRunner
+from scanner.satellite.six import SatelliteSixV2
+from tests.scanner.test_util import create_scan_job
+
+
+def mock_conn_exception(param1):
+    """Mock method to throw connection error."""
+    raise exceptions.ConnectionError()
+
+
+def mock_sat_auth_exception(param1):
+    """Mock method to throw satellite auth error."""
+    raise SatelliteAuthError()
+
+
+def mock_timeout_error(param1):
+    """Mock method to throw timeout error."""
+    raise TimeoutError()
+
+
+class TestConnectTaskRunner:
+    """Tests Satellite connect capabilities."""
+
+    def setup_method(self, _test_method):
+        """Create test case setup."""
+        self.cred = Credential(
+            name="cred1",
+            cred_type=DataSources.SATELLITE,
+            username="username",
+            password="password",
+            become_password=None,
+            become_method=None,
+            become_user=None,
+            ssh_keyfile=None,
+        )
+        self.cred.save()
+
+        self.source = Source(name="source1", port=443, hosts=["1.2.3.4"])
+        self.source.save()
+        self.source.credentials.add(self.cred)
+
+        self.scan_job, self.scan_task = create_scan_job(
+            self.source, ScanTask.SCAN_TYPE_CONNECT
+        )
+
+    @pytest.mark.django_db
+    def test_run_unknown_sat(self):
+        """Test the running connect task for unknown sat version."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status", return_value=(None, None, None)
+        ) as mock_sat_status:
+            status = task.run()
+            mock_sat_status.assert_called_once_with(ANY)
+            assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
+    def test_run_sat6_bad_status(self):
+        """Test the running connect task for Sat 6 with bad status."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status",
+            return_value=(401, None, SATELLITE_VERSION_6),
+        ) as mock_sat_status:
+            status = task.run()
+            mock_sat_status.assert_called_once_with(ANY)
+            assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
+    def test_run_sat6_bad_api_version(self):
+        """Test the running connect task for Sat6 with bad api version."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status",
+            return_value=(200, 3, SATELLITE_VERSION_6),
+        ) as mock_sat_status:
+            status = task.run()
+            mock_sat_status.assert_called_once_with(ANY)
+            assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
+    def test_run_with_conn_err(self):
+        """Test the running connect task with connection error."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status", side_effect=mock_conn_exception
+        ) as mock_sat_status:
+            status = task.run()
+            mock_sat_status.assert_called_once_with(ANY)
+            assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
+    def test_run_with_sat_err(self):
+        """Test the running connect task with satellite error."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status", side_effect=SatelliteError()
+        ) as mock_sat_status:
+            status = task.run()
+            mock_sat_status.assert_called_once_with(ANY)
+            assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
+    def test_run_with_auth_err(self):
+        """Test the running connect task with satellite auth error."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status",
+            side_effect=mock_sat_auth_exception,
+        ) as mock_sat_status:
+            status = task.run()
+            mock_sat_status.assert_called_once_with(ANY)
+            assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
+    def test_run_with_timeout_err(self):
+        """Test the running connect task with timeout error."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status", side_effect=mock_timeout_error
+        ) as mock_sat_status:
+            status = task.run()
+            mock_sat_status.assert_called_once_with(ANY)
+            assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
+    def test_run_sat6_v2(self):
+        """Test the running connect task for Sat6 with api version 2."""
+        task = ConnectTaskRunner(self.scan_job, self.scan_task)
+
+        with patch(
+            "scanner.satellite.runner.utils.status",
+            return_value=(200, 2, SATELLITE_VERSION_6),
+        ) as mock_sat_status:
+            with patch.object(
+                SatelliteSixV2, "host_count", return_value=1
+            ) as mock_host_count:
+                with patch.object(
+                    SatelliteSixV2, "hosts", return_value=["sys1"]
+                ) as mock_hosts:
+                    status = task.run()
+                    mock_sat_status.assert_called_once_with(ANY)
+                    mock_host_count.assert_called_once_with()
+                    mock_hosts.assert_called_once_with()
+                    assert status[1] == ScanTask.COMPLETED

--- a/quipucords/tests/scanner/satellite/test_sat_inspect.py
+++ b/quipucords/tests/scanner/satellite/test_sat_inspect.py
@@ -65,6 +65,18 @@ class TestInspectTaskRunner:
         return scan_job, inspect_task
 
     @pytest.mark.django_db
+    def test_run_failed_prereq(self):
+        """Test the running connect task with no source options."""
+        scan_job, inspect_task = self.create_scan_job()
+        connect_task = inspect_task.prerequisites.first()
+        connect_task.status = ScanTask.FAILED
+        connect_task.save()
+        task = InspectTaskRunner(scan_job, inspect_task)
+        status = task.run()
+
+        assert status[1] == ScanTask.FAILED
+
+    @pytest.mark.django_db
     def test_run_unknown_sat(self):
         """Test running the inspect scan for unknown sat."""
         scan_job, inspect_task = self.create_scan_job()
@@ -177,18 +189,12 @@ class TestInspectTaskRunner:
         scan_job, inspect_task = self.create_scan_job()
         task = InspectTaskRunner(scan_job, inspect_task)
 
-        with (
-            patch(
-                "scanner.satellite.runner.utils.status",
-                return_value=(200, 2, SATELLITE_VERSION_6),
-            ) as mock_sat_status,
-            patch.object(SatelliteSixV2, "host_count") as mock_host_count,
-            patch.object(SatelliteSixV2, "hosts") as mock_hosts,
-            patch.object(SatelliteSixV2, "hosts_facts") as mock_facts,
-        ):
-            status = task.run()
-            mock_sat_status.assert_called_once_with(ANY)
-            mock_host_count.assert_called_once_with()
-            mock_hosts.assert_called_once_with()
-            mock_facts.assert_called_once_with()
-            assert status[1] == ScanTask.COMPLETED
+        with patch(
+            "scanner.satellite.runner.utils.status",
+            return_value=(200, 2, SATELLITE_VERSION_6),
+        ) as mock_sat_status:
+            with patch.object(SatelliteSixV2, "hosts_facts") as mock_facts:
+                status = task.run()
+                mock_sat_status.assert_called_once_with(ANY)
+                mock_facts.assert_called_once_with()
+                assert status[1] == ScanTask.COMPLETED

--- a/quipucords/tests/scanner/satellite/test_sat_six.py
+++ b/quipucords/tests/scanner/satellite/test_sat_six.py
@@ -63,10 +63,10 @@ class TestSatelliteSixV1:
         job_conn_result.save()
         connection_results = TaskConnectionResult(job_connection_result=job_conn_result)
         connection_results.save()
-        self.api.inspect_scan_task.connection_result = connection_results
-        self.api.inspect_scan_task.connection_result.save()
+        self.api.connect_scan_task.connection_result = connection_results
+        self.api.connect_scan_task.connection_result.save()
 
-        conn_result = self.api.inspect_scan_task.connection_result
+        conn_result = self.api.connect_scan_task.connection_result
         sys_result = SystemConnectionResult(
             name="sys1",
             status=InspectResult.SUCCESS,
@@ -85,7 +85,7 @@ class TestSatelliteSixV1:
             task_connection_result=conn_result,
         )
         sys_result.save()
-        self.api.inspect_scan_task.save()
+        self.api.connect_scan_task.save()
 
     @pytest.mark.django_db
     def test_get_orgs(self):
@@ -584,17 +584,17 @@ class TestSatelliteSixV2:
         job_conn_result.save()
         connection_results = TaskConnectionResult(job_connection_result=job_conn_result)
         connection_results.save()
-        self.api.inspect_scan_task.connection_result = connection_results
-        self.api.inspect_scan_task.connection_result.save()
+        self.api.connect_scan_task.connection_result = connection_results
+        self.api.connect_scan_task.connection_result.save()
 
-        conn_result = self.api.inspect_scan_task.connection_result
+        conn_result = self.api.connect_scan_task.connection_result
         sys_result = SystemConnectionResult(
             name="sys1_1",
             status=InspectResult.SUCCESS,
             task_connection_result=conn_result,
         )
         sys_result.save()
-        self.api.inspect_scan_task.save()
+        self.api.connect_scan_task.save()
 
     @pytest.mark.django_db
     def test_host_count(self):
@@ -1069,16 +1069,16 @@ class TestSatelliteSixV2:
         job_conn_result.save()
         connection_results = TaskConnectionResult(job_connection_result=job_conn_result)
         connection_results.save()
-        api.inspect_scan_task.connection_result = connection_results
-        api.inspect_scan_task.connection_result.save()
+        api.connect_scan_task.connection_result = connection_results
+        api.connect_scan_task.connection_result.save()
 
         sys_result = SystemConnectionResult(
             name="sys1_1",
             status=InspectResult.SUCCESS,
-            task_connection_result=api.inspect_scan_task.connection_result,
+            task_connection_result=api.connect_scan_task.connection_result,
         )
         sys_result.save()
-        api.inspect_scan_task.save()
+        api.connect_scan_task.save()
         hosts_url = "https://{sat_host}:{port}/api/v2/hosts"
 
         _request_host_details = [


### PR DESCRIPTION
This reverts commit b4999fde72c35b1d0712b529d2f6b92ac0ff12bf.

Unfortunately, that commit breaks the ability for a scan to contain multiple types of sources if one of those types is a Satellite source.

Relates to JIRA: DISCOVERY-784