### PR TITLE
feat: Set Job as "completed" if any task "completed"

### DIFF
--- a/quipucords/scanner/job.py
+++ b/quipucords/scanner/job.py
@@ -106,15 +106,12 @@ def run_task_runner(runner: ScanTaskRunner, *run_args):
     # Save Task status
     if task_status == ScanTask.CANCELED:
         runner.scan_task.status_cancel()
-        runner.scan_job.status_cancel()
     elif task_status == ScanTask.PAUSED:
         runner.scan_task.status_pause()
-        runner.scan_job.status_pause()
     elif task_status == ScanTask.COMPLETED:
         runner.scan_task.status_complete(status_message)
     elif task_status == ScanTask.FAILED:
         runner.scan_task.status_fail(status_message)
-        runner.scan_job.status_fail(status_message)
     else:
         error_message = (
             f"ScanTask {runner.scan_task.sequence_number:d} failed."

--- a/quipucords/scanner/tasks.py
+++ b/quipucords/scanner/tasks.py
@@ -2,6 +2,7 @@
 
 import functools
 import logging
+from collections import defaultdict
 
 import celery
 from django.conf import settings
@@ -246,14 +247,40 @@ def _finalize_scan(self: celery.Task, scan_job_id: int):
         scan_job.status_cancel()
         return
 
-    failed_tasks = (
+    tasks_status = (
         ScanTask.objects.filter(job_id=scan_job_id)
-        .exclude(status=ScanTask.COMPLETED)
-        .values("id")
+        .order_by("id")
+        .values("id", "status")
     )
-    if failed_tasks:
-        failed_tasks_ids = [task["id"] for task in failed_tasks]
-        error_message = f"The following tasks failed: {failed_tasks_ids}"
-        scan_job.status_fail(error_message)
-    else:
+    logger.info(
+        "Scan Job %s finalize_scan running based on %s tasks",
+        scan_job_id,
+        len(tasks_status),
+    )
+
+    if not tasks_status:
         scan_job.status_complete()
+        return
+
+    tasks_status_map = defaultdict(list)
+    for task in tasks_status:
+        tasks_status_map[task.get("status")].append(task.get("id"))
+    for status, task_ids in tasks_status_map.items():
+        logger.debug(
+            "Scan Job %s finalize_scan status %s tasks: %s",
+            scan_job_id,
+            status,
+            task_ids,
+        )
+
+    all_canceled = all(t["status"] == ScanTask.CANCELED for t in tasks_status)
+    if all_canceled:
+        scan_job.status_cancel()
+        return
+
+    any_complete = any(t["status"] == ScanTask.COMPLETED for t in tasks_status)
+    if any_complete:
+        scan_job.status_complete()
+        return
+
+    scan_job.status_fail("None of the tasks completed")

--- a/quipucords/tests/scanner/job/test_job_celery_based.py
+++ b/quipucords/tests/scanner/job/test_job_celery_based.py
@@ -11,6 +11,7 @@ you update or add more tests.
 
 from unittest.mock import patch
 
+import factory
 import pytest
 from django.test import override_settings
 
@@ -25,7 +26,7 @@ from tests.utils import fake_semver, raw_facts_generator
 def inspect_scan_job():
     """Prepare an "inspect" type ScanJob.
 
-    This ScanJob includes 3 ScanTasks: connect, inspect, and fingerprint.
+    This ScanJob includes 2 ScanTasks: inspect, and fingerprint.
     """
     scan_job = ScanJobFactory(
         scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.PENDING
@@ -53,13 +54,27 @@ def inspect_scan_job():
 def inspect_scan_job_multiple_sources():
     """Prepare an "inspect" type ScanJob with multiple Sources.
 
-    This ScanJob includes six ScanTasks: 2 connect (one per Source), 2 inspect (one per
-    source), and 1 fingerprint.
+    This ScanJob includes three ScanTasks: 2 inspect (one per source),
+    and 1 fingerprint.
     """
     scan_job = ScanJobFactory(
         scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.PENDING
     )
-    source_a, source_b = SourceFactory.create_batch(size=2)
+    # SourceFactory will create a Source with hosts=[], because it does not understand
+    # there should be addresses inside.
+    # Unfortunately, Ansible and RHACS expect hosts to have exactly one element, and
+    # if they are chosen for test_finalize_scan_endtoend, the test will fail when
+    # constructing a ScanTaskRunner.
+    # Using a subset of DataSources in this fixture is the least intrusive solution.
+    valid_source_types = (
+        DataSources.NETWORK,
+        DataSources.SATELLITE,
+        DataSources.VCENTER,
+        DataSources.OPENSHIFT,
+    )
+    source_a, source_b = SourceFactory.create_batch(
+        size=2, source_type=factory.Faker("random_element", elements=valid_source_types)
+    )
     scan_tasks = [
         ScanTaskFactory(
             job=scan_job,
@@ -233,3 +248,34 @@ def test_fingerprint_job_canceled(fingerprint_only_scanjob, mocker):
 
     fingerprint_only_scanjob.refresh_from_db()
     assert fingerprint_only_scanjob.status == ScanTask.CANCELED
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db(transaction=True)
+def test_finalize_scan_endtoend(
+    mock__fingerprint,
+    inspect_scan_job_multiple_sources,
+):
+    """Test finalize_scan flow end to end.
+
+    finalize_scan task is responsible for setting ScanJob status based on job.tasks
+    statuses. We have a coverage for this logic in test_finalize_scan.
+    The problem is, historically job status used to be set all over the place.
+    As a result, all test_finalize_scan tests passed, but Job was still presented
+    as failed instead of completed - because job status was set earlier.
+    This test exists to capture this situation.
+    """
+    job_runner = job.ScanJobRunner(inspect_scan_job_multiple_sources)
+    assert isinstance(job_runner, job.CeleryBasedScanJobRunner)
+
+    with patch.object(
+        job.ScanTaskRunner,
+        "run",
+        side_effect=(("Failure", ScanTask.FAILED), ("", ScanTask.COMPLETED)),
+    ) as mock_task_runner:
+        async_result = job_runner.run()
+        async_result.get()
+
+    assert mock_task_runner.call_count == 2
+    inspect_scan_job_multiple_sources.refresh_from_db()
+    assert inspect_scan_job_multiple_sources.status == ScanTask.COMPLETED

--- a/quipucords/tests/scanner/job/test_run_task_runner.py
+++ b/quipucords/tests/scanner/job/test_run_task_runner.py
@@ -8,7 +8,10 @@ from scanner import job
 
 @pytest.mark.django_db
 def test_run_task_runner_task_fails(mocker, faker):
-    """Test run_task_runner sets task and job statuses when the run fails."""
+    """Test run_task_runner sets task status when the run fails.
+
+    Job status will be set by finalize_scan task.
+    """
     expected_message = faker.sentence()
     expected_status = ScanTask.FAILED
 
@@ -20,4 +23,4 @@ def test_run_task_runner_task_fails(mocker, faker):
     runner_status = job.run_task_runner(runner=mock_runner)
     assert runner_status == expected_status
     mock_scan_task.status_fail.assert_called_once_with(expected_message)
-    mock_scan_job.status_fail.assert_called_once_with(expected_message)
+    mock_scan_job.status_fail.assert_not_called()

--- a/quipucords/tests/scanner/tasks/test_finalize_scan.py
+++ b/quipucords/tests/scanner/tasks/test_finalize_scan.py
@@ -10,34 +10,152 @@ from scanner import tasks
 from tests.factories import ScanJobFactory, ScanTaskFactory
 
 
+def log_task_ids(tasks):
+    """Format tasks ids as they will appear in log message."""
+    task_ids = ", ".join(str(t.id) for t in tasks)
+    return f"[{task_ids}]"
+
+
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @pytest.mark.django_db
-def test_finalize_scan_none_failed():
+def test_finalize_scan_all_complete(caplog):
     """Test finalize_scan sets job status COMPLETED if all tasks are COMPLETED."""
+    caplog.set_level(logging.DEBUG, logger="scanner.tasks")
     scan_job = ScanJobFactory(status=ScanTask.RUNNING)
-    scan_job.tasks.add(
-        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.COMPLETED)
-    )
+    scan_tasks = [
+        ScanTaskFactory(
+            scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.COMPLETED
+        ),
+        ScanTaskFactory(
+            scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.COMPLETED
+        ),
+    ]
+    scan_job.tasks.add(*scan_tasks)
 
     tasks.finalize_scan.delay(scan_job_id=scan_job.id).get()
 
     scan_job.refresh_from_db()
     assert scan_job.status == ScanTask.COMPLETED
+    log_message = (
+        f"Scan Job {scan_job.id} finalize_scan status "
+        f"{ScanTask.COMPLETED} tasks: {log_task_ids(scan_tasks)}"
+    )
+    assert log_message in caplog.messages
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @pytest.mark.django_db
-def test_finalize_scan_some_failed(caplog):
-    """Test finalize_scan sets job status FAILED if any task is not COMPLETED."""
-    caplog.set_level(logging.ERROR, logger="api.scanjob.model")
+def test_finalize_scan_all_failed(caplog):
+    """Test finalize_scan sets job status FAILED if all tasks are FAILED."""
+    caplog.set_level(logging.DEBUG, logger="scanner.tasks")
     scan_job = ScanJobFactory(status=ScanTask.RUNNING)
-    running_task = ScanTaskFactory(
-        scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.RUNNING
-    )
-    scan_job.tasks.add(running_task)
+    scan_tasks = [
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.FAILED),
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.FAILED),
+    ]
+    scan_job.tasks.add(*scan_tasks)
 
     tasks.finalize_scan.delay(scan_job_id=scan_job.id).get()
 
     scan_job.refresh_from_db()
     assert scan_job.status == ScanTask.FAILED
-    assert f"The following tasks failed: [{running_task.id}]" in caplog.messages[0]
+    log_message = (
+        f"Scan Job {scan_job.id} finalize_scan status "
+        f"{ScanTask.FAILED} tasks: {log_task_ids(scan_tasks)}"
+    )
+    assert log_message in caplog.messages
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db
+def test_finalize_scan_all_canceled(caplog):
+    """Test finalize_scan sets job status CANCELED if all tasks are CANCELED."""
+    caplog.set_level(logging.DEBUG, logger="scanner.tasks")
+    scan_job = ScanJobFactory(status=ScanTask.RUNNING)
+    scan_tasks = [
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.CANCELED),
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.CANCELED),
+    ]
+    scan_job.tasks.add(*scan_tasks)
+
+    tasks.finalize_scan.delay(scan_job_id=scan_job.id).get()
+
+    scan_job.refresh_from_db()
+    assert scan_job.status == ScanTask.CANCELED
+    log_message = (
+        f"Scan Job {scan_job.id} finalize_scan status "
+        f"{ScanTask.CANCELED} tasks: {log_task_ids(scan_tasks)}"
+    )
+    assert log_message in caplog.messages
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db
+def test_finalize_scan_all_running(caplog):
+    """Test finalize_scan sets job status FAILED if all tasks are RUNNING."""
+    caplog.set_level(logging.DEBUG, logger="scanner.tasks")
+    scan_job = ScanJobFactory(status=ScanTask.RUNNING)
+    scan_tasks = [
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.RUNNING),
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.RUNNING),
+    ]
+    scan_job.tasks.add(*scan_tasks)
+
+    tasks.finalize_scan.delay(scan_job_id=scan_job.id).get()
+
+    scan_job.refresh_from_db()
+    assert scan_job.status == ScanTask.FAILED
+    log_message = (
+        f"Scan Job {scan_job.id} finalize_scan status "
+        f"{ScanTask.RUNNING} tasks: {log_task_ids(scan_tasks)}"
+    )
+    assert log_message in caplog.messages
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db
+def test_finalize_scan_any_complete(caplog):
+    """Test finalize_scan sets job status COMPLETE if any task is COMPLETE."""
+    caplog.set_level(logging.DEBUG, logger="scanner.tasks")
+    scan_job = ScanJobFactory(status=ScanTask.RUNNING)
+    scan_tasks = [
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.RUNNING),
+        ScanTaskFactory(
+            scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.COMPLETED
+        ),
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.FAILED),
+        ScanTaskFactory(scan_type=ScanTask.SCAN_TYPE_INSPECT, status=ScanTask.CANCELED),
+    ]
+    scan_job.tasks.add(*scan_tasks)
+
+    tasks.finalize_scan.delay(scan_job_id=scan_job.id).get()
+
+    scan_job.refresh_from_db()
+    assert scan_job.status == ScanTask.COMPLETED
+    for scan_task in scan_tasks:
+        log_message = (
+            f"Scan Job {scan_job.id} finalize_scan status "
+            f"{scan_task.status} tasks: {log_task_ids([scan_task])}"
+        )
+        assert log_message in caplog.messages
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db
+def test_finalize_scan_completed_even_if_no_tasks_exist():
+    """
+    Test finalize_scan sets expected COMPLETED status if no tasks exist.
+
+    This is exercising a possibly unexpected edge case with our existing scan job logic
+    that we preserved when we wrote finalize_scan. If a task exists with not-COMPLETED
+    status, the job fails. Otherwise, it succeeds even if the job has zero tasks.
+    A scan with zero tasks reaching this part of the process *probably* never actually
+    happens in practice, but since our code technically allows it, I'm defining this
+    test so we know if/when this behavior changes.
+    """
+    scan_job = ScanJobFactory(status=ScanTask.RUNNING)
+
+    tasks.finalize_scan.delay(scan_job_id=scan_job.id).get()
+
+    scan_job.refresh_from_db()
+    assert scan_job.status == ScanTask.COMPLETED

