### PR TITLE
feat: add report ID to each JSON and CSV filename in downloaded tarball

### DIFF
--- a/quipucords/api/common/common_report.py
+++ b/quipucords/api/common/common_report.py
@@ -38,9 +38,11 @@ def sanitize_row(row):
     return new_row
 
 
-def create_filename(file_name, file_ext, report_id):
+def create_filename(file_name, file_ext, report_id, detailed_filename=False):
     """Create the filename."""
     file_name = f"report_id_{report_id}/{file_name}"
+    if detailed_filename:
+        file_name += f"-{report_id}"
     if file_ext:
         file_name += f".{file_ext}"
     return file_name

--- a/quipucords/api/common/util.py
+++ b/quipucords/api/common/util.py
@@ -119,6 +119,21 @@ def check_path_validity(path_list):
     return invalid_paths
 
 
+def split_filename(filename) -> tuple[str, str | None]:
+    """
+    Split a filename into its stem/main name and optional suffix/extension.
+
+    >>> split_filename("hello") == ("hello", None)
+    >>> split_filename("hello.txt") == ("hello", "txt")
+    >>> split_filename("hello.world.txt") == ("hello.world", "txt")
+    """
+    path = Path(filename)
+    if path.suffix:
+        return path.stem, path.suffix[1:]  # remove the leading dot
+    else:
+        return path.name, None
+
+
 def expand_scanjob_with_times(scanjob):  # noqa: PLR0912, C901
     """Expand a scanjob object into a JSON dict to send to the user.
 

--- a/quipucords/api/report/reports_gzip_renderer.py
+++ b/quipucords/api/report/reports_gzip_renderer.py
@@ -9,6 +9,7 @@ from rest_framework import renderers
 
 from api import messages
 from api.common.common_report import create_filename, create_tar_buffer, encode_content
+from api.common.util import split_filename
 from api.deployments_report.util import create_deployments_csv
 from api.details_report.util import create_details_csv
 
@@ -69,7 +70,8 @@ class ReportsGzipRenderer(renderers.BaseRenderer):
         if not log_files:
             logger.warning("No logs were found for report_id=%s", report_id)
         for log in log_files:
-            file_name = create_filename(log.name, None, report_id)
+            basename, extension = split_filename(log.name)
+            file_name = create_filename(basename, extension, report_id, True)
             files_data[file_name] = encode_content(log.read_text(), "plaintext")
 
         # generate hashes

--- a/quipucords/api/report/reports_gzip_renderer.py
+++ b/quipucords/api/report/reports_gzip_renderer.py
@@ -46,11 +46,11 @@ class ReportsGzipRenderer(renderers.BaseRenderer):
             return None
 
         # create the file names
-        aggregate_json_name = create_filename("aggregate", "json", report_id)
-        details_json_name = create_filename("details", "json", report_id)
-        deployments_json_name = create_filename("deployments", "json", report_id)
-        details_csv_name = create_filename("details", "csv", report_id)
-        deployments_csv_name = create_filename("deployments", "csv", report_id)
+        aggregate_json_name = create_filename("aggregate", "json", report_id, True)
+        details_json_name = create_filename("details", "json", report_id, True)
+        deployments_json_name = create_filename("deployments", "json", report_id, True)
+        details_csv_name = create_filename("details", "csv", report_id, True)
+        deployments_csv_name = create_filename("deployments", "csv", report_id, True)
         sha256sum_name = create_filename("SHA256SUM", None, report_id)
 
         # map the file names to the file data

--- a/quipucords/tests/api/common/test_common_util.py
+++ b/quipucords/tests/api/common/test_common_util.py
@@ -9,7 +9,7 @@ import pytest
 from rest_framework.exceptions import ParseError
 
 from api.common.common_report import CSVHelper, create_tar_buffer, encode_content
-from api.common.util import ALL_IDS_MAGIC_STRING, set_of_ids_or_all_str
+from api.common.util import ALL_IDS_MAGIC_STRING, set_of_ids_or_all_str, split_filename
 from tests.report_utils import extract_files_from_tarball
 
 
@@ -179,3 +179,16 @@ def test_set_of_ids_or_all_str(input_ids, expected_ids, expect_exception):
             set_of_ids_or_all_str(input_ids)
     else:
         assert expected_ids == set_of_ids_or_all_str(input_ids)
+
+
+@pytest.mark.parametrize(
+    "filename,expected_output",
+    [
+        ["hello", ("hello", None)],
+        ["hello.txt", ("hello", "txt")],
+        ["hello.world.txt", ("hello.world", "txt")],
+    ],
+)
+def test_split_filename(filename, expected_output):
+    """Test split_filename returns expected values."""
+    assert split_filename(filename) == expected_output

--- a/quipucords/tests/api/report/test_reports.py
+++ b/quipucords/tests/api/report/test_reports.py
@@ -112,7 +112,7 @@ def test_report_with_logs(client_logged_in, deployment_with_logs):
     expected_files = {
         f"report_id_{report_id}/{fname.format(report_id=report_id)}"
         for fname in TARBALL_ALWAYS_EXPECTED_FILENAMES.union(
-            {f"scan-job-{scan_job_id}-test.txt"}
+            {f"scan-job-{scan_job_id}-test-{report_id}.txt"}
         )
     }
     with tarfile.open(fileobj=BytesIO(response.content)) as tarball:
@@ -131,7 +131,7 @@ def test_report_tarball_sha256sum(client_logged_in, deployment_with_logs):
         (name.format(report_id=report_id) for name in TARBALL_ALWAYS_EXPECTED_FILENAMES)
     )
     expected_filenames = report_filenames.union(
-        {f"scan-job-{deployments_report.report.scanjob.id}-test.txt"}
+        {f"scan-job-{deployments_report.report.scanjob.id}-test-{report_id}.txt"}
     )
     assert expected_filenames == set(files_contents.keys()), (
         "incorrect files in tarball"

--- a/quipucords/tests/constants.py
+++ b/quipucords/tests/constants.py
@@ -9,11 +9,11 @@ from tests.env import BaseURI, EnvVar, as_bool
 PROJECT_ROOT_DIR = Path(__file__).absolute().parent.parent.parent
 
 CLEANUP_DOCKER_LAYERS = False
-FILENAME_AGGREGATE_JSON = "aggregate.json"
-FILENAME_DEPLOYMENTS_CSV = "deployments.csv"
-FILENAME_DEPLOYMENTS_JSON = "deployments.json"
-FILENAME_DETAILS_CSV = "details.csv"
-FILENAME_DETAILS_JSON = "details.json"
+FILENAME_AGGREGATE_JSON = "aggregate-{report_id}.json"
+FILENAME_DEPLOYMENTS_CSV = "deployments-{report_id}.csv"
+FILENAME_DEPLOYMENTS_JSON = "deployments-{report_id}.json"
+FILENAME_DETAILS_CSV = "details-{report_id}.csv"
+FILENAME_DETAILS_JSON = "details-{report_id}.json"
 FILENAME_SHA256SUM = "SHA256SUM"
 POSTGRES_DB = "qpc-db"
 POSTGRES_PASSWORD = "qpc"

--- a/quipucords/tests/integration/test_smoker.py
+++ b/quipucords/tests/integration/test_smoker.py
@@ -263,11 +263,11 @@ class Smoker:
 
         with tarfile.open(fileobj=BytesIO(full_report_response.content)) as tarball:
             tarball_details_dict = load_json_from_tarball(
-                f"report_id_{report_id}/details.json", tarball
+                f"report_id_{report_id}/details-{report_id}.json", tarball
             )
             assert tarball_details_dict == details_response.json()
 
             tarball_deployments_dict = load_json_from_tarball(
-                f"report_id_{report_id}/deployments.json", tarball
+                f"report_id_{report_id}/deployments-{report_id}.json", tarball
             )
             assert tarball_deployments_dict == deployments_response.json()


### PR DESCRIPTION
This should help users who are manually processing files from multiple report directories. That use case came to us as a specific feature request from an end user.

Upon expanding a report tarball download, the contents should now look like this example:

```
report_id_18578
├── aggregate-18578.json
├── deployments-18578.csv
├── deployments-18578.json
├── details-18578.csv
├── details-18578.json
├── scan-job-18137-ansible-stderr-18578.txt
├── scan-job-18137-ansible-stdout-18578.txt
└── SHA256SUM
```

In this example, the `-18578` suffix is newly added to the various filenames, and that value is the same as the report ID used in the parent directory's name and the downloaded tarball filename. However, please also note that the numeric values in the *middle* of the `ansible` logs filenames, `-18137-` in this example, refer to the related scan job ID, and that value was already present in these filenames before this change.

Relates to JIRA: DISCOVERY-788