### PR TITLE
fix: Avoid common false positives in EAP and Fuse scans

### DIFF
--- a/quipucords/scanner/network/processing/eap.py
+++ b/quipucords/scanner/network/processing/eap.py
@@ -158,6 +158,7 @@ class ProcessJbossEapChkconfig(util.InitLineFinder):
     DEPS = ["internal_have_chkconfig"]
     KEY = "jboss_eap_chkconfig"
     KEYWORDS = ["jboss", "eap"]
+    IGNORE_WORDS = ["e2scrub_reap"]
 
 
 class ProcessJbossEapSystemctl(util.InitLineFinder):
@@ -166,6 +167,7 @@ class ProcessJbossEapSystemctl(util.InitLineFinder):
     DEPS = ["internal_have_systemctl"]
     KEY = "jboss_eap_systemctl_unit_files"
     KEYWORDS = ["jboss", "eap"]
+    IGNORE_WORDS = ["e2scrub_reap"]
 
 
 class ProcessEapHomeLs(util.IndicatorFileFinder):

--- a/quipucords/scanner/network/processing/karaf.py
+++ b/quipucords/scanner/network/processing/karaf.py
@@ -68,7 +68,7 @@ class ProcessJbossFuseSystemctl(util.InitLineFinder):
     DEPS = ["internal_have_systemctl"]
     KEY = "jboss_fuse_systemctl_unit_files"
     KEYWORDS = ["fuse"]
-    IGNORE_WORDS = ["sys-fs-fuse-connections.mount"]
+    IGNORE_WORDS = ["sys-fs-fuse-connections.mount", "fuse.mount"]
 
 
 class ProcessKarafHomeBinFuse(process.Processor):

--- a/quipucords/tests/scanner/network/processing/test_eap.py
+++ b/quipucords/tests/scanner/network/processing/test_eap.py
@@ -250,6 +250,29 @@ class TestProcessJbossEapInitFiles(unittest.TestCase):
                 ["eap bar"],
             )
 
+    def test_e2scrub_only(self):
+        """'e2scrub_reap' is a false positive."""
+        for processor in self.processors:
+            self.assertEqual(
+                processor.process(
+                    ansible_result("e2scrub_reap.service enabled enabled")
+                ),
+                [],
+            )
+
+    def test_e2scrub_and_jboss(self):
+        """'e2scrub_reap' is a false positive."""
+        for processor in self.processors:
+            self.assertEqual(
+                processor.process(
+                    ansible_result(
+                        "e2scrub_reap.service enabled enabled\n"
+                        "eap8-domain.service disabled disabled"
+                    )
+                ),
+                ["eap8-domain.service disabled disabled"],
+            )
+
 
 class TestProcessEapHomeBinForFuse(unittest.TestCase):
     """Test looking for fuse scripts."""

--- a/quipucords/tests/scanner/network/processing/test_karaf.py
+++ b/quipucords/tests/scanner/network/processing/test_karaf.py
@@ -88,6 +88,38 @@ class TestProcessKarafInitFiles(unittest.TestCase):
                 ["fuse bar"],
             )
 
+    def test_mount_only(self):
+        r"""'run-vmblock\x2dfuse.mount' is a false positive."""
+        for processor in self.processors:
+            expected = [r"run-vmblock\x2dfuse.mount  enabled enabled"]
+            if processor.IGNORE_WORDS is not None:
+                expected = []
+            self.assertEqual(
+                processor.process(
+                    ansible_result(r"run-vmblock\x2dfuse.mount  enabled enabled")
+                ),
+                expected,
+            )
+
+    def test_mount_and_custom_service(self):
+        r"""'run-vmblock\x2dfuse.mount' is a false positive."""
+        for processor in self.processors:
+            expected = [
+                r"run-vmblock\x2dfuse.mount  enabled enabled",
+                "fuse-server.service disabled disabled",
+            ]
+            if processor.IGNORE_WORDS is not None:
+                expected = ["fuse-server.service disabled disabled"]
+            self.assertEqual(
+                processor.process(
+                    ansible_result(
+                        r"run-vmblock\x2dfuse.mount  enabled enabled"
+                        "\nfuse-server.service disabled disabled"
+                    )
+                ),
+                expected,
+            )
+
 
 class TestProcessKarafHomeBinFuse(unittest.TestCase):
     """Test using locate to find karaf home bin fuse."""


### PR DESCRIPTION
On Fedora you can install `e2scrub` package that provides a service file. Before this change, deployments report showed EAP as "potential". After this change, it is shown as "absent".

On older RHEL versions service was provided by `e2fsprogs` package.

Relates to JIRA: DISCOVERY-1198

## Summary by Sourcery

Refine EAP and Fuse service detection to ignore known non-application system services and prevent false positives in scan results.

Bug Fixes:
- Treat the e2scrub_reap systemd service as an ignored unit when detecting JBoss EAP via chkconfig and systemd unit files.
- Extend Fuse/Karaf systemd processing to ignore generic fuse.mount variants that can cause false-positive Fuse detections.

Tests:
- Add EAP processor tests to assert that e2scrub_reap alone does not trigger EAP detection and is ignored when real EAP services are present.
- Add Karaf/Fuse processor tests to ensure fuse.mount-only units are ignored while still detecting valid Fuse-related services when present.