### PR TITLE
chore: update Konflux clamav image reference

### DIFF
--- a/.tekton/discovery-server-pull-request.yaml
+++ b/.tekton/discovery-server-pull-request.yaml
@@ -450,7 +450,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/discovery-server-push.yaml
+++ b/.tekton/discovery-server-push.yaml
@@ -450,7 +450,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Let's see if aligning clamav image with one we have in UI repo fixes contract pipeline problems.

## Summary by Sourcery

Update the clamav-scan task bundle image digest in Tekton workflows to match the UI repository and address contract pipeline issues.

Chores:
- Bump the SHA256 digest of quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3 in discovery-server-pull-request.yaml
- Bump the SHA256 digest of quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3 in discovery-server-push.yaml