### PR TITLE
refactor: remove update-konflux-pipeline target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ make update-lockfiles
 ```
 
 Besides python dependencies required for development, this command also requires `podman`, `skopeo`, `yq` (the go version, not the one on pypi),
-[`konflux-pipeline-patcher`](https://github.com/simonbaird/konflux-pipeline-patcher) and, if you are on macOS, `gsed`. You should already have these installed if you followed the instructions in `README.md`.
+and, if you are on macOS, `gsed`. You should already have these installed if you followed the instructions in `README.md`.
 
 -----
 

--- a/Makefile
+++ b/Makefile
@@ -254,12 +254,4 @@ lock-baseimages:
 	done; \
 	echo "$${separator}"
 
-update-konflux-pipeline:
-	@if which pipeline-patcher > /dev/null 2>&1; then \
-		pipeline-patcher bump-task-refs .; \
-	else \
-		echo "'pipeline-patcher' not found in PATH; Refer to https://github.com/simonbaird/konflux-pipeline-patcher/blob/main/README.md."; \
-		exit 1; \
-	fi
-
-update-lockfiles: lock-baseimages lock-rpms update-requirements update-konflux-pipeline
+update-lockfiles: lock-baseimages lock-rpms update-requirements

--- a/README.md
+++ b/README.md
@@ -34,33 +34,18 @@ Building and running quipucords locally from source requires modern versions of:
 - podman (https://podman.io/getting-started/installation)
 - skopeo
 - make
-- oras
 - rename
 - shellcheck
 - yq ([the go version](https://github.com/mikefarah/yq), not the one on pypi)
-- [Konflux Pipeline Patcher](https://github.com/simonbaird/konflux-pipeline-patcher)
 
 Use your system's package manager to install or upgrade as necessary.
-
-Note that [Konflux Pipeline Patcher](https://github.com/simonbaird/konflux-pipeline-patcher) is simply a shell script you must download like this:
-
-```sh
-# Replace $HOME/bin with wherever you keep custom scripts or programs.
-mkdir -p "$HOME/bin"
-curl -sL -o "$HOME/bin/pipeline-patcher" https://github.com/simonbaird/konflux-pipeline-patcher/raw/main/pipeline-patcher
-chmod a+x "$HOME/bin/pipeline-patcher"
-
-# You must include that bin dir in your PATH.
-# We strongly recommend you add this to your shell's rc/profile.
-export PATH="$HOME/bin:$PATH"
-```
 
 ## macOS prereqs
 
 The default versions in macOS of some programs like `make` and `sed` are too old or incompatible with our build commands. Install modern versions plus additional required programs using Homebrew:
 
 ```sh
-brew install make coreutils gnu-sed skopeo oras rename yq shellcheck nmap
+brew install make coreutils gnu-sed skopeo rename yq shellcheck nmap
 ```
 
 After installing some programs like `make`, update your `PATH` to override the system defaults. For example:


### PR DESCRIPTION
Recently it became clear that pipeline-patcher (which was used on update-konflux-pipeline target) was not enough to properly upgrade our tekton pipelines. It became clear that using this tool alone represents a risk, so let's remove it.

In the future we might reproduce what MintMaker does by running it locally [1] with MintMaker config [2], which relies on a tool called pipeline-migration-tool to properly handle migrations. Or maybe just on MintMaker to propose updates to our pipelines.

[1]: https://docs.renovatebot.com/modules/platform/local/
[2]: https://github.com/konflux-ci/mintmaker/blob/a3816e76f5e06ba3114731fc34fa14f76d442b6c/config/renovate/renovate.json#L70-L116

## Summary by Sourcery

Remove the update-konflux-pipeline target and references to konflux-pipeline-patcher to eliminate an unsupported pipeline patching step.

Enhancements:
- Remove the update-konflux-pipeline Makefile target and drop it from the update-lockfiles dependency chain
- Delete references to konflux-pipeline-patcher from the CONTRIBUTING.md prerequisites