### PR TITLE
fix: Improve publish error messages

### DIFF
--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -213,8 +213,8 @@ REPORT_UNSUPPORTED_REPORT_TYPE = "Unsupported report_type %(report_type)s specif
 PUBLISH_NO_AUTH_TOKEN = "No authentication token found. Please log in first."
 PUBLISH_TOKEN_EXPIRED = "Authentication token has expired. Please log in again."
 PUBLISH_PAYLOAD_FAILED = "Failed to generate report payload: %s"
-PUBLISH_CONNECTION_ERROR = "Connection error: %s"
-PUBLISH_AUTH_REJECTED = "Authentication rejected by server: %s"
+PUBLISH_CONNECTION_ERROR = "Connection error: %s. Please try again later."
+PUBLISH_AUTH_REJECTED = "Authentication rejected by server: %s. Please log in again."
 PUBLISH_CLIENT_ERROR = (
     "Request rejected by ingress (%s): %s. This might be a bug in Discovery."
 )


### PR DESCRIPTION
- Improve a couple of the Lightspeed report publish error messages to include user recommendations (i.e. retry).

For: https://redhat.atlassian.net/browse/DISCOVERY-1215

## Summary by Sourcery

Clarify Lightspeed report publish error messages with specific user guidance for connection and authentication failures.

Enhancements:
- Improve connection error message to suggest retrying later.
- Improve authentication rejection message to instruct users to log in again.