### PR TITLE
fix: Make regex detect double digits in JWS roles

### DIFF
--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -22,7 +22,7 @@
 
 # If client has not renamed default JWS_HOME folder and followed recommended zip file install instructions, JWS_HOME should be in /opt.
 - name: search for JWS_HOME in search directories
-  raw: export LANG=C LC_ALL=C; find {{search_directories}} -type d 2>/dev/null | egrep '(ews|jws).*[0-99]\.[0-99]$'
+  raw: export LANG=C LC_ALL=C; find {{search_directories}} -type d 2>/dev/null | egrep '(ews|jws).*[0-9]+\.[0-9]+$'
   register: internal_jws_find_home_from_search
   ignore_errors: yes
   when: 'jboss_ws_ext'
@@ -57,7 +57,7 @@
 
 # ------------------------------ DETECT JWS/EWS -------------------------------
 - name: check jws presence with yum
-  raw: "export LANG=C LC_ALL=C; yum -C grouplist {{item}} 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-99]'"
+  raw: "export LANG=C LC_ALL=C; yum -C grouplist {{item}} 2>/dev/null | grep -A1 'Installed Groups:' | grep 'Red Hat JBoss Web Server [0-9]\\+'"
   register: internal_jws_installed_with_rpm
   with_items:
     - jws3


### PR DESCRIPTION
`[0-99]` is likely meant as "any number between 0 and 99", but it means "any character out of {0 1 2 3 4 5 6 7 8 9 9}". The second "9" is pointless.

Because `egrep` used `.*` before number, `grep` has no line anchors and there was never a JWS release with double-digit minor version, this ended up not mattering so far. But let's keep the code aligned with intent.

## Summary by Sourcery

Correct JBoss Web Server detection patterns to properly handle numeric version components in paths and yum group names.

Bug Fixes:
- Fix JWS_HOME directory search regex to correctly match multi-digit numeric version segments.
- Fix yum-based JBoss Web Server presence check to correctly match numeric version identifiers in group names.