### PR TITLE
PoC: Opt out from automatic fingerprinting on scans + v2 reports

### DIFF
--- a/quipucords/api/merge_report/view.py
+++ b/quipucords/api/merge_report/view.py
@@ -28,7 +28,7 @@ def async_merge_reports(request):
             scan_type=ScanTask.SCAN_TYPE_FINGERPRINT,
             report=Report.objects.create(),
         )
-        merge_job.copy_raw_facts_from_reports(report_ids)
+        merge_job.copy_raw_facts(from_reports=report_ids)
     start_scan.send(sender=__name__, instance=merge_job)
     serializer = SimpleScanJobSerializer(merge_job)
     return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/quipucords/api/reports/model.py
+++ b/quipucords/api/reports/model.py
@@ -26,6 +26,11 @@ class Report(BaseModel):
     )
     cached_csv = models.TextField(null=True)
 
+    class Meta:
+        indexes = [
+            models.Index(fields=["report_platform_id"], name="report_platform_id_idx"),
+        ]
+
     @cached_property
     def sources(self):
         """

--- a/quipucords/api/reports/serializer_v1.py
+++ b/quipucords/api/reports/serializer_v1.py
@@ -1,0 +1,71 @@
+"""Serializers for reports."""
+
+import re
+
+from django.db import transaction
+from rest_framework.serializers import (
+    CharField,
+    ChoiceField,
+    DictField,
+    ListField,
+    Serializer,
+    UUIDField,
+    ValidationError,
+)
+
+from api.models import (
+    Report,
+    ScanJob,
+    ScanTask,
+)
+from constants import MINIMUM_REPORT_VERSION, DataSources
+
+
+class SourceSerializer(Serializer):
+    """Serializer for 'details report' sources."""
+
+    server_id = UUIDField()
+    report_version = CharField()
+    source_name = CharField()
+    source_type = ChoiceField(choices=DataSources.choices)
+    facts = ListField(child=DictField(), min_length=1)
+
+    def validate_report_version(self, value):
+        """Validate report version."""
+        regex_match = re.match(r"(\d+)\.(\d+)\.(\d+)\+\S", value)
+        if not regex_match:
+            raise ValidationError("Invalid report_version.")
+        source_version = tuple(map(int, regex_match.groups()))
+        if source_version < MINIMUM_REPORT_VERSION:
+            source_version_str = ".".join(map(str, source_version))
+            minimum_version_str = ".".join(map(str, MINIMUM_REPORT_VERSION))
+            raise ValidationError(
+                f"Source version ({source_version_str}) is below the minimum "
+                f"supported report version ({minimum_version_str})"
+            )
+        return value
+
+
+class ReportUploadSerializer(Serializer):
+    """Serializer for uploaded details reports."""
+
+    report_type = ChoiceField(choices=["details"])
+    sources = SourceSerializer(many=True)
+
+    def validate_sources(self, value):
+        """Validate sources."""
+        if len(value) == 0:
+            raise ValidationError("minimum length required for 'sources' is 1.")
+        return value
+
+    @transaction.atomic
+    def create(self, validated_data):
+        """Create a report filled with raw data and a fingerprint-type ScanJob."""
+        report = Report.objects.create()
+        # create a scan job and required scan tasks for a "upload" job
+        scan_job = ScanJob.objects.create(
+            scan_type=ScanTask.SCAN_TYPE_FINGERPRINT,
+            report=report,
+        )
+        scan_job.ingest_sources(validated_data["sources"])
+        return report

--- a/quipucords/api/reports/view_v1.py
+++ b/quipucords/api/reports/view_v1.py
@@ -1,0 +1,68 @@
+"""View for reports."""
+
+import logging
+
+from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext as _
+from rest_framework import status
+from rest_framework.decorators import api_view, renderer_classes
+from rest_framework.response import Response
+
+from api.aggregate_report.model import get_aggregate_report_by_report_id
+from api.deployments_report.view import build_cached_json_report
+from api.models import DeploymentsReport, Report
+from api.reports.reports_gzip_renderer import ReportsGzipRenderer
+from api.serializers import (
+    DetailsReportSerializer,
+    ReportUploadSerializer,
+    SimpleScanJobSerializer,
+)
+from api.signal.scanjob_signal import start_scan
+
+logger = logging.getLogger(__name__)
+
+
+@api_view(["GET"])
+@renderer_classes((ReportsGzipRenderer,))
+def reports(request, report_id):
+    """Lookup and return reports."""
+    reports_dict = {}
+    reports_dict["report_id"] = report_id
+    report = get_object_or_404(Report, id=report_id)
+    # add scan job id to allow detection of related logs on GzipRenderer
+    reports_dict["scan_job_id"] = report.scanjob.id
+    serializer = DetailsReportSerializer(report)
+    json_details = serializer.data
+    json_details.pop("cached_csv", None)
+    reports_dict["details_json"] = json_details
+    deployments_report = get_object_or_404(DeploymentsReport, report__id=report_id)
+    # deployments_report.status seems redundant considering scan job already
+    # has a "state machine". Consider removing this in future iterations (we will
+    # be forced to revisit this idea when Report replaces Deployments models)
+    if deployments_report.status != DeploymentsReport.STATUS_COMPLETE:
+        return Response(
+            {
+                "detail": _(
+                    f"Deployment report {report_id} could not be created."
+                    " See server logs."
+                )
+            },
+            status=status.HTTP_424_FAILED_DEPENDENCY,
+        )
+    deployments_json = build_cached_json_report(deployments_report)
+    reports_dict["deployments_json"] = deployments_json
+    aggregate_json = get_aggregate_report_by_report_id(report_id)
+    reports_dict["aggregate_json"] = aggregate_json
+    return Response(reports_dict)
+
+
+@api_view(["POST"])
+def upload_raw_facts(request):
+    """Dedicated view for uploading reports."""
+    input_serializer = ReportUploadSerializer(data=request.data)
+    input_serializer.is_valid(raise_exception=True)
+    report = input_serializer.save()
+    # start fingerprint job
+    start_scan.send(sender=__name__, instance=report.scanjob)
+    output_serializer = SimpleScanJobSerializer(report.scanjob)
+    return Response(output_serializer.data, status=status.HTTP_201_CREATED)

--- a/quipucords/api/scanjob/serializer.py
+++ b/quipucords/api/scanjob/serializer.py
@@ -18,6 +18,7 @@ from api.common.util import convert_to_int, is_int
 from api.models import Scan, ScanJob, ScanTask, Source
 from api.scan.serializer import ScanSerializer
 from api.scantask.serializer import ScanTaskSerializer, SourceField
+from api.source.serializer import InternalSourceSerializer
 
 SCAN_KEY = "scan"
 SOURCES_KEY = "sources"
@@ -158,16 +159,6 @@ class ScanJobSerializerV1(NotEmptySerializer):
         if options is not None:
             ScanSerializer.validate_options(options)
         return options
-
-
-class InternalSourceSerializer(ModelSerializer):
-    """Summarized source serializer for ScanJobSerializer."""
-
-    class Meta:
-        """Serializer metadata."""
-
-        model = Source
-        fields = ["id", "name", "source_type"]
 
 
 class ScanJobSerializerV2(ModelSerializer):

--- a/quipucords/api/serializers.py
+++ b/quipucords/api/serializers.py
@@ -17,7 +17,7 @@ from api.inspectresult.serializer import (
     RawFactSerializer,
     SystemInspectionResultSerializer,
 )
-from api.reports.serializer import ReportUploadSerializer
+from api.reports.serializer_v1 import ReportUploadSerializer
 from api.scan.serializer import ScanSerializer
 from api.scanjob.serializer import (
     ScanJobSerializerV1,

--- a/quipucords/api/source/serializer.py
+++ b/quipucords/api/source/serializer.py
@@ -562,3 +562,13 @@ match API_VERSION:
         SourceSerializer = SourceSerializerV2
     case _:
         SourceSerializer = SourceSerializerV1
+
+
+class InternalSourceSerializer(ModelSerializer):
+    """Summarized source serializer for ScanJobSerializer."""
+
+    class Meta:
+        """Serializer metadata."""
+
+        model = Source
+        fields = ["id", "name", "source_type"]

--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -4,7 +4,8 @@ from django.urls import include, path
 from rest_framework.routers import SimpleRouter
 
 from api.aggregate_report.view import aggregate_report
-from api.reports.view import upload_raw_facts
+from api.reports.view import ReportViewSet
+from api.reports.view_v1 import upload_raw_facts
 from api.scan.view import scan_bulk_delete
 from api.views import (
     CredentialViewSetV1,
@@ -38,6 +39,7 @@ ROUTER_V2 = SimpleRouter()
 ROUTER_V2.register(r"credentials", CredentialViewSetV2, basename="credentials")
 ROUTER_V2.register(r"sources", SourceViewSet, basename="source")
 ROUTER_V2.register(r"jobs", ScanJobViewSetV2, basename="job")
+ROUTER_V2.register(r"reports", ReportViewSet, basename="report")
 
 
 v1_urls = [

--- a/quipucords/api/views.py
+++ b/quipucords/api/views.py
@@ -9,7 +9,8 @@ from api.deployments_report.view import deployments
 from api.details_report.view import details
 from api.insights_report.view import insights
 from api.merge_report.view import async_merge_reports
-from api.reports.view import reports, upload_raw_facts
+from api.reports.view import ReportViewSet
+from api.reports.view_v1 import reports, upload_raw_facts
 from api.scan.view import ScanViewSet, jobs
 from api.scanjob.view import ScanJobViewSetV1, ScanJobViewSetV2
 from api.source.view import SourceViewSet, source_bulk_delete

--- a/quipucords/quipucords/settings.py
+++ b/quipucords/quipucords/settings.py
@@ -14,7 +14,6 @@ import logging
 import os
 import random
 import string
-import warnings
 from pathlib import Path
 
 import environ
@@ -38,6 +37,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # This suppresses warnings for models where an explicit primary key is not defined.
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+AUTOMATIC_REPORT_GENERATION = env.bool("QUIPUCORDS_AUTOMATIC_REPORT_GENERATION", True)
 
 
 class RelativePathnameFormatter(logging.Formatter):
@@ -430,14 +430,14 @@ LOGGING = {
 }
 
 
-def warn_on_deprecation(message, category, filename, lineno, file=None, line=None):  # noqa: PLR0913
-    """Redirect deprecation warnings to our logger."""
-    logger = logging.getLogger("quipucords.warnings")
-    logger.warning(f"{message} (from {filename}:{lineno})")
+# def warn_on_deprecation(message, category, filename, lineno, file=None, line=None):  # noqa: PLR0913
+#     """Redirect deprecation warnings to our logger."""
+#     logger = logging.getLogger("quipucords.warnings")
+#     logger.warning(f"{message} (from {filename}:{lineno})")
 
 
-warnings.showwarning = warn_on_deprecation
-warnings.simplefilter("always", DeprecationWarning)
+# warnings.showwarning = warn_on_deprecation
+# warnings.simplefilter("always", DeprecationWarning)
 
 # Reverse default behavior to avoid host key checking
 os.environ.setdefault("ANSIBLE_HOST_KEY_CHECKING", "False")

--- a/quipucords/tests/api/reports/test_serializer.py
+++ b/quipucords/tests/api/reports/test_serializer.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from api.reports.serializer import SourceSerializer
+from api.reports.serializer_v1 import SourceSerializer
 from api.serializers import ReportUploadSerializer
 from constants import DataSources
 


### PR DESCRIPTION
Add the feature flag `QUIPUCORDS_AUTOMATIC_REPORT_GENERATION`,  which is enabled by default. When turned off, it disables the fingerprint task in "inspection type scan jobs".

The new endpoint `/api/v2/reports` was added to support this workflow:
- the POST verb accepts a list of scanjob ids or a list of report ids, which shall be used to create a "fingerprint type scan job"  that will fingerprint and duplicate the data associated with the original scanjobs / reports.
- the GET verb (and the detail `/api/v2/reports/<report-id>`) have extra information from the scanjob that originated the report, so this info can be easily used on upcoming changes to UI's "report tab". Example response below:

```json
{
  "count": 3,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 9,
      "report_platform_id": "f4eaee4c-8988-48ff-a9cd-ac01dd8d8496",
      "status": "running",
      "start_time": "2025-04-02T11:10:28.600008Z",
      "end_time": null,
      "sources": [
        {
          "id": 1,
          "name": "vagrant",
          "source_type": "network"
        }
      ]
    },
    {
      "id": 8,
      "report_platform_id": "83c6eae0-6039-4f70-aa3f-7cba06087e6a",
      "status": "running",
      "start_time": "2025-04-02T11:09:42.959889Z",
      "end_time": null,
      "sources": [
        {
          "id": 1,
          "name": "vagrant",
          "source_type": "network"
        }
      ]
    },
    {
      "id": 4,
      "report_platform_id": "fddf173d-47ad-4c0d-a924-38d95c2cd60f",
      "status": "completed",
      "start_time": "2025-04-02T03:08:57.156170Z",
      "end_time": "2025-04-02T03:09:40.837940Z",
      "sources": [
        {
          "id": 1,
          "name": "vagrant",
          "source_type": "network"
        }
      ]
    }
  ]
}
```


This workflow was manually tested with `QUIPUCORDS_AUTOMATIC_REPORT_GENERATION` set to `True` and `False`.

The workflow with uploaded reports was not tested.
