### PR TITLE
feat: Add support for azure_offer Fact

### DIFF
--- a/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/subman/tasks/main.yml
@@ -168,3 +168,19 @@
   when:
     - '"stdout_lines" in internal_subscription_manager_id_cmd'
     - 'internal_subscription_manager_id_cmd["stdout_lines"] | length > 0'
+
+#  azure_offer fact
+- name: gather azure_offer fact
+  raw: export LANG=C LC_ALL=C; subscription-manager facts --list 2>/dev/null | grep '^azure_offer:' | sed -n -e 's/^azure_offer:\s*//p'
+  register: azure_offer_cmd
+  ignore_errors: yes
+  become: yes
+  when: 'user_has_sudo and internal_have_subscription_manager'
+
+- name: extract result value for azure_offer
+  set_fact:
+    azure_offer: "{{ azure_offer_cmd['stdout_lines'][-1] | trim | default(None) }}"
+  ignore_errors: yes
+  when:
+    - '"stdout_lines" in azure_offer_cmd'
+    - 'azure_offer_cmd["stdout_lines"] | length > 0'


### PR DESCRIPTION
- For VMs deployed from Azure, we need to grab the azure_offer fact. for example, on a RHEL deployed VM:

```
    $ sudo sudo subscription-manager facts --list | grep azure
    azure_instance_id: 927b518b-d37d-4ad8-ad04-e1b0e31e7c68
    azure_offer: RHEL
    azure_sku: 94_gen2
    azure_subscription_id: c2b810d4-e83c-4df5-a728-f1301dd78561
```

  The fact of interest here being azure_offer. whereas on VMs deployed from other providers that line does not exist and will end up in a Null fact.