### PR TITLE
fix: improve EAP detection robustness

### DIFF
--- a/docs/sudo_cmd_list.txt
+++ b/docs/sudo_cmd_list.txt
@@ -36,7 +36,7 @@ export LANG=C LC_ALL=C; dmidecode | grep -A4 'System Information' | grep 'Manufa
 export LANG=C LC_ALL=C; echo "user has sudo" 2>/dev/null
 export LANG=C LC_ALL=C; find {{search_directories}} -xdev -type f -name jboss-modules.jar 2> /dev/null | xargs -n 1 --no-run-if-empty dirname | sort -u
 export LANG=C LC_ALL=C; find {{search_directories}} -xdev -type f -name karaf.jar 2> /dev/null | sed -n -e 's/\(.*\)lib\/karaf\.jar$/\1/p' | xargs -n 1 --no-run-if-empty readlink --canonicalize | sort -u
-export LANG=C LC_ALL=C; for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*" 2>/dev/null); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
+export LANG=C LC_ALL=C; for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*" 2>/dev/null); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]\+/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
 export LANG=C LC_ALL=C; if command -v ifconfig >/dev/null ; then ifconfig -a; else hostname -I 2>/dev/null; fi
 export LANG=C LC_ALL=C; ifconfig -a |  grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'
 export LANG=C LC_ALL=C; ip address show | cat -

--- a/quipucords/scanner/network/processing/eap.py
+++ b/quipucords/scanner/network/processing/eap.py
@@ -181,7 +181,7 @@ class ProcessEapHomeVersionTxt(util.PerItemProcessor):
 
     KEY = "eap_home_version_txt"
     VERSION_RE = re.compile(
-        r"Red Hat JBoss Enterprise Application Platform - Version (.*)\.GA"
+        r"Red Hat JBoss Enterprise Application Platform - Version ([^\s]+)"
     )
 
     @staticmethod
@@ -191,7 +191,7 @@ class ProcessEapHomeVersionTxt(util.PerItemProcessor):
             return False
         match = ProcessEapHomeVersionTxt.VERSION_RE.match(item["stdout"].strip())
         if match:
-            return match.group(1)
+            return match.group(1).removesuffix(".GA")
 
         # If we found a version.txt file, this likely *is* JBoss EAP,
         # it's just a version file format that we don't recognize. If

--- a/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_eap/tasks/main.yml
@@ -6,7 +6,7 @@
 
 # Tasks that can locate an EAP_HOME directory
 - name: Gather jboss.eap.running-paths
-  raw: export LANG=C LC_ALL=C; for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*" 2>/dev/null); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
+  raw: export LANG=C LC_ALL=C; for proc_pid in $(find /proc -maxdepth 1 -xdev -name "[0-9]*" 2>/dev/null); do ls -l ${proc_pid}/fd 2>/dev/null | grep "java"; done | grep -e "/modules/system/layers/base\|/opt/rh/eap[0-9]\+/root/usr/share/wildfly" | sed -n "s/.*\-> //p" | sed -n 's/\/modules\/system\/layers\/base.*//p;s/\(.*wildfly\).*/\1/p' | sort -u
   register: internal_jboss_eap_running_paths
   ignore_errors: yes
   become: yes
@@ -183,6 +183,7 @@
     - /opt/hpom/share/jboss
     - /opt/jboss
     - /opt/rh/eap7
+    - /opt/rh/eap8
     - /usr/local/jee/jboss
     - /usr/log/jboss-as
     - /usr/share/jbossas
@@ -191,6 +192,10 @@
     - /usr/share/java/jboss-modules.jar
     - /usr/share/jbossas/jboss-modules.jar
     - /etc/init.d/jboss-as-standalone.sh
+    - /etc/systemd/system/jboss-eap-standalone.service
+    - /etc/systemd/system/jboss-eap-domain.service
+    - /usr/lib/systemd/system/jboss-eap-standalone.service
+    - /usr/lib/systemd/system/jboss-eap-domain.service
   when: 'user_has_sudo and jboss_eap'
 
 - name: set jboss_eap_common_files fact
