### PR TITLE
Improve django support for pyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ var/
 
 # test profiling results
 prof/
+
+# direnv configuration
+.envrc

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
   # unnoficial RHEL images
-  (6..9).each do |n|
+  (7..9).each do |n|
     config.vm.define "rhel%d" % n do |vmconfig|
       vmconfig.vm.box = "generic/rhel%d" % n
     end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "watchdog[watchmedo]<3.0.0,>=2.2.1",
     # temporarily lock pip behind 25.1 (pybuild-deps will require a change)
     "pip<25.1",
+    "django-types>=0.22.0",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -586,6 +586,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-types"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-psycopg2", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/26/5f2873f7208dee0791710fda494a8d3ef7fb1d34785069b55168a23e2ac2/django_types-0.22.0.tar.gz", hash = "sha256:4cecc9eee846e7ff2a398bec9dfe6543e76efb922a7a58c5d6064bcb0e6a3dc5", size = 187214, upload-time = "2025-07-15T01:05:48.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3a/0ecbaab07cfe7b0a4fd72dfde4be8e7c11aad2b88c816cfcbb800c14cbda/django_types-0.22.0-py3-none-any.whl", hash = "sha256:ba15c756c7a732e58afd0737e54489f1c5e6f1bd24132e9199c637b1f88b057c", size = 376869, upload-time = "2025-07-15T01:05:46.621Z" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1921,6 +1933,7 @@ dependencies = [
 dev = [
     { name = "coverage", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "django-extensions", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
+    { name = "django-types", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "factory-boy", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "httpretty", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
     { name = "ipython", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
@@ -1974,6 +1987,7 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = ">=7.0.5,<8.0.0" },
     { name = "django-extensions", specifier = ">=3.2.1,<4.0.0" },
+    { name = "django-types", specifier = ">=0.22.0" },
     { name = "factory-boy", specifier = ">=3.2.1,<4.0.0" },
     { name = "httpretty", specifier = ">=1.1.4,<2.0.0" },
     { name = "ipython", specifier = ">=8.10.0,<9.0.0" },
@@ -2291,6 +2305,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-psycopg2"
+version = "2.9.21.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/d0/66f3f04bab48bfdb2c8b795b2b3e75eb20c7d1fb0516916db3be6aa4a683/types_psycopg2-2.9.21.20250809.tar.gz", hash = "sha256:b7c2cbdcf7c0bd16240f59ba694347329b0463e43398de69784ea4dee45f3c6d", size = 26539, upload-time = "2025-08-09T03:14:54.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/98/182497602921c47fadc8470d51a32e5c75343c8931c0b572a5c4ae3b948b/types_psycopg2-2.9.21.20250809-py3-none-any.whl", hash = "sha256:59b7b0ed56dcae9efae62b8373497274fc1a0484bdc5135cdacbe5a8f44e1d7b", size = 24824, upload-time = "2025-08-09T03:14:53.908Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
django-types adds proper django-related stubs so code editors that
rely on pyright based language servers (like what is used on VSCodium,
Cursor, Zed, etc) can properly understand django code.

It seems that pylance has its own version of django-stubs bundled
in it - after inspecting extensions code locally I found
~/.vscode/extensions/ms-python.vscode-pylance-2025.6.2/dist/bundled/stubs/django-stubs*.

Just installing this package made both Zed and Cursor stop complaining about many
(but not all) issues with django-related code - especially when it comes to ORM.

*: it is named django-stubs because django-types is a fork of
django-stubs. I tried django-stubs as well and had a better experience with django-types.


This PR also includes small changes unrelated to django support in pyright.

## Summary by Sourcery

Add django-types stubs for improved Pyright support in Django code, drop outdated RHEL6 Vagrant environment, and update project ignore/lock configurations

New Features:
- Add django-types>=0.22.0 to dev dependencies for proper Django type stubs

Enhancements:
- Remove RHEL6 support from Vagrantfile

Chores:
- Update .gitignore and regenerate uv.lock