--- a/quipucords/tests/scanner/tasks/test_tasks.py
+++ b/quipucords/tests/scanner/tasks/test_tasks.py
@@ -3,7 +3,6 @@
 import logging
 
 import pytest
-from django.test import override_settings
 
 from api.scanjob.model import ScanJob
 from api.scantask.model import ScanTask
@@ -17,49 +16,6 @@ class UnexpectedError(Exception):
     def __str__(self):
         """Get string representation."""
         return self.__class__.__name__
-
-
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-@pytest.mark.django_db
-def test_finalize_scan_completed_if_all_tasks_are_completed():
-    """Test finalize_scan sets expected COMPLETED status if all tasks are COMPLETED."""
-    scan_job = ScanJobFactory(status=ScanTask.RUNNING)
-    ScanTaskFactory(status=ScanTask.COMPLETED, job=scan_job)
-    ScanTaskFactory(status=ScanTask.COMPLETED, job=scan_job)
-    tasks.finalize_scan.delay(scan_job_id=scan_job.id)
-    scan_job.refresh_from_db()
-    assert scan_job.status == ScanTask.COMPLETED
-
-
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-@pytest.mark.django_db
-def test_finalize_scan_completed_even_if_no_tasks_exist():
-    """
-    Test finalize_scan sets expected COMPLETED status if no tasks exist.
-
-    This is exercising a possibly unexpected edge case with our existing scan job logic
-    that we preserved when we wrote finalize_scan. If a task exists with not-COMPLETED
-    status, the job fails. Otherwise, it succeeds even if the job has zero tasks.
-    A scan with zero tasks reaching this part of the process *probably* never actually
-    happens in practice, but since our code technically allows it, I'm defining this
-    test so we know if/when this behavior changes.
-    """
-    scan_job = ScanJobFactory(status=ScanTask.RUNNING)
-    tasks.finalize_scan.delay(scan_job_id=scan_job.id)
-    scan_job.refresh_from_db()
-    assert scan_job.status == ScanTask.COMPLETED
-
-
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-@pytest.mark.django_db
-def test_finalize_scan_failed_if_any_task_failed():
-    """Test finalize_scan sets expected FAILED status if any task failed."""
-    scan_job = ScanJobFactory(status=ScanTask.RUNNING)
-    ScanTaskFactory(status=ScanTask.FAILED, job=scan_job)
-    ScanTaskFactory(status=ScanTask.COMPLETED, job=scan_job)
-    tasks.finalize_scan.delay(scan_job_id=scan_job.id)
-    scan_job.refresh_from_db()
-    assert scan_job.status == ScanTask.FAILED
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
There are two commits.

