### PR TITLE
fix: Actually login to Vault when reading secret

### DIFF
--- a/quipucords/api/auth/hashicorp_vault/auth.py
+++ b/quipucords/api/auth/hashicorp_vault/auth.py
@@ -262,6 +262,7 @@ def read_vault_secret(credential) -> str:
 
     try:
         with hashicorp_vault_client(vault_token=vault_token) as client:
+            client.auth.cert.login()
             if not client.is_authenticated():
                 raise ScanFailureError(api.messages.VAULT_SECRET_AUTH_FAILED)
             read_kwargs = {"path": path}


### PR DESCRIPTION
This is fundamentally the same as 94182c204490542a13f2f20a8f2af2427c9685c2 (#3205 ) , just in one more place.

There are no more references to hashicorp_vault_client without explicit login in the codebase, so it should be the last one.

## Summary by Sourcery

Bug Fixes:
- Perform an explicit certificate-based login on the Vault client before checking authentication and reading a secret.