### PR TITLE
feat: Adding the source's scan task id and status in a source's view

### DIFF
--- a/quipucords/api/source/view.py
+++ b/quipucords/api/source/view.py
@@ -46,6 +46,8 @@ def format_source(json_source):
         task_for_source = scan_job.tasks.filter(source=source_id).first()
 
         if task_for_source is not None:
+            json_scan_job["source_task_id"] = task_for_source.id
+            json_scan_job["source_task_status"] = task_for_source.status
             json_scan_job["source_systems_count"] = task_for_source.systems_count
             json_scan_job["source_systems_scanned"] = task_for_source.systems_scanned
             json_scan_job["source_systems_failed"] = task_for_source.systems_failed

--- a/quipucords/tests/api/source/test_source.py
+++ b/quipucords/tests/api/source/test_source.py
@@ -241,6 +241,8 @@ class TestSource:
         scan_job.end_time = end
         scan_job.status = ScanTask.COMPLETED
         scan_job.save()
+        source_task = scan_job.tasks.filter(source=source.id).first()
+
         source.most_recent_connect_scan = scan_job
         source.save()
 
@@ -270,6 +272,8 @@ class TestSource:
                 "source_systems_scanned": 9,
                 "source_systems_failed": 1,
                 "source_systems_unreachable": 0,
+                "source_task_id": source_task.id,
+                "source_task_status": source_task.status,
             },
         }
         assert out == expected
@@ -1802,6 +1806,7 @@ class TestSourceV2:
         scan_job.save()
         source.most_recent_connect_scan = scan_job
         source.save()
+        source_task = scan_job.tasks.filter(source=source.id).first()
 
         serializer = SourceSerializer(source)
         json_source = serializer.data
@@ -1829,6 +1834,8 @@ class TestSourceV2:
                 "source_systems_scanned": 9,
                 "source_systems_failed": 1,
                 "source_systems_unreachable": 0,
+                "source_task_id": source_task.id,
+                "source_task_status": source_task.status,
             },
         }
         assert out == expected


### PR DESCRIPTION
Do not merge, this is a POC. Needs additional testing in UI for different scenarios.

- When querying a source, we are returning in the connection relationship details on the scan job status and related task statuses upon failure. What was missing in that response is the scan task specific to the source, its id and status. While we could report of the scan job's status (which may show failure for a multi-source job), we could not report on the scanning status of the one source at hand.

Relates-to: https://redhat.atlassian.net/browse/DISCOVERY-1105

## Summary by Sourcery

Expose source-specific scan task id and status in the source view response and update tests accordingly

New Features:
- Add source_task_id and source_task_status to the formatted source scan job response

Tests:
- Update source serializer tests to include and assert source_task_id and source_task_status