### PR TITLE
feat(api): add search_by_scan_name filter to reports list endpoint, and add ordering by scan_id and scan_name

### DIFF
--- a/quipucords/api/report/view.py
+++ b/quipucords/api/report/view.py
@@ -2,7 +2,7 @@
 
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
-from django_filters import NumberFilter
+from django_filters import CharFilter, NumberFilter
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -54,6 +54,9 @@ class ReportFilter(FilterSet):
     """Filter for reports."""
 
     scan_id = NumberFilter(field_name="scanjob__scan_id")
+    search_by_scan_name = CharFilter(
+        field_name="scanjob__scan__name", lookup_expr="icontains", distinct=True
+    )
 
     class Meta:
         """Metadata for filterset."""

--- a/quipucords/api/report/view.py
+++ b/quipucords/api/report/view.py
@@ -1,5 +1,6 @@
 """Report view."""
 
+from django.db.models import F
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from django_filters import CharFilter, NumberFilter
@@ -72,11 +73,14 @@ class ReportFilter(FilterSet):
 class ReportViewSet(ReadOnlyModelViewSet):
     """A view set for Reports."""
 
-    queryset = Report.objects.select_related("scanjob__scan")
+    queryset = Report.objects.select_related("scanjob__scan").annotate(
+        scan_id=F("scanjob__scan_id"),
+        scan_name=F("scanjob__scan__name"),
+    )
     serializer_class = ReportSerializer
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filterset_class = ReportFilter
-    ordering_fields = ("id", "origin", "created_at")
+    ordering_fields = ("id", "origin", "created_at", "scan_id", "scan_name")
     ordering = ("-created_at",)
 
 

--- a/quipucords/tests/api/report/test_reports.py
+++ b/quipucords/tests/api/report/test_reports.py
@@ -670,3 +670,21 @@ def test_reports_filter_by_scan_id(client_logged_in):
     assert len(results) == 1
     assert results[0]["id"] == report1.id
     assert results[0]["scan_name"] == scan1.name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_reports_filter_by_scan_name(client_logged_in):
+    """Test that reports list can be filtered by scan name."""
+    scan1 = ScanFactory(name="Alpha-Scan")
+    scan2 = ScanFactory(name="Beta-Scan")
+    report1 = ReportFactory(scanjob=ScanJobFactory(scan=scan1))
+    ReportFactory(scanjob=ScanJobFactory(scan=scan2))
+
+    response = client_logged_in.get(
+        reverse("v2:reports-list"), {"search_by_scan_name": "alpha"}
+    )
+    assert response.ok, response.text
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == report1.id
+    assert results[0]["scan_name"] == scan1.name

--- a/quipucords/tests/api/report/test_reports.py
+++ b/quipucords/tests/api/report/test_reports.py
@@ -688,3 +688,39 @@ def test_reports_filter_by_scan_name(client_logged_in):
     assert len(results) == 1
     assert results[0]["id"] == report1.id
     assert results[0]["scan_name"] == scan1.name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_reports_order_by_scan_id(client_logged_in):
+    """Test that reports list can be sorted by scan_id."""
+    scan1 = ScanFactory()
+    scan2 = ScanFactory()
+    report1 = ReportFactory(scanjob=ScanJobFactory(scan=scan1))
+    report2 = ReportFactory(scanjob=ScanJobFactory(scan=scan2))
+
+    response = client_logged_in.get(reverse("v2:reports-list"), {"ordering": "scan_id"})
+    assert response.ok, response.text
+    ids = [r["id"] for r in response.json()["results"]]
+    expected = sorted(
+        [report1.id, report2.id],
+        key=lambda rid: (
+            report1.scanjob.scan_id if rid == report1.id else report2.scanjob.scan_id
+        ),
+    )
+    assert ids == expected
+
+
+@pytest.mark.django_db(transaction=True)
+def test_reports_order_by_scan_name(client_logged_in):
+    """Test that reports list can be sorted by scan_name."""
+    scan1 = ScanFactory(name="Zeta-Scan")
+    scan2 = ScanFactory(name="Alpha-Scan")
+    report1 = ReportFactory(scanjob=ScanJobFactory(scan=scan1))
+    report2 = ReportFactory(scanjob=ScanJobFactory(scan=scan2))
+
+    response = client_logged_in.get(
+        reverse("v2:reports-list"), {"ordering": "scan_name"}
+    )
+    assert response.ok, response.text
+    ids = [r["id"] for r in response.json()["results"]]
+    assert ids == [report2.id, report1.id]  # Alpha before Zeta


### PR DESCRIPTION
Allows filtering GET /api/v2/reports/ by scan name substring (case-insensitive), matching the search_by_name pattern used by credential and scan list endpoints.

Allow sorting GET /api/v2/reports/ results by scan_id and scan_name.

This is a followup to https://github.com/quipucords/quipucords/pull/3240 and is required for https://github.com/quipucords/quipucords-ui/pull/979

Relates to JIRA: DISCOVERY-1343

Assisted-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Add scan name-based filtering and sorting options to the reports list API endpoint.

New Features:
- Allow reports list API results to be filtered by a case-insensitive scan name substring via a search_by_scan_name query parameter.
- Enable ordering of reports list API results by scan_id and scan_name.

Tests:
- Add tests covering filtering reports by scan name and ordering reports by scan_id and scan_name.