### PR TITLE
fix: Use "one" instead of "1"

### DIFF
--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -37,7 +37,7 @@ HC_NO_KEY_W_PASS = (
 HC_NAME_ALREADY_EXISTS = "Host credential with name=%s already exists"
 CRED_TYPE_NOT_ALLOWED_UPDATE = "cred_type is invalid for credential update"
 CRED_DELETE_NOT_VALID_W_SOURCES = (
-    "Credential cannot be deleted because it is used by 1 or more sources."
+    "Credential cannot be deleted because it is used by one or more sources."
 )
 
 # source messages
@@ -53,7 +53,7 @@ SOURCE_TYPE_INV = "A source_type must not be provided when updating a source."
 SOURCE_CRED_IDS_INV = "Credential identifiers must be integer values."
 SOURCE_MIN_CREDS = "Source must have at least one set of credentials."
 SOURCE_DELETE_NOT_VALID_W_SCANS = (
-    "Source cannot be deleted because it is used by 1 or more scans."
+    "Source cannot be deleted because it is used by one or more scans."
 )
 SOURCE_INVALID_SCHEMA_PROXY_URL = (
     "Enter a valid proxy URL including the protocol, such as 'http://host:port'."


### PR DESCRIPTION
This makes message consistent with message displayed in UI: https://github.com/quipucords/quipucords-ui/pull/651

Change from "1" to "one" was done on docs team request.

BTW: you can find all strings that contain single digits using [ast-grep](http://ast-grep.github.io/):

```
ast-grep scan -r /tmp/nums.yml ./path/to/quipucords/
```

Where yaml file is:
```
id: find-strings-with-single-digit
language: python
rule:
  any:
    - regex: '([a-z]\s)\d(\s[a-z])'
      kind: 'string_content'
    - regex: '^\d(\s[a-z])'
      kind: 'string_content'
    - regex: '([a-z]\s)\d$'
      kind: 'string_content'
```

You **can** use simple regex `\d`, but then it finds stuff like `"1.2.3.4"` and `"acs_source_1"`.

Relates to JIRA: DISCOVERY-824

## Summary by Sourcery

Use word "one" instead of the digit "1" in two API error messages to align with UI wording

Bug Fixes:
- Change credential deletion error to say "one or more sources" instead of "1 or more sources"
- Change source deletion error to say "one or more scans" instead of "1 or more scans"