### PR TITLE
build: konflux broke its task-ecosystem-cert-preflight-checks; try another sha256 that might not be broken

### DIFF
--- a/.tekton/discovery-server-pull-request.yaml
+++ b/.tekton/discovery-server-pull-request.yaml
@@ -397,7 +397,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:1f151e00f7fc427654b7b76045a426bb02fe650d192ffe147a304d2184787e38
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dae8e28761cee4ab0baf04ab9f8f1a4b3cee3c7decf461fda2bacc5c01652a60
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/discovery-server-push.yaml
+++ b/.tekton/discovery-server-push.yaml
@@ -394,7 +394,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:1f151e00f7fc427654b7b76045a426bb02fe650d192ffe147a304d2184787e38
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dae8e28761cee4ab0baf04ab9f8f1a4b3cee3c7decf461fda2bacc5c01652a60
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
See this Slack comment for context: https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1758140756019529?thread_ts=1758036508.704449&cid=C02QSNF1UKE

## Summary by Sourcery

Build:
- Update the sha256 digest for the ecosystem-cert-preflight-checks Tekton task bundle in pull-request and push pipeline configs