### PR TITLE
build: bump quipucords version to 2.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["quipucords"]
 
 [project]
 name = "quipucords"
-version = "2.6.1"
+version = "2.6.2"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 requires-python = "<3.14,>=3.12"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1975,7 +1975,7 @@ wheels = [
 
 [[package]]
 name = "quipucords"
-version = "2.6.1"
+version = "2.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update pyproject configuration to reflect the new 2.6.2 release version.