@@ -210,7 +215,7 @@
   ignore_errors: yes
 
 - name: check for jboss packages
-  raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{NAME}|%{VERSION}|%{RELEASE}|%{INSTALLTIME}|%{VENDOR}|%{BUILDTIME}|%{BUILDHOST}|%{SOURCERPM}|%{LICENSE}|%{PACKAGER}|%{INSTALLTIME:date}|%{BUILDTIME:date}\n" | grep -E '(eap7)|(jbossas)' | sort
+  raw: export LANG=C LC_ALL=C; rpm -qa --qf "%{NAME}|%{VERSION}|%{RELEASE}|%{INSTALLTIME}|%{VENDOR}|%{BUILDTIME}|%{BUILDHOST}|%{SOURCERPM}|%{LICENSE}|%{PACKAGER}|%{INSTALLTIME:date}|%{BUILDTIME:date}\n" | grep -E '(eap[0-9]+)|(jbossas)' | sort
   register: internal_jboss_eap_packages
   ignore_errors: yes
   when: 'jboss_eap'

--- a/quipucords/tests/scanner/network/processing/test_eap.py
+++ b/quipucords/tests/scanner/network/processing/test_eap.py
@@ -181,6 +181,11 @@ class TestProcessEapHomeVersionTxt(unittest.TestCase):
     """Test scanning the contents of $EAP_HOME/version.txt."""
 
     cat_result = "Red Hat JBoss Enterprise Application Platform - Version 6.4.0.GA"
+    cat_result_no_ga = "Red Hat JBoss Enterprise Application Platform - Version 8.0"
+    cat_result_post_version = (
+        "Red Hat JBoss Enterprise Application Platform - Version"
+        " 8.1.0 General Availability"
+    )
 
     def test_three_dirs(self):
         """A directory can have three outcomes."""
@@ -194,10 +199,21 @@ class TestProcessEapHomeVersionTxt(unittest.TestCase):
                         {"item": "dir2", "rc": 1, "stdout": self.cat_result},
                         # dir3: cat was successful, output does not have 'Red Hat'.
                         {"item": "dir3", "stdout": "foo"},
+                        # dir4: cat was successful, stdout has 'Red Hat' but no .GA
+                        {"item": "dir4", "stdout": self.cat_result_no_ga},
+                        # dir5: cat was successful, stdout has 'Red Hat' and some
+                        # extra content after version
+                        {"item": "dir5", "stdout": self.cat_result_post_version},
                     ]
                 )
             ),
-            {"dir1": "6.4.0", "dir2": False, "dir3": "foo"},
+            {
+                "dir1": "6.4.0",
+                "dir2": False,
+                "dir3": "foo",
+                "dir4": "8.0",
+                "dir5": "8.1.0",
+            },
         )
 
 


### PR DESCRIPTION
JBoss EAP 8 was released in early 2024.

- Improve scanner regular expression to match eap followed by one or more digits. This hopefully will work with EAP 9, EAP 10 and other future versions.
- In EAP version.txt processing, make "GA" suffix optional. It is not present in EAP 8. When suffix was mandatory, `eap_home_version_txt` fact contained the whole `version.txt` content. Now that suffix is optional, the fact will contain only version number.

I had three distinct VMs with EAP 8 installed through different installation methods:
- `jboss-eap-installation-manager`
- archive installation
- RPM

I've ran network scan against all three of them.

Before this change, `deployments.json` file showed "present" for archive and RPM, but "potential" for jboss-eap-installation-manager.

After this change, `deployments.json` file shows "present" for all three of them.

Additionally, change `eap_home_version_txt` fact in `details.json` file. Before, it contained full content of `version.txt` file. Now it contains only version number.

Relates to JIRA: DISCOVERY-1277

## Summary by Sourcery

Improve robustness of JBoss EAP version detection across installations, including newer EAP releases.

Bug Fixes:
- Correct JBoss EAP home version parsing so the stored fact captures only the version number even when the GA suffix is absent.
- Broaden RPM-based JBoss EAP package detection to recognize EAP versions beyond 7 using a generic numeric pattern.