### PR TITLE
build: upgrade task-git-clone-oci-ta from 0.1 to 0.2

### DIFF
--- a/.tekton/discovery-server-pull-request.yaml
+++ b/.tekton/discovery-server-pull-request.yaml
@@ -180,7 +180,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:89da85c1508b3a2b7ad884c1215b9fd3a7d9e28c2335aca6750948d129707035
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/discovery-server-push.yaml
+++ b/.tekton/discovery-server-push.yaml
@@ -170,7 +170,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:89da85c1508b3a2b7ad884c1215b9fd3a7d9e28c2335aca6750948d129707035
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Reverting the previous commits that downgraded task-git-clone-oci-ta back to 0.1 because Konflux support claims 0.2 should be allowed.

- git revert 58e62f86812ee37e8df48967725e8dcb567aa17d
- git revert 6d2e39e02b0df2958a34d3f82527c72a307703b4

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1782922660431769?thread_ts=1782377560.929869&cid=C04PZ7H0VA8

> v0.2 was reintroduced in the bundle a couple of days ago

## Summary by Sourcery

Build:
- Update Tekton pipeline bundle image for git-clone-oci-ta from v0.1 to v0.2 in discovery server CI configurations.