### PR TITLE
feat(vault): fetch credentials from HashiCorp Vault during OCP and AAP scans

### DIFF
--- a/quipucords/api/auth/hashicorp_vault/auth.py
+++ b/quipucords/api/auth/hashicorp_vault/auth.py
@@ -14,6 +14,7 @@ from urllib3.exceptions import HTTPError as BaseHTTPError
 
 import api.messages
 from api.secure_token.model import SecureToken
+from scanner.exceptions import ScanFailureError
 
 logger = getLogger(__name__)
 
@@ -231,3 +232,42 @@ def hashicorp_vault_authenticate(vault_token=None, metadata=None):
             raise HashiCorpVaultAuthError(
                 _(api.messages.HASHICORP_VAULT_HTTP_ERROR % (vault_address, str(err)))
             )
+
+
+def read_vault_secret(credential) -> str:
+    """Fetch a secret value from HashiCorp Vault using credential configuration."""
+    vault_token = get_hashicorp_vault_token()
+    if vault_token is None:
+        raise ScanFailureError(api.messages.VAULT_SECRET_NOT_CONFIGURED)
+
+    path = credential.vault_secret_path
+    mount_point = credential.vault_mount_point
+    secret_key = credential.vault_secret_key
+
+    try:
+        with hashicorp_vault_client(vault_token=vault_token) as client:
+            if not client.is_authenticated():
+                raise ScanFailureError(api.messages.VAULT_SECRET_AUTH_FAILED)
+            read_kwargs = {"path": path}
+            if mount_point:
+                read_kwargs["mount_point"] = mount_point
+            response = client.secrets.kv.v2.read_secret_version(**read_kwargs)
+    except (
+        hvac.exceptions.VaultError,
+        ConnectionError,
+        BaseHTTPError,
+        HashiCorpVaultAuthError,
+    ) as err:
+        raise ScanFailureError(
+            api.messages.VAULT_SECRET_FETCH_FAILED % (path, mount_point, err)
+        ) from err
+
+    secret_data = response.get("data", {}).get("data", {})
+    if not secret_data:
+        raise ScanFailureError(api.messages.VAULT_SECRET_NO_DATA % (path, mount_point))
+    value = secret_data.get(secret_key)
+    if not value:
+        raise ScanFailureError(
+            api.messages.VAULT_SECRET_MISSING_KEY % (secret_key, path)
+        )
+    return value

--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -192,6 +192,19 @@ USER_PASS_OR_VAULT = "A credential must have a username+password or vault_secret
 USER_PASS_OR_VAULT_NOT_BOTH = (
     "A credential must have either a username+password or vault_secret_path, not both."
 )
+VAULT_SECRET_AUTH_FAILED = (
+    "Failed to authenticate with HashiCorp Vault when reading credential secret."
+)
+VAULT_SECRET_FETCH_FAILED = (
+    "Failed to retrieve secret from HashiCorp Vault (path=%s, mount_point=%s): %s"
+)
+VAULT_SECRET_NOT_CONFIGURED = (
+    "Credential uses vault_secret_path but HashiCorp Vault is not configured."
+)
+VAULT_SECRET_NO_DATA = "Vault secret at path '%s' (mount_point='%s') returned no data."
+VAULT_SECRET_MISSING_KEY = (
+    "Vault secret does not contain the expected '%s' key (path='%s')."
+)
 
 # report messages
 REPORTS_TAR_ERROR = "An error occurred compressing files."

--- a/quipucords/scanner/ansible/api.py
+++ b/quipucords/scanner/ansible/api.py
@@ -30,8 +30,9 @@ class AnsibleControllerApi(Session):
         host,
         protocol,
         port,
-        username,
-        password,
+        username=None,
+        password=None,
+        auth_token=None,
         ssl_verify: bool = True,
         proxy_url: str = None,
     ):
@@ -43,13 +44,18 @@ class AnsibleControllerApi(Session):
         :param port: The port to use for connecting to the server.
         :param username: The username to use for connecting to the server.
         :param password: The password to use for connecting to the server.
