### PR TITLE
feat: Allow listing scanjobs by related report id

### DIFF
--- a/quipucords/api/scanjob/view.py
+++ b/quipucords/api/scanjob/view.py
@@ -86,6 +86,7 @@ class ScanJobFilterV2(FilterSet):
             "status": ["exact"],
             "scan_type": ["exact"],
             "scan_id": ["exact", "isnull"],
+            "report_id": ["exact"],
         }
 
 


### PR DESCRIPTION
This will aid qpc to decide if insights report should be downloaded.

The report itself does not know what sources were used to create it, and qpc users can run `qpc report insights --report ID` to download report directly. If we want to tell user that maybe insights report does not exist for this particular report, then we need to obtain scan / scanjob that was used to create a report. And without this patch there's no easy way to get scan / scanjob data if you only have report id.

With that patch, you can filter scanjobs by related report id.

Relates to JIRA: DISCOVERY-791