### PR TITLE
build: bump quipucords version to 2.6.3

### DIFF
--- a/.tekton/discovery-server-push.yaml
+++ b/.tekton/discovery-server-push.yaml
@@ -170,7 +170,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:89da85c1508b3a2b7ad884c1215b9fd3a7d9e28c2335aca6750948d129707035
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
         - name: kind
           value: task
         resolver: bundles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["quipucords"]
 
 [project]
 name = "quipucords"
-version = "2.6.2"
+version = "2.6.3"
 description = "Tool for discovery, inspection, collection, deduplication, and reporting on an IT environment."
 requires-python = "<3.14,>=3.12"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1975,7 +1975,7 @@ wheels = [
 
 [[package]]
 name = "quipucords"
-version = "2.6.2"
+version = "2.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "ansible", marker = "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')" },


### PR DESCRIPTION
…with a small fix to the pipeline that builds downstream artifacts. Literally no changes upstream other than the version bump.

## Summary by Sourcery

Bump the quipucords project version to 2.6.3 and adjust the downstream discovery server Tekton pipeline to use an updated git-clone OCI task bundle.

Enhancements:
- Update project metadata to reflect quipucords version 2.6.3.

Build:
- Switch the discovery-server Tekton pipeline to a different git-clone-oci-ta bundle reference for building downstream artifacts.