### PR TITLE
feat(api): add scan_name and scan_id filter to reports API

### DIFF
--- a/quipucords/api/report/serializer.py
+++ b/quipucords/api/report/serializer.py
@@ -43,6 +43,7 @@ class ReportSerializer(ModelSerializer):
     """Report Serializer."""
 
     scan_id = ReadOnlyField(source="scanjob.scan_id")
+    scan_name = ReadOnlyField(source="scanjob.scan.name", default=None)
     can_publish = SerializerMethodField()
     cannot_publish_reason = SerializerMethodField()
     cannot_download_reason = SerializerMethodField()
@@ -59,6 +60,7 @@ class ReportSerializer(ModelSerializer):
             "report_platform_id",
             "origin",
             "scan_id",
+            "scan_name",
             "can_publish",
             "cannot_publish_reason",
             "can_download",

--- a/quipucords/api/report/view.py
+++ b/quipucords/api/report/view.py
@@ -2,6 +2,7 @@
 
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
+from django_filters import NumberFilter
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -51,6 +52,8 @@ class RawFactsReportView(ReportViewMixin, ListAPIView):
 
 class ReportFilter(FilterSet):
     """Filter for reports."""
+
+    scan_id = NumberFilter(field_name="scanjob__scan_id")
 
     class Meta:
         """Metadata for filterset."""

--- a/quipucords/api/report/view.py
+++ b/quipucords/api/report/view.py
@@ -66,7 +66,7 @@ class ReportFilter(FilterSet):
 class ReportViewSet(ReadOnlyModelViewSet):
     """A view set for Reports."""
 
-    queryset = Report.objects.select_related("scanjob")
+    queryset = Report.objects.select_related("scanjob__scan")
     serializer_class = ReportSerializer
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filterset_class = ReportFilter

--- a/quipucords/tests/api/report/test_reports.py
+++ b/quipucords/tests/api/report/test_reports.py
@@ -54,7 +54,12 @@ from tests.constants import (
     FILENAME_LIGHTSPEED_TGZ,
     FILENAME_SHA256SUM,
 )
-from tests.factories import DeploymentReportFactory, ReportFactory
+from tests.factories import (
+    DeploymentReportFactory,
+    ReportFactory,
+    ScanFactory,
+    ScanJobFactory,
+)
 from tests.report_utils import extract_files_from_tarball
 from tests.utils import raw_facts_generator
 from tests.utils.auth import create_lightspeed_secure_token
@@ -620,3 +625,48 @@ def test_cannot_download_deployments_failed():
         deployment.report.cannot_download_reason
         == ReportCannotDownloadReason.STATUS_FAILED
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_report_with_scan_includes_scan_name(client_logged_in):
+    """Test that v2 reports detail includes the originating scan's name."""
+    scan = ScanFactory()
+    scan_job = ScanJobFactory(scan=scan)
+    report = ReportFactory(scanjob=scan_job)
+
+    response = client_logged_in.get(reverse("v2:reports-detail", args=(report.id,)))
+    assert response.ok, response.text
+    assert response.json()["scan_name"] == scan.name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_report_without_scan_has_null_scan_name(client_logged_in):
+    """Test that scan_name is None when no scan is linked (e.g. uploaded reports)."""
+    report = ReportFactory()
+
+    detail_response = client_logged_in.get(
+        reverse("v2:reports-detail", args=(report.id,))
+    )
+    assert detail_response.ok, detail_response.text
+    assert detail_response.json()["scan_name"] is None
+
+    list_response = client_logged_in.get(reverse("v2:reports-list"))
+    assert list_response.ok, list_response.text
+    results = list_response.json()["results"]
+    assert results[0]["scan_name"] is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_reports_filter_by_scan_id(client_logged_in):
+    """Test that reports list can be filtered by scan_id."""
+    scan1 = ScanFactory()
+    scan2 = ScanFactory()
+    report1 = ReportFactory(scanjob=ScanJobFactory(scan=scan1))
+    ReportFactory(scanjob=ScanJobFactory(scan=scan2))
+
+    response = client_logged_in.get(reverse("v2:reports-list"), {"scan_id": scan1.id})
+    assert response.ok, response.text
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == report1.id
+    assert results[0]["scan_name"] == scan1.name


### PR DESCRIPTION
Two small API additions to support improved data in the reports table view in quipucords-ui:

- `scan_name` field: The report list and detail endpoints now include the originating scan's name (via `scanjob.scan.name`), or `null` for reports that don't have a related scan (uploaded or merged reports don't have scans).
- `scan_id` filter: The reports list endpoint (`GET /api/v2/reports/`) now accepts a `scan_id` query parameter to return only reports from a specific scan.

Relates to JIRA: DISCOVERY-1343

## Summary by Sourcery

Expose scan metadata on reports and allow filtering reports by originating scan in the v2 reports API.

New Features:
- Add scan_name to report API responses to surface the originating scan's name.
- Allow filtering the reports list by scan_id to return reports from a specific scan.

Tests:
- Add API tests validating scan_name presence or null value on report detail responses.
- Add API test verifying reports list filtering by scan_id returns only matching reports.