### PR TITLE
fix: Actually login to Vault

### DIFF
--- a/quipucords/api/auth/hashicorp_vault/auth.py
+++ b/quipucords/api/auth/hashicorp_vault/auth.py
@@ -206,6 +206,7 @@ def hashicorp_vault_authenticate(vault_token=None, metadata=None):
     ) as vault_client:
         vault_address = hashicorp_vault_address(metadata)
         try:
+            vault_client.auth.cert.login()
             if vault_client.is_authenticated():
                 logger.debug(api.messages.HASHICORP_VAULT_AUTHENTICATED, vault_address)
                 return
@@ -214,6 +215,21 @@ def hashicorp_vault_authenticate(vault_token=None, metadata=None):
             )
             raise HashiCorpVaultAuthError(
                 _(api.messages.HASHICORP_VAULT_FAILED_AUTHENTICATION % vault_address)
+            )
+        except hvac.exceptions.VaultError as err:
+            # VaultError is a parent for all errors coming from hvac module.
+            # Some known cases are:
+            # - VaultDown when Vault is sealed
+            # - Forbidden when cert authentication is disabled
+            # - InvalidRequest when provided certs do not match any user
+            logger.error(
+                api.messages.HASHICORP_VAULT_UPSTREAM_ERROR, vault_address, str(err)
+            )
+            raise HashiCorpVaultAuthError(
+                _(
+                    api.messages.HASHICORP_VAULT_UPSTREAM_ERROR
+                    % (vault_address, str(err))
+                )
             )
         except ConnectionError as err:
             logger.error(

--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -169,6 +169,9 @@ HASHICORP_VAULT_FAILED_DECODE_CERT = (
 )
 HASHICORP_VAULT_AUTHENTICATED = "Authenticated with HashiCorp Vault %s"
 HASHICORP_VAULT_FAILED_AUTHENTICATION = "Failed to authenticate to HashiCorp Vault %s"
+HASHICORP_VAULT_UPSTREAM_ERROR = (
+    "Failed to authenticate to HashiCorp Vault %s, VaultError: %s"
+)
 HASHICORP_VAULT_CONNECTION_ERROR = (
     "Failed to authenticate to HashiCorp Vault %s, ConnectionError: %s"
 )

--- a/quipucords/tests/api/auth/test_auth_hashicorp_vault.py
+++ b/quipucords/tests/api/auth/test_auth_hashicorp_vault.py
@@ -233,6 +233,32 @@ class TestHashiCorpVaultAuthenticate:
         )
         assert vault_err_message in str(exc_info.value)
 
+    def test_hashicorp_vault_authenticate_vault_error(
+        self, mocker, hashicorp_vault_data
+    ):
+        """Test authentication with vault error."""
+        vault_token = get_or_create_hashicorp_vault_token()
+        vault_token.metadata = hashicorp_vault_data
+        vault_token.save()
+
+        mock_client = mocker.MagicMock()
+        error_message = "failed to match all constraints for this login certificate"
+        mock_client.is_authenticated.side_effect = hvac.exceptions.InvalidRequest(
+            error_message
+        )
+        mocker.patch(
+            "api.auth.hashicorp_vault.auth.hvac.Client", return_value=mock_client
+        )
+
+        with pytest.raises(HashiCorpVaultAuthError) as exc_info:
+            hashicorp_vault_authenticate(vault_token=vault_token)
+        vault_address = hashicorp_vault_address(hashicorp_vault_data)
+        vault_err_message = (
+            messages.HASHICORP_VAULT_FAILED_AUTHENTICATION % vault_address
+        )
+        assert vault_err_message in str(exc_info.value)
+        assert f"VaultError: {error_message}" in str(exc_info.value)
+
     def test_hashicorp_vault_authenticate_connection_error(
         self, mocker, hashicorp_vault_data
     ):


### PR DESCRIPTION
Explicitly call `vault_client.auth.cert.login()` to log in using provided certificates.

hvac.Client() will read token from `~/.vault-token`. If developer ever did `vault login` and then ran quipucords through dev server, it appeared that client is correctly authenticating to Vault - but it is using token created `vault` binary.

When quipucords was running in container, it never had `~/.vault-token` and `qpc vault add` always failed.

The returned error message is a bit awkward, with duplicated host:
    Error: Failed to authenticate to HashiCorp Vault 127.0.0.1:8200, VaultError: failed to match all constraints for this login certificate, on post https://127.0.01:8200/v1/auth/cert/login

The first host is kept for consistency with other Vault authentication error conditions. The second host (full API URL) comes from hvac library.

## Summary by Sourcery

Ensure certificate-based authentication to HashiCorp Vault is explicitly performed and surfaced with clearer upstream error handling.

Bug Fixes:
- Trigger explicit cert-based login to Vault instead of relying on any pre-existing token state.

Enhancements:
- Add dedicated handling and messaging for generic VaultError conditions from the hvac client during authentication.

Tests:
- Extend HashiCorp Vault authentication tests to cover upstream VaultError scenarios and verify improved error messages.