### PR TITLE
fix: restore connect task for satellite to fix broken multi-type scans

### DIFF
--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -63,15 +63,6 @@ def create_report_for_scan_job(scan_job: ScanJob):
     :returns: tuple[Report,str] with the created Report (if successful)
         and error string (if not successful)
     """
-    if not scan_job.no_connect_tasks:
-        # TODO Remove this when we have removed all connect scan jobs/tasks.
-        conn_query = ScanTask.objects.filter(
-            job=scan_job, scan_type=ScanTask.SCAN_TYPE_CONNECT
-        ).aggregate(successful_connections=Sum("systems_scanned"))
-
-        if not conn_query["successful_connections"]:
-            return None, "No connection results found."
-
     inspect_query = ScanTask.objects.filter(
         job=scan_job, scan_type=ScanTask.SCAN_TYPE_INSPECT
     ).aggregate(successful_connections=Sum("systems_scanned"))

--- a/quipucords/scanner/satellite/api.py
+++ b/quipucords/scanner/satellite/api.py
@@ -43,6 +43,9 @@ class SatelliteInterface(ABC):
         else:
             self.max_concurrency = scan_job.options.get(Scan.MAX_CONCURRENCY)
 
+        # Next line assumes scan_task has type 'inspect'.
+        # TODO Delete next line when we stop using connect scan tasks.
+        self.connect_scan_task = scan_task.prerequisites.first()
         self.inspect_scan_task = scan_task
         self.source = scan_task.source
 
@@ -58,11 +61,11 @@ class SatelliteInterface(ABC):
             source=self.source,
             credential=credential,
             status=SystemConnectionResult.SUCCESS,
-            task_connection_result=self.inspect_scan_task.connection_result,
+            task_connection_result=self.connect_scan_task.connection_result,
         )
         sys_result.save()
 
-        self.inspect_scan_task.increment_stats(name, increment_sys_scanned=True)
+        self.connect_scan_task.increment_stats(name, increment_sys_scanned=True)
 
     @cached_property
     def _inspect_group(self):

--- a/quipucords/scanner/satellite/six.py
+++ b/quipucords/scanner/satellite/six.py
@@ -466,7 +466,7 @@ class SatelliteSix(SatelliteInterface, metaclass=ABCMeta):
     def _request_and_record_hosts(self, credential, org_id=None):
         """Request and record hosts for the given credential and optional org filter."""
         hosts = []
-        for result in request_results(self.inspect_scan_task, self.HOSTS_URL, org_id):
+        for result in request_results(self.connect_scan_task, self.HOSTS_URL, org_id):
             host_name = result.get(NAME)
             host_id = result.get(ID)
 
@@ -482,7 +482,7 @@ class SatelliteSix(SatelliteInterface, metaclass=ABCMeta):
 
     def hosts_facts(self):
         """Obtain the managed hosts detail raw facts."""
-        systems_count = len(self.inspect_scan_task.connection_result.systems.all())
+        systems_count = len(self.connect_scan_task.connection_result.systems.all())
         if self.inspect_scan_task is None:
             raise SatelliteError("hosts_facts cannot be called for a connection scan")
         self.inspect_scan_task.reset_stats()
@@ -529,7 +529,7 @@ class SatelliteSixV1(SatelliteSix):
 
         self.orgs = [
             result.get(ID)
-            for result in request_results(self.inspect_scan_task, ORGS_V1_URL)
+            for result in request_results(self.connect_scan_task, ORGS_V1_URL)
             if result.get(ID) is not None
         ]
         return self.orgs
@@ -551,14 +551,14 @@ class SatelliteSixV1(SatelliteSix):
                     f"Invalid response code {response.status_code} for url: {url}"
                 )
             systems_count += response.json().get("total", 0)
-            self.inspect_scan_task.update_stats(
+            self.connect_scan_task.update_stats(
                 "INITIAL SATELLITE STATS", sys_count=systems_count
             )
             return systems_count
 
     def hosts(self):
         """Obtain the managed hosts."""
-        credential = utils.get_credential(self.inspect_scan_task)
+        credential = utils.get_credential(self.connect_scan_task)
 
         hosts = list(
             itertools.chain.from_iterable(
@@ -591,21 +591,21 @@ class SatelliteSixV2(SatelliteSix):
         """Obtain the count of managed hosts."""
         params = {PAGE: 1, PER_PAGE: 10, THIN: 1}
         response, url = utils.execute_request(
-            self.inspect_scan_task, url=HOSTS_V2_URL, query_params=params
+            self.connect_scan_task, url=HOSTS_V2_URL, query_params=params
         )
         if response.status_code != requests.codes.ok:
             raise SatelliteError(
                 f"Invalid response code {response.status_code} for url: {url}"
             )
         systems_count = response.json().get("total", 0)
-        self.inspect_scan_task.update_stats(
+        self.connect_scan_task.update_stats(
             "INITIAL SATELLITE STATS", sys_count=systems_count
         )
         return systems_count
 
     def hosts(self):
         """Obtain the managed hosts."""
-        credential = utils.get_credential(self.inspect_scan_task)
+        credential = utils.get_credential(self.connect_scan_task)
         return self._request_and_record_hosts(credential)
 
     def _requests_hosts_unique(self):

--- a/quipucords/tests/scanner/satellite/test_sat_six.py
+++ b/quipucords/tests/scanner/satellite/test_sat_six.py
@@ -63,10 +63,10 @@ class TestSatelliteSixV1:
         job_conn_result.save()
         connection_results = TaskConnectionResult(job_connection_result=job_conn_result)
         connection_results.save()
-        self.api.inspect_scan_task.connection_result = connection_results
-        self.api.inspect_scan_task.connection_result.save()
+        self.api.connect_scan_task.connection_result = connection_results
+        self.api.connect_scan_task.connection_result.save()
 
-        conn_result = self.api.inspect_scan_task.connection_result
+        conn_result = self.api.connect_scan_task.connection_result
         sys_result = SystemConnectionResult(
             name="sys1",
             status=InspectResult.SUCCESS,
@@ -85,7 +85,7 @@ class TestSatelliteSixV1:
             task_connection_result=conn_result,
         )
         sys_result.save()
-        self.api.inspect_scan_task.save()
+        self.api.connect_scan_task.save()
 
     @pytest.mark.django_db
     def test_get_orgs(self):
@@ -584,17 +584,17 @@ class TestSatelliteSixV2:
         job_conn_result.save()
         connection_results = TaskConnectionResult(job_connection_result=job_conn_result)
         connection_results.save()
-        self.api.inspect_scan_task.connection_result = connection_results
-        self.api.inspect_scan_task.connection_result.save()
+        self.api.connect_scan_task.connection_result = connection_results
+        self.api.connect_scan_task.connection_result.save()
 
-        conn_result = self.api.inspect_scan_task.connection_result
+        conn_result = self.api.connect_scan_task.connection_result
         sys_result = SystemConnectionResult(
             name="sys1_1",
             status=InspectResult.SUCCESS,
             task_connection_result=conn_result,
         )
         sys_result.save()
-        self.api.inspect_scan_task.save()
+        self.api.connect_scan_task.save()
 
     @pytest.mark.django_db
     def test_host_count(self):
@@ -1069,16 +1069,16 @@ class TestSatelliteSixV2:
         job_conn_result.save()
         connection_results = TaskConnectionResult(job_connection_result=job_conn_result)
         connection_results.save()
-        api.inspect_scan_task.connection_result = connection_results
-        api.inspect_scan_task.connection_result.save()
+        api.connect_scan_task.connection_result = connection_results
+        api.connect_scan_task.connection_result.save()
 
         sys_result = SystemConnectionResult(
             name="sys1_1",
             status=InspectResult.SUCCESS,
-            task_connection_result=api.inspect_scan_task.connection_result,
+            task_connection_result=api.connect_scan_task.connection_result,
         )
         sys_result.save()
-        api.inspect_scan_task.save()
+        api.connect_scan_task.save()
         hosts_url = "https://{sat_host}:{port}/api/v2/hosts"
 
         _request_host_details = [


### PR DESCRIPTION
Before this change, standalone scans for each type (Satellite, network, etc.) all worked fine in isolation. However, if you created a scan with multiple types of sources, and one of those types included Satellite which recently stopped using connect scan tasks, the overall scan would fail because the task models had an inconsistent API across different source types. That problem was introduced in b4999fde72c35b1d0712b529d2f6b92ac0ff12bf via <https://github.com/quipucords/quipucords/pull/2845>.

This change restores the use of connect scan tasks for Satellite to preserve the old internal interface as still used by other source types. The restored use of the connect scan task is only superficial, though, and all "connect" logic for Satellite has still been moved out of its old connect task runner and into its inspect task runner. After we have performed similar refactoring work to the other source types, we should be able to fully remove the connect type scan task from *all* of the different source type task runners.

Relates to JIRA: DISCOVERY-784