### PR TITLE
fix(vcenter): update pyVmomi to 9.0.0 and validate proxy support

### DIFF
--- a/lockfiles/requirements-build.txt
+++ b/lockfiles/requirements-build.txt
@@ -55,7 +55,7 @@ hatchling==1.27.0
     #   referencing
     #   sqlparse
     #   urllib3
-maturin==1.9.1
+maturin==1.9.2
     # via
     #   cryptography
     #   rpds-py
@@ -164,6 +164,7 @@ setuptools==80.9.0
     #   pynacl
     #   python-daemon
     #   python-dateutil
+    #   pyvmomi
     #   pyyaml
     #   resolvelib
     #   semver

--- a/lockfiles/requirements.txt
+++ b/lockfiles/requirements.txt
@@ -155,7 +155,7 @@ python-dateutil==2.9.0.post0 ; (implementation_name == 'cpython' and sys_platfor
     #   kubernetes
 python-string-utils==1.0.0 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')
     # via openshift
-pyvmomi==8.0.3.0.1 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')
+pyvmomi @ git+https://github.com/vmware/pyvmomi.git@e6cc09f32593d263b9ea0b611596a2c505786c6b ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')
     # via quipucords
 pyyaml==6.0.2 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')
     # via
@@ -191,7 +191,6 @@ six==1.17.0 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or
     #   kubernetes
     #   openshift
     #   python-dateutil
-    #   pyvmomi
 sqlparse==0.5.3 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')
     # via django
 typing-extensions==4.14.1 ; (implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,12 @@ dependencies = [
     "pexpect<5.0.0,>=4.8.0",
     "psycopg[c]<4.0.0,>=3.2.3",
     "pydantic<2.0.0,>=1.10.4",
-    "rpds-py==0.24.0",  # pinning because konflux/hermeto/cargo is failing on newer 0.25.1 version
-    "pyvmomi<9.0.0,>=8.0.2",
+    "rpds-py==0.24.0", # pinning because konflux/hermeto/cargo is failing on newer 0.25.1 version
     "pyyaml<7.0.0,>=6.0.1",
     "requests<3.0.0,>=2.32.2",
     "whitenoise<7.0.0,>=6.3.0",
     "django-json-agg>=0.0.1",
+    "pyvmomi",
 ]
 
 [dependency-groups]
@@ -143,3 +143,6 @@ required-version = ">=0.7"
 environments = [
     "implementation_name == 'cpython' and (sys_platform == 'linux' or sys_platform == 'darwin')",
 ]
+
+[tool.uv.sources]
+pyvmomi = { git = "https://github.com/vmware/pyvmomi.git", tag = "v9.0.0.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -1842,12 +1842,8 @@ wheels = [
 
 [[package]]
 name = "pyvmomi"
-version = "8.0.3.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/78/4a3847c0487283e57679364b5797ee8f7a2c40a13bccdb430864e9190782/pyvmomi-8.0.3.0.1.tar.gz", hash = "sha256:db795c960159cfa3c81e6af4cf1f46618e61cf0349db1666de75df98a4f29c69", size = 1191984, upload-time = "2024-06-26T19:29:36.985Z" }
+version = "9.0.0.0"
+source = { git = "https://github.com/vmware/pyvmomi.git?tag=v9.0.0.0#e6cc09f32593d263b9ea0b611596a2c505786c6b" }
 
 [[package]]
 name = "pyyaml"
@@ -1971,7 +1967,7 @@ requires-dist = [
     { name = "pexpect", specifier = ">=4.8.0,<5.0.0" },
     { name = "psycopg", extras = ["c"], specifier = ">=3.2.3,<4.0.0" },
     { name = "pydantic", specifier = ">=1.10.4,<2.0.0" },
-    { name = "pyvmomi", specifier = ">=8.0.2,<9.0.0" },
+    { name = "pyvmomi", git = "https://github.com/vmware/pyvmomi.git?tag=v9.0.0.0" },
     { name = "pyyaml", specifier = ">=6.0.1,<7.0.0" },
     { name = "requests", specifier = ">=2.32.2,<3.0.0" },
     { name = "rpds-py", specifier = "==0.24.0" },


### PR DESCRIPTION
I reviewed our vcenter_connect implementation against the [VCF 9.0 release notes](https://github.com/vmware/pyvmomi/releases) and validated functionality.

Observations:
- SmartConnect with httpProxyHost and httpProxyPort works as expected.
- The removal of SoapAdapter.HTTPProxyConnection does not affect our usage. 
- We do not use any deprecated parameters such as b64token or mechanism.
- No references to ThumbprintMismatchException or other removed classes exist in our code.
- SSL context handling remains valid.
- Dependency pinning on pyOpenSSL < 24.3.0 does not impact our environment.
- Functionality was tested both with and without a proxy, using the Squid proxy set up by Mirek on OpenStack.

Conclusion:
No changes are required for VCF 9.0. Our current vCenter connection logic is fully compatible.

Relates to [JIRA: DISCOVERY-1016](https://issues.redhat.com/browse/DISCOVERY-1016)

## Summary by Sourcery

Bump pyvmomi to 9.0.0 and ensure existing vCenter connection logic supports proxies with the new version

Enhancements:
- Validate that vcenter_connect works with vCenter 9.0 and external HTTP proxies without any code changes

Build:
- Update pyvmomi dependency range to >=9.0.0