### PR TITLE
fix: no inline comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,11 +245,8 @@ lock-baseimages:
 	for image in $${baseimages[@]}; do \
 		echo "$${separator}"; \
 		echo "updating $${image}..."; \
-		# escape "/" for use in $(SED) later \
 		escaped_img=$$(echo $${image} | $(SED) 's/\//\\\//g') ;\
-		# extract the image digest \
 		updated_sha=$$(skopeo inspect --raw "docker://$${image}:latest" | sha256sum | cut -d ' ' -f1); \
-		# update Containerfile with the new digest \
 		$(SED) -i "s/^\(FROM $${escaped_img}@sha256:\)[[:alnum:]]*/\1$${updated_sha}/g" Containerfile; \
 	done; \
 	echo "$${separator}"


### PR DESCRIPTION
- Having inline comments in embedded shell in the Makefile causes make to fail with a syntax error

```
    $ make update-lockfiles
    ...
    /bin/sh: -c: line 1: syntax error: unexpected end of file
    make: *** [lock-baseimages] Error 2
```

## Summary by Sourcery

Bug Fixes:
- Remove commented lines in the lock-baseimages target loop to avoid shell syntax errors