The first changes logic in `finalize_scan` to consider entire ScanJob completed (succeeded) if any task inside succeeded. That fixes a problem of multi-source scans where one source has only invalid hosts.

The second ensures that `finalize_scan` will set a ScanJob status, at least in usual cases. Historically, ScanJob status was set all over the place, often in response to a failed task. In multi-source scan scenario, a source with only invalid hosts will fail faster, and would set entire ScanJob as failed even when the other source is being scanned. It would also prevent the logic from first commit, as ScanJob can't move from failed to completed.

Relates to JIRA: DISCOVERY-1363

## Summary by Sourcery

Adjust scan job finalization so job status is derived centrally from task outcomes, and add coverage to ensure multi-source scans complete successfully when any task completes.

Bug Fixes:
- Ensure multi-source scan jobs are marked completed when at least one source task completes successfully instead of remaining failed due to earlier task failures.

Enhancements:
- Centralize ScanJob status setting in finalize_scan based on aggregate task statuses, including handling for all-canceled and no-task edge cases and improved debug logging.
- Update end-to-end and unit tests around scan job/task execution to reflect the new status derivation rules and to avoid invalid source setups in tests.

Tests:
- Expand finalize_scan unit tests to cover combinations of task statuses and expected job status and logging.
- Add an end-to-end test for celery-based multi-source inspect jobs to verify that finalize_scan ultimately sets the job to completed when appropriate.
- Adjust existing task runner tests so job status is no longer set directly by individual task runs.