### PR TITLE
refactor: forbid ambiguous unicode characters in source code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ lint.select = [
     "PTH", # flake8-use-pathlib
     "S",   # flake8-bandit
     "N",   # pep8-naming
+    "RUF001", # ambiguous-unicode-character-string
+    "RUF002", # ambiguous-unicode-character-docstring
+    "RUF003", # ambiguous-unicode-character-comment
 ]
 lint.ignore = [
     "D107",

--- a/quipucords/scanner/network/processing/eap.py
+++ b/quipucords/scanner/network/processing/eap.py
@@ -63,7 +63,7 @@ class ProcessIdUJboss(process.Processor):
         # marks around the username it doesn't recognize.
         if plain_output in [
             "id: jboss: no such user",  # BusyBox id tends to use no quotes
-            "id: ‘jboss’: no such user",  # GNU id tends to use these "smart" quotes
+            "id: ‘jboss’: no such user",  # noqa: RUF001 E501, GNU id tends to use these "smart" quotes
             "id: 'jboss': no such user",  # Unknown build of id seen using plain quotes
         ]:
             return False

--- a/quipucords/tests/scanner/network/test_inspect_callback.py
+++ b/quipucords/tests/scanner/network/test_inspect_callback.py
@@ -177,13 +177,13 @@ def fact_with_bad_bytes():
             "rc": 0,
             "stdout": (
                 "root:x:0:0:root:/root:/bin/bash\r\n"
-                "ß´˜µ∫∑´®˙∆˚©ƒ∑´®¨˚˙∆ß∂ƒ∫≤“‘æ…≤≤µ˜e\udcc0\udcc0\udcf4\udcff:x:"
+                "ß´˜µ∫∑´®˙∆˚©ƒ∑´®¨˚˙∆ß∂ƒ∫≤“‘æ…≤≤µ˜e\udcc0\udcc0\udcf4\udcff:x:"  # noqa: RUF001 E501
                 "69420:69420:i am a potato:/home/potato:/bin/bash\r\n"
             ),
             "stdout_lines": [
                 "root:x:0:0:root:/root:/bin/bash",
                 (
-                    "ß´˜µ∫∑´®˙∆˚©ƒ∑´®¨˚˙∆ß∂ƒ∫≤“‘æ…≤≤µ˜e\udcc0\udcc0\udcf4\udcff:x:"
+                    "ß´˜µ∫∑´®˙∆˚©ƒ∑´®¨˚˙∆ß∂ƒ∫≤“‘æ…≤≤µ˜e\udcc0\udcc0\udcf4\udcff:x:"  # noqa: RUF001 E501
                     "69420:69420:i am a potato:/home/potato:/bin/bash"
                 ),
             ],


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-1053

## Summary by Sourcery

Enforce linting rules to forbid ambiguous Unicode characters and update existing code and tests to comply

Enhancements:
- Enforce flake8 rules RUF001, RUF002, and RUF003 to ban ambiguous Unicode in strings, docstrings, and comments
- Add noqa directives to existing source code and test files to suppress current ambiguous Unicode violations

Build:
- Enable the new RUF rules in the flake8 configuration within pyproject.toml