### PR TITLE
fix: destroy and create new aggregate report model; never update it

### DIFF
--- a/quipucords/api/aggregate_report/model.py
+++ b/quipucords/api/aggregate_report/model.py
@@ -339,8 +339,14 @@ def build_aggregate_report(
         aggregated = AggregateReport.objects.get(report_id=report_id)
         if report.updated_at <= aggregated.updated_at and not force_build:
             return aggregated
+        # If we are here, then we need to update the aggregate report.
+        # To be safe and eliminate any risk of double counting, delete the old
+        # report object and start fresh after exiting this try block.
+        aggregated.delete()
     except AggregateReport.DoesNotExist:
-        aggregated = AggregateReport.objects.create(report_id=report_id)
+        pass
+
+    aggregated = AggregateReport.objects.create(report_id=report_id)
 
     # Note that `aggregated` is treated as a pass-by-reference here and is updated
     # directly in these functions instead of returning a new instance.


### PR DESCRIPTION
We had a bug where downloading a report tarball multiple times would result in some aggregate report numbers doubling the second time you performed the download. The root cause is related to cached details and deployments report files being written to disk at the time of the download. Writing those files to disk causes their models' updated_at field to update, but an aggregate report model instance was already created during the tail end of the scan (fingerprinting task, I think). Subsequent attempts to retrieve the aggregate report would compare updated_at values, find that the aggregate report is "older" than the related report objects, and attempt to recalculate the aggregate report contents. However, because aggregate report data already existed, that "recalculation" began with the originally calculated numbers as the baselines instead of zero, and thus the results doubled.

The fix here is simply to destroy the aggregate report object and start clean any time it looks like it needs updating.

This is very much a "quick fix" for the aggregate report object updating issue. I strongly advise rethinking the surrounding logic to evaluate if it should be kept or refactored with more aggressive presence-checking logic regarding the related cached report data.

Relates to JIRA: DISCOVERY-977