+        :param auth_token: Bearer token for OAuth2 authentication.
         :param ssl_verify: Whether to verify the SSL certificate.
         :param proxy_url: proxy URL in the format 'http(s)://host:port'.
         """
         formatted_host = cls._format_host_for_url(host)
         base_uri = f"{protocol}://{formatted_host}:{port}"
-        auth = HTTPBasicAuth(username=username, password=password)
-        session = cls(base_url=base_uri, verify=ssl_verify, auth=auth)
+        if auth_token:
+            session = cls(base_url=base_uri, verify=ssl_verify)
+            session.headers["Authorization"] = f"Bearer {auth_token}"
+        else:
+            auth = HTTPBasicAuth(username=username, password=password)
+            session = cls(base_url=base_uri, verify=ssl_verify, auth=auth)
 
         proxies = {}
         if proxy_url:

--- a/quipucords/scanner/ansible/runner.py
+++ b/quipucords/scanner/ansible/runner.py
@@ -3,6 +3,7 @@
 from abc import ABCMeta
 from functools import cached_property
 
+from api.auth.hashicorp_vault.auth import read_vault_secret
 from api.models import ScanJob, ScanTask
 from api.vault import decrypt_data_as_unicode
 from scanner.ansible.api import AnsibleControllerApi
@@ -47,15 +48,19 @@ class AnsibleTaskRunner(ScanTaskRunner, metaclass=ABCMeta):
         ssl_enabled, ssl_verify = scan_task.source.get_ssl_options()
         credential = scan_task.source.single_credential
         proxy_url = scan_task.source.proxy_url
-        return {
+        conn = {
             "host": host,
-            "password": decrypt_data_as_unicode(credential.password),
             "port": port,
             "protocol": "https" if ssl_enabled else "http",
             "ssl_verify": ssl_verify,
-            "username": credential.username,
             "proxy_url": proxy_url,
         }
+        if credential.vault_secret_path:
+            conn["auth_token"] = read_vault_secret(credential)
+        else:
+            conn["username"] = credential.username
+            conn["password"] = decrypt_data_as_unicode(credential.password)
+        return conn
 
     @classmethod
     def get_client(cls, scan_task: ScanTask) -> AnsibleControllerApi:

--- a/quipucords/scanner/openshift/runner.py
+++ b/quipucords/scanner/openshift/runner.py
@@ -2,6 +2,7 @@
 
 from abc import ABCMeta
 
+from api.auth.hashicorp_vault.auth import read_vault_secret
 from api.models import ScanTask
 from api.vault import decrypt_data_as_unicode
 from scanner.openshift.api import OpenShiftApi
@@ -25,8 +26,10 @@ class OpenShiftTaskRunner(ScanTaskRunner, metaclass=ABCMeta):
             "ssl_verify": ssl_verify,
             "proxy_url": proxy_url,
         }
-        if credential.auth_token:
-            conn_info.update(auth_token=decrypt_data_as_unicode(credential.auth_token))
+        if credential.vault_secret_path:
+            conn_info["auth_token"] = read_vault_secret(credential)
+        elif credential.auth_token:
+            conn_info["auth_token"] = decrypt_data_as_unicode(credential.auth_token)
         else:
             conn_info.update(
                 username=credential.username,

--- a/quipucords/tests/api/auth/test_auth_hashicorp_vault.py
+++ b/quipucords/tests/api/auth/test_auth_hashicorp_vault.py
@@ -2,6 +2,7 @@
 
 import base64
 import http
+from unittest.mock import MagicMock, patch
 
 import hvac
 import pytest
@@ -27,7 +28,9 @@ from api.auth.hashicorp_vault.auth import (
     hashicorp_vault_authenticate,
     hashicorp_vault_client,
     hashicorp_vault_url,
+    read_vault_secret,
 )
+from scanner.exceptions import ScanFailureError
 
 HASHICORP_VAULT_VIEW = "v2:hashicorp-vault-list"
 
@@ -1148,3 +1151,222 @@ class TestHashiCorpVaultDelete:
 
         assert response1.status_code == http.HTTPStatus.NO_CONTENT
         assert response2.status_code == http.HTTPStatus.NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_happy_path():
+    """Test read_vault_secret returns the value for vault_secret_key on success."""
+    credential = MagicMock()
+    credential.vault_secret_path = "my/secret/path"
+    credential.vault_mount_point = "discovery"
+    credential.vault_secret_key = "auth_token"
+
+    mock_client = MagicMock()
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {
+        "data": {"data": {"auth_token": "tok"}}
+    }
+
+    with (
+        patch(
+            "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token"
+        ) as mock_get_token,
+        patch(
+            "api.auth.hashicorp_vault.auth.hashicorp_vault_client"
+        ) as mock_vault_client,
+    ):
+        mock_get_token.return_value = MagicMock()
+        mock_vault_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_vault_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = read_vault_secret(credential)
+
+    assert result == "tok"
+    mock_client.is_authenticated.assert_called_once()
+    mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+        path="my/secret/path", mount_point="discovery"
+    )
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_no_mount_point():
+    """Test read_vault_secret omits mount_point when not set."""
+    credential = MagicMock()
+    credential.vault_secret_path = "my/secret/path"
+    credential.vault_mount_point = ""
+    credential.vault_secret_key = "auth_token"
+
+    mock_client = MagicMock()
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {
+        "data": {"data": {"auth_token": "tok"}}
+    }
+
+    with (
+        patch(
+            "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token"
+        ) as mock_get_token,
+        patch(
+            "api.auth.hashicorp_vault.auth.hashicorp_vault_client"
+        ) as mock_vault_client,
+    ):
+        mock_get_token.return_value = MagicMock()
+        mock_vault_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_vault_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = read_vault_secret(credential)
+
+    assert result == "tok"
+    mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+        path="my/secret/path"
+    )
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_vault_not_configured():
+    """Test read_vault_secret raises ScanFailureError when Vault is not configured."""
+    credential = MagicMock()
+    credential.vault_secret_path = "my/secret/path"
+
+    with patch(
+        "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token", return_value=None
+    ):
+        with pytest.raises(ScanFailureError, match="not configured"):
+            read_vault_secret(credential)
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_missing_key():
+    """Test read_vault_secret raises ScanFailureError when key is missing."""
+    credential = MagicMock()
+    credential.vault_secret_path = "my/secret/path"
+    credential.vault_mount_point = ""
+    credential.vault_secret_key = "auth_token"
+
+    mock_client = MagicMock()
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {
+        "data": {"data": {"username": "admin"}}
+    }
+
+    with (
+        patch(
+            "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token"
+        ) as mock_get_token,
+        patch(
+            "api.auth.hashicorp_vault.auth.hashicorp_vault_client"
+        ) as mock_vault_client,
+    ):
+        mock_get_token.return_value = MagicMock()
+        mock_vault_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_vault_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(ScanFailureError, match="auth_token"):
+            read_vault_secret(credential)
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_no_data():
+    """Test read_vault_secret raises ScanFailureError when secret has no data."""
+    credential = MagicMock()
+    credential.vault_secret_path = "my/secret/path"
+    credential.vault_mount_point = "discovery"
+    credential.vault_secret_key = "auth_token"
+
+    mock_client = MagicMock()
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {"data": {"data": {}}}
+
+    with (
+        patch(
+            "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token"
+        ) as mock_get_token,
+        patch(
+            "api.auth.hashicorp_vault.auth.hashicorp_vault_client"
+        ) as mock_vault_client,
+    ):
+        mock_get_token.return_value = MagicMock()
+        mock_vault_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_vault_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(ScanFailureError, match="returned no data"):
+            read_vault_secret(credential)
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_authentication_failed():
+    """Test read_vault_secret raises ScanFailureError when not authenticated."""
+    credential = MagicMock()
+    credential.vault_secret_path = "my/secret/path"
+    credential.vault_mount_point = "discovery"
+    credential.vault_secret_key = "auth_token"
+
+    mock_client = MagicMock()
+    mock_client.is_authenticated.return_value = False
+
+    with (
+        patch(
+            "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token"
+        ) as mock_get_token,
+        patch(
+            "api.auth.hashicorp_vault.auth.hashicorp_vault_client"
+        ) as mock_vault_client,
+    ):
+        mock_get_token.return_value = MagicMock()
+        mock_vault_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_vault_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(ScanFailureError, match="Failed to authenticate"):
+            read_vault_secret(credential)
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_invalid_path():
+    """Test read_vault_secret raises ScanFailureError on invalid Vault path."""
+    credential = MagicMock()
+    credential.vault_secret_path = "bad/path"
+    credential.vault_mount_point = "discovery"
+    credential.vault_secret_key = "auth_token"
+
+    mock_client = MagicMock()
+    mock_client.secrets.kv.v2.read_secret_version.side_effect = (
+        hvac.exceptions.InvalidPath("not found")
+    )
+
+    with (
+        patch(
+            "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token"
+        ) as mock_get_token,
+        patch(
+            "api.auth.hashicorp_vault.auth.hashicorp_vault_client"
+        ) as mock_vault_client,
+    ):
+        mock_get_token.return_value = MagicMock()
+        mock_vault_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_vault_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(ScanFailureError, match="Failed to retrieve"):
+            read_vault_secret(credential)
+
+
+@pytest.mark.django_db
+def test_read_vault_secret_connection_error():
+    """Test read_vault_secret raises ScanFailureError on ConnectionError."""
+    credential = MagicMock()
+    credential.vault_secret_path = "my/secret/path"
+    credential.vault_mount_point = "discovery"
+    credential.vault_secret_key = "auth_token"
+
+    mock_client = MagicMock()
+    mock_client.is_authenticated.side_effect = ConnectionError("unreachable")
+
+    with (
+        patch(
+            "api.auth.hashicorp_vault.auth.get_hashicorp_vault_token"
+        ) as mock_get_token,
+        patch(
+            "api.auth.hashicorp_vault.auth.hashicorp_vault_client"
+        ) as mock_vault_client,
+    ):
+        mock_get_token.return_value = MagicMock()
+        mock_vault_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_vault_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(ScanFailureError, match="Failed to retrieve"):
+            read_vault_secret(credential)

--- a/quipucords/tests/scanner/ansible/test_api.py
+++ b/quipucords/tests/scanner/ansible/test_api.py
@@ -196,3 +196,32 @@ def test_ansible_api_instantiation_with_ipv6_host():
     )
 
     assert api.base_url == "https://[fd00:dead:beef::126]:6443"
+
+
+def test_ansible_api_instantiation_with_auth_token():
+    """Assert bearer token auth sets Authorization header without HTTPBasicAuth."""
+    api = AnsibleControllerApi.from_connection_info(
+        host="localhost",
+        protocol="https",
+        port=8443,
+        auth_token="my-bearer-token",
+        ssl_verify=True,
+    )
+
+    assert api.base_url == "https://localhost:8443"
+    assert api.headers["Authorization"] == "Bearer my-bearer-token"
+    assert api.auth is None
+
+
+def test_ansible_api_instantiation_with_user_pass_no_bearer():
+    """Assert username/password uses HTTPBasicAuth and no bearer header."""
+    api = AnsibleControllerApi.from_connection_info(
+        host="localhost",
+        protocol="https",
+        port=8443,
+        username="admin",
+        password="secret",
+    )
+
+    assert isinstance(api.auth, HTTPBasicAuth)
+    assert "Authorization" not in api.headers

--- a/quipucords/tests/scanner/ansible/test_inspect.py
+++ b/quipucords/tests/scanner/ansible/test_inspect.py
@@ -1,5 +1,7 @@
 """Test Ansible InspectTaskRunner."""
 
+from unittest.mock import patch
+
 import pytest
 
 from api.models import ScanTask
@@ -7,7 +9,8 @@ from constants import DataSources
 from scanner.ansible.exceptions import AnsibleApiDetectionError
 from scanner.ansible.inspect import InspectTaskRunner
 from scanner.ansible.runner import AnsibleTaskRunner
-from tests.factories import ScanTaskFactory
+from scanner.exceptions import ScanFailureError
+from tests.factories import CredentialFactory, ScanTaskFactory
 
 
 @pytest.fixture
@@ -71,3 +74,55 @@ def test_check_connection_handles_api_detection_error(
     failure_message, status = runner.check_connection()
     assert not mock_client.assert_called_once()
     assert status == ScanTask.FAILED
+
+
+@pytest.mark.django_db
+def test_get_connection_info_with_vault_credential():
+    """Test _get_connection_info fetches auth_token from Vault."""
+    cred = CredentialFactory(
+        cred_type=DataSources.ANSIBLE,
+        vault_secret_path="vault/dev/aap-token",
+        vault_mount_point="discovery",
+        vault_secret_key="auth_token",
+    )
+    scan_task = ScanTaskFactory(
+        source__credentials=[cred],
+        source__source_type=DataSources.ANSIBLE,
+        source__hosts=["10.0.0.1"],
+        source__port=443,
+    )
+
+    with patch(
+        "scanner.ansible.runner.read_vault_secret",
+        return_value="vault-fetched-token",
+    ) as mock_read:
+        conn_info = AnsibleTaskRunner._get_connection_info(scan_task)
+
+    mock_read.assert_called_once_with(cred)
+    assert conn_info["auth_token"] == "vault-fetched-token"
+    assert "username" not in conn_info
+    assert "password" not in conn_info
+
+
+@pytest.mark.django_db
+def test_get_connection_info_vault_failure_propagates():
+    """Test _get_connection_info propagates ScanFailureError from Vault."""
+    cred = CredentialFactory(
+        cred_type=DataSources.ANSIBLE,
+        vault_secret_path="vault/dev/aap-token",
+        vault_mount_point="discovery",
+        vault_secret_key="auth_token",
+    )
+    scan_task = ScanTaskFactory(
+        source__credentials=[cred],
+        source__source_type=DataSources.ANSIBLE,
+        source__hosts=["10.0.0.1"],
+        source__port=443,
+    )
+
+    with patch(
+        "scanner.ansible.runner.read_vault_secret",
+        side_effect=ScanFailureError("Vault unreachable"),
+    ):
+        with pytest.raises(ScanFailureError, match="Vault unreachable"):
+            AnsibleTaskRunner._get_connection_info(scan_task)

--- a/quipucords/tests/scanner/openshift/test_task.py
+++ b/quipucords/tests/scanner/openshift/test_task.py
@@ -1,7 +1,10 @@
 """Test OpenShiftTaskRunner."""
 
+from unittest.mock import patch
+
 import pytest
 
+from scanner.exceptions import ScanFailureError
 from scanner.openshift.api import OpenShiftApi
 from scanner.openshift.runner import OpenShiftTaskRunner
 from tests.factories import CredentialFactory, ScanTaskFactory
@@ -123,3 +126,61 @@ class TestGetOcpClient:
         )
         assert patched_kube_config.call_args == expected_kube_config_call
         assert patched_kube_config().verify_ssl == ssl_verify
+
+
+@pytest.mark.django_db
+def test_get_connection_info_with_vault_credential(mocker):
+    """Test _get_connection_info fetches auth_token from Vault."""
+    mocker.patch("scanner.openshift.api.ApiClient")
+    mocker.patch("scanner.openshift.api.DynamicClient")
+
+    cred = CredentialFactory(
+        cred_type="openshift",
+        vault_secret_path="vault/dev/ocp-token",
+        vault_mount_point="discovery",
+        vault_secret_key="auth_token",
+    )
+    scan_task = ScanTaskFactory(
+        source__credentials=[cred],
+        source__source_type="openshift",
+        source__hosts=["10.0.0.1"],
+        source__port=6443,
+    )
+
+    with patch(
+        "scanner.openshift.runner.read_vault_secret",
+        return_value="vault-fetched-token",
+    ) as mock_read:
+        conn_info = OpenShiftTaskRunner._get_connection_info(scan_task)
+
+    mock_read.assert_called_once_with(cred)
+    assert conn_info["auth_token"] == "vault-fetched-token"
+    assert "username" not in conn_info
+    assert "password" not in conn_info
+
+
+@pytest.mark.django_db
+def test_get_connection_info_vault_failure_propagates(mocker):
+    """Test _get_connection_info propagates ScanFailureError from Vault."""
+    mocker.patch("scanner.openshift.api.ApiClient")
+    mocker.patch("scanner.openshift.api.DynamicClient")
+
+    cred = CredentialFactory(
+        cred_type="openshift",
+        vault_secret_path="vault/dev/ocp-token",
+        vault_mount_point="discovery",
+        vault_secret_key="auth_token",
+    )
+    scan_task = ScanTaskFactory(
+        source__credentials=[cred],
+        source__source_type="openshift",
+        source__hosts=["10.0.0.1"],
+        source__port=6443,
+    )
+
+    with patch(
+        "scanner.openshift.runner.read_vault_secret",
+        side_effect=ScanFailureError("Vault unreachable"),
+    ):
+        with pytest.raises(ScanFailureError, match="Vault unreachable"):
+            OpenShiftTaskRunner._get_connection_info(scan_task)


### PR DESCRIPTION
## Summary

- Add `read_vault_secret` helper that authenticates to HashiCorp Vault via TLS cert
  and reads the `auth_token` from a KV v2 secret using the credential's
  `vault_secret_path` and `vault_mount_point`.
- Wire vault credential support into OpenShift scan tasks - when a credential has a
  `vault_secret_path`, the scanner fetches the bearer token from Vault at scan time
  instead of using stored credentials.
- Wire vault credential support into AAP scan tasks - same approach, plus extend
  `AnsibleControllerApi` to support bearer-token (OAuth2) authentication.

Credentials retrieved from Vault are never cached, logged, or persisted; they are
fetched fresh on every scan execution.

If Vault is unreachable or denies access, the scan task fails with an appropriate
error message via `ScanFailureError` → `ScanTask.FAILED`.

## Test plan

- [x] Unit tests for `read_vault_secret`: happy path, missing key, forbidden,
  invalid path, connection error, vault-not-configured.
- [x] Integration tests for OCP `_get_connection_info` with vault credential and
  failure propagation.
- [x] Integration tests for AAP `_get_connection_info` with vault credential and
  failure propagation.
- [x] Unit tests for `AnsibleControllerApi` bearer-token instantiation.
- [x] Manual test against a live Vault instance with TLS cert auth and KV v2 engine.

Relates to JIRA: DISCOVERY-1228

## Summary by Sourcery

Integrate HashiCorp Vault-backed bearer-token credentials into OpenShift and Ansible scan flows, including a shared Vault secret reader and updated Ansible controller API authentication behavior.

New Features:
- Add helper to fetch OAuth bearer tokens from HashiCorp Vault for credentials using a Vault secret path.
- Enable OpenShift scan tasks to retrieve authentication tokens from HashiCorp Vault at scan time instead of stored credentials.
- Enable Ansible Automation Platform scan tasks to retrieve authentication tokens from HashiCorp Vault and use bearer-token authentication in the controller API client.

Enhancements:
- Improve error messaging and failure handling when Vault is not configured, secrets are malformed, or Vault access fails.

Tests:
- Add unit tests for Vault secret retrieval helper covering success and multiple failure modes.
- Add integration-style tests ensuring OpenShift and Ansible scanners use Vault-backed credentials and propagate Vault errors.
- Add tests for AnsibleControllerApi instantiation with bearer tokens versus basic auth.