### PR TITLE
feat: Add support for Ansible Automation Platform 2.5

### DIFF
--- a/quipucords/scanner/ansible/exceptions.py
+++ b/quipucords/scanner/ansible/exceptions.py
@@ -1,0 +1,5 @@
+"""Ansible scanner custom exceptions."""
+
+
+class AnsibleApiDetectionError(Exception):
+    """Exception for Detecting Ansible Automation Platform API Endpoints."""

--- a/quipucords/scanner/ansible/inspect.py
+++ b/quipucords/scanner/ansible/inspect.py
@@ -138,6 +138,11 @@ class InspectTaskRunner(AnsibleTaskRunner):
                 hosts=v2_ctrl_ep["hosts"],
                 jobs=v2_ctrl_ep["jobs"],
             )
+
+            logger.info(
+                f"Ansible Controller Endpoints for {self.scan_task.source.name}"
+                f" are {self.endpoints}"
+            )
         except KeyError as exception:
             self.endpoints = None
             raise AnsibleApiDetectionError(

--- a/quipucords/scanner/ansible/inspect.py
+++ b/quipucords/scanner/ansible/inspect.py
@@ -230,9 +230,12 @@ class InspectTaskRunner(AnsibleTaskRunner):
 
     def get_hosts_from_job_events(self, job_id) -> set:
         """Get unique hosts found in job events."""
+        jobs_ep = self.endpoints.jobs
+        if not jobs_ep.endswith("/"):
+            jobs_ep += "/"
+        jobs_url = urljoin(jobs_ep, f"{job_id}/job_events/?event=runner_on_start")
         events_generator = self.client.get_paginated_results(
-            urljoin(self.endpoints.jobs, f"{job_id}/job_events/?event=runner_on_start"),
-            **self.REQUEST_KWARGS,
+            jobs_url, **self.REQUEST_KWARGS
         )
         unique_hosts = set()
         for event in events_generator:

--- a/quipucords/tests/integration/test_ansible_scan.py
+++ b/quipucords/tests/integration/test_ansible_scan.py
@@ -20,6 +20,19 @@ def mocked_requests(requests_mock, live_server):
     for method in ("GET", "POST"):
         requests_mock.register_uri(method, django_url_matcher, real_http=True)
     ansible_host = "https://ansible-controller.host:443"
+    # we simulate an AAP Controller type API (<=2.4)
+    requests_mock.get(
+        f"{ansible_host}/api/", json={"available_versions": {"v2": "/api/v2/"}}
+    )
+    requests_mock.get(
+        f"{ansible_host}/api/v2/",
+        json={
+            "me": "/api/v2/me/",
+            "ping": "/api/v2/ping/",
+            "hosts": "/api/v2/hosts/",
+            "jobs": "/api/v2/jobs/",
+        },
+    )
     # only thing we care "me" is if it has a valid status code.
     requests_mock.get(f"{ansible_host}/api/v2/me/")
     requests_mock.get(

--- a/quipucords/tests/scanner/ansible/test_inspect.py
+++ b/quipucords/tests/scanner/ansible/test_inspect.py
@@ -1,0 +1,73 @@
+"""Test Ansible InspectTaskRunner."""
+
+import pytest
+
+from api.models import ScanTask
+from constants import DataSources
+from scanner.ansible.exceptions import AnsibleApiDetectionError
+from scanner.ansible.inspect import InspectTaskRunner
+from scanner.ansible.runner import AnsibleTaskRunner
+from tests.factories import ScanTaskFactory
+
+
+@pytest.fixture
+def scan_task():
+    """Return a ScanTask for testing."""
+    inspect_task = ScanTaskFactory(
+        source__source_type=DataSources.ANSIBLE,
+        source__hosts=["1.2.3.4"],
+        source__port=4321,
+        scan_type=ScanTask.SCAN_TYPE_INSPECT,
+        sequence_number=1,
+    )
+    return inspect_task
+
+
+@pytest.fixture
+def mock_client(mocker):
+    """Return a mocked Ansible client."""
+    return mocker.patch.object(AnsibleTaskRunner, "get_client")
+
+
+@pytest.fixture
+def test_api_endpoints():
+    """Return a mocked set of Ansible API endpoints."""
+    return InspectTaskRunner.AAP_ENDPOINTS(
+        me="/api/test/v2/me",
+        ping="/api/test/v2/ping",
+        hosts="/api/test/v2/hosts",
+        jobs="/api/test/v2/jobs",
+    )
+
+
+@pytest.mark.django_db
+def test_detect_ansible_endpoints_does_not_requery_api(
+    mocker, mock_client, test_api_endpoints, scan_task: ScanTask
+):
+    """Test Detecting Ansible endpoints does not re-query API."""
+    runner = InspectTaskRunner(scan_task=scan_task, scan_job=scan_task.job)
+    runner.client = mock_client
+    mocker.patch.object(
+        runner, "inspect", return_value=[runner.success_message, ScanTask.COMPLETED]
+    )
+    runner.endpoints = test_api_endpoints
+    runner._detect_ansible_endpoints()
+    assert not mock_client.assert_called_once()
+    assert runner.endpoints.me == "/api/test/v2/me"
+
+
+@pytest.mark.django_db
+def test_check_connection_handles_api_detection_error(
+    mocker, mock_client, test_api_endpoints, scan_task: ScanTask
+):
+    """Test that check_connection handles API detection errors."""
+    runner = InspectTaskRunner(scan_task=scan_task, scan_job=scan_task.job)
+    runner.client = mock_client
+    runner._detect_ansible_endpoints = mocker.Mock(side_effect=AnsibleApiDetectionError)
+    mocker.patch.object(
+        runner, "inspect", return_value=[runner.success_message, ScanTask.COMPLETED]
+    )
+    runner.endpoints = test_api_endpoints
+    failure_message, status = runner.check_connection()
+    assert not mock_client.assert_called_once()
+    assert status == ScanTask.FAILED


### PR DESCRIPTION
- With 2.4 and earlier, the 8443 port exposes the controller api's giving us the /api/v2/ endpoint for it.
- With 2.5 and later, AAP also exposes the gateway at 443, giving us the /api/controller/v2/ endpoint for it.
- Enhanced the Ansible inspection code to automatically detect the type of API we are accessing and fetch the related v2 version of the controller API.
- We now also detect the endpoints of the API's we use, specifically /me, /ping, /hosts and /jobs.

Tested with:
- AAP 2.4 on port 8443. (/api/v2/)
- AAP 2.5 on port 8443. (/api/v2/)
- AAP 2.5 on port 443. (/api/controller/v2)

Resolves: [DISCOVERY-1021](https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=17051&view=detail&selectedIssue=DISCOVERY-1021)

Draft
- [x] add /api/controller/v2 tests

## Summary by Sourcery

Enable support for Ansible Automation Platform 2.5 by enhancing the scan to auto-detect API versions, unify endpoint handling across AAP 2.4 and 2.5, and update integration tests to cover both scenarios

New Features:
- Automatically detect whether the Ansible controller API is the legacy (/api/v2) or new gateway (/api/controller/v2) endpoint
- Dynamically fetch and use API endpoints for /me, /ping, /hosts, and /jobs based on the detected API type
- Support scanning Ansible Automation Platform 2.5 via the gateway endpoint on port 443

Enhancements:
- Refactor the inspector to introduce a _detect_ansible_endpoints method and centralized endpoint resolution
- Introduce an AAP_ENDPOINTS namedtuple to encapsulate discovered endpoint URLs

Tests:
- Parameterize integration tests to run against both AAP 2.4 and AAP 2.5 API endpoints
- Extend the mocked_requests fixture to simulate both controller and gateway endpoints and add tests for /api/controller/v2