### PR TITLE
ci(mintmaker): disable all python package updates and group PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["group:all"],
+  "python": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Extend renovate schema (upstream of mintmaker) to completely disable python related PRs. Also, in order to limit the number of PRs, extend a base configuration that groups all updates in a single PR.

Unfortunately we can't add comments to JSON to link to the relevant documentation, so adding relevant docs to this commit message should suffice:

- https://docs.renovatebot.com/presets-group/#groupall
- https://konflux-ci.dev/docs/mintmaker/user/
- https://docs.renovatebot.com/python/#disabling-python-support

Relates to JIRA: DISCOVERY-1039

## Summary by Sourcery

Configure Renovate to disable all Python package updates and consolidate all dependency updates into a single grouped PR

Enhancements:
- Disable Python support in Renovate to prevent any Python-related update PRs
- Extend the base Renovate configuration to group all dependency updates into one combined PR