### PR TITLE
build: unpin transitive build dependency rpds-py

### DIFF
--- a/lockfiles/requirements.txt
+++ b/lockfiles/requirements.txt
@@ -170,7 +170,6 @@ resolvelib==1.0.1 ; (implementation_name == 'cpython' and sys_platform == 'darwi
 rpds-py==0.30.0 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')
     # via
     #   jsonschema
-    #   quipucords
     #   referencing
 six==1.17.0 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "pexpect<5.0.0,>=4.8.0",
     "psycopg[c]<4.0.0,>=3.2.3",
     "pydantic<2.0.0,>=1.10.4",
-    "rpds-py<1.0.0,>=0.30.0",
     "pyyaml<7.0.0,>=6.0.1",
     "requests<3.0.0,>=2.32.2",
     "whitenoise<7.0.0,>=6.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1774,7 +1774,6 @@ dependencies = [
     { name = "pyvmomi", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "pyyaml", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "requests", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
-    { name = "rpds-py", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "urllib3", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "whitenoise", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
 ]
@@ -1828,7 +1827,6 @@ requires-dist = [
     { name = "pyvmomi", git = "https://github.com/vmware/pyvmomi.git?tag=v9.0.0.0" },
     { name = "pyyaml", specifier = ">=6.0.1,<7.0.0" },
     { name = "requests", specifier = ">=2.32.2,<3.0.0" },
-    { name = "rpds-py", specifier = ">=0.30.0,<1.0.0" },
     { name = "urllib3", specifier = ">=2.6.0" },
     { name = "whitenoise", specifier = ">=6.3.0,<7.0.0" },
 ]


### PR DESCRIPTION
See also https://github.com/quipucords/quipucords/pull/2955 which originally pinned rpds-py to `0.24.0` in d40676f467bc0b90fb27b010152ac5940dafcf4b because downstream Konflux builds were failing on newer versions of rpds-py.

## Summary by Sourcery

Build:
- Update project dependency configuration to remove the explicit rpds-py requirement from pyproject.toml and rely on transitive resolution instead.