### PR TITLE
fix: Remove vault's ssl_verify option and require the CA_CERT

### DIFF
--- a/quipucords/api/auth/hashicorp_vault/auth.py
+++ b/quipucords/api/auth/hashicorp_vault/auth.py
@@ -147,7 +147,6 @@ def hashicorp_vault_client(vault_token=None, metadata=None):
         metadata = vault_token.metadata
     if metadata is None:
         metadata = {}
-    ssl_verify = metadata.get("ssl_verify", True)
     vault_url = hashicorp_vault_url(metadata)
     client_cert_content = hashicorp_cert_file(
         HASHICORP_VAULT_CLIENT_CERT, metadata.get(HASHICORP_VAULT_CLIENT_CERT, None)
@@ -169,6 +168,11 @@ def hashicorp_vault_client(vault_token=None, metadata=None):
             _(api.messages.HASHICORP_VAULT_VALID_CLIENT_KEY_REQUIRED)
         )
 
+    if ca_file_content is None:
+        raise HashiCorpVaultAuthError(
+            _(api.messages.HASHICORP_VAULT_VALID_CA_CERT_REQUIRED)
+        )
+
     with (
         tempfile.NamedTemporaryFile(delete=True) as cert_file,
         tempfile.NamedTemporaryFile(delete=True) as key_file,
@@ -178,19 +182,13 @@ def hashicorp_vault_client(vault_token=None, metadata=None):
         cert_file.flush()
         key_file.write(client_key_content.encode("utf-8"))
         key_file.flush()
-
-        if ssl_verify:
-            if ca_file_content is None:
-                raise HashiCorpVaultAuthError(
-                    _(api.messages.HASHICORP_VAULT_VALID_CA_CERT_REQUIRED)
-                )
-            ca_file.write(ca_file_content.encode("utf-8"))
-            ca_file.flush()
+        ca_file.write(ca_file_content.encode("utf-8"))
+        ca_file.flush()
 
         hvac_client_args = {
             "url": vault_url,
             "cert": (cert_file.name, key_file.name),
-            "verify": False if not ssl_verify else ca_file.name,
+            "verify": ca_file.name,
             "timeout": settings.QUIPUCORDS_HASHICORP_VAULT_TIMEOUT,
         }
 

--- a/quipucords/api/auth/hashicorp_vault/serializer.py
+++ b/quipucords/api/auth/hashicorp_vault/serializer.py
@@ -30,10 +30,9 @@ class HashiCorpVaultSerializer(serializers.Serializer):
     port = serializers.IntegerField(
         required=False, default=settings.QUIPUCORDS_HASHICORP_VAULT_DEFAULT_PORT
     )
-    ssl_verify = serializers.BooleanField(required=False, default=True)
     client_key = serializers.CharField(required=True, max_length=CLIENT_KEY_MAX_SIZE)
     client_cert = serializers.CharField(required=True, max_length=CLIENT_CERT_MAX_SIZE)
-    ca_cert = serializers.CharField(required=False, max_length=CA_CERT_MAX_SIZE)
+    ca_cert = serializers.CharField(required=True, max_length=CA_CERT_MAX_SIZE)
 
     class Meta:
         """Metadata for the serializer."""
@@ -114,17 +113,6 @@ class HashiCorpVaultSerializer(serializers.Serializer):
     def validate(self, data):
         """Validate the data is valid and we can communicate with HashiCorp Vault."""
         attrs = super().validate(data)
-
-        errors = {}
-        ssl_verify = attrs.get("ssl_verify", True)
-        if ssl_verify and attrs.get(HASHICORP_VAULT_CA_CERT, None) is None:
-            errors[HASHICORP_VAULT_CA_CERT] = _(
-                api.messages.HASHICORP_VAULT_MUST_SPECIFY_CA_CERT
-            )
-
-        if errors:
-            raise ValidationError(errors)
-
         hashicorp_vault_authenticate(metadata=attrs)
         return attrs
 
@@ -134,4 +122,3 @@ class HashiCorpVaultResponseSerializer(serializers.Serializer):
 
     address = serializers.CharField(required=True)
     port = serializers.IntegerField(required=True)
-    ssl_verify = serializers.BooleanField(required=True)

--- a/quipucords/api/auth/hashicorp_vault/view.py
+++ b/quipucords/api/auth/hashicorp_vault/view.py
@@ -98,7 +98,6 @@ class HashiCorpVaultViewSet(viewsets.GenericViewSet):
                         value={
                             "address": "vault.example.com",
                             "port": 8200,
-                            "ssl_verify": False,
                         },
                     )
                 ],
@@ -131,9 +130,9 @@ class HashiCorpVaultViewSet(viewsets.GenericViewSet):
                     value={
                         "address": "vault.example.com",
                         "port": 8200,
-                        "ssl_verify": False,
                         "client_cert": "....",
                         "client_key": "....",
+                        "ca_cert": "....",
                     },
                     request_only=True,
                 ),
@@ -149,7 +148,6 @@ class HashiCorpVaultViewSet(viewsets.GenericViewSet):
                         value={
                             "address": "vault.example.com",
                             "port": 8200,
-                            "ssl_verify": False,
                         },
                     )
                 ],
@@ -204,7 +202,6 @@ class HashiCorpVaultViewSet(viewsets.GenericViewSet):
                     value={
                         "address": "newvault.example.com",
                         "port": 8210,
-                        "ssl_verify": True,
                         "client_cert": "....",
                         "client_key": "....",
                         "ca_cert": "....",
@@ -223,7 +220,6 @@ class HashiCorpVaultViewSet(viewsets.GenericViewSet):
                         value={
                             "address": "newvault.example.com",
                             "port": 8210,
-                            "ssl_verify": True,
                         },
                     )
                 ],
@@ -288,7 +284,6 @@ class HashiCorpVaultViewSet(viewsets.GenericViewSet):
                         value={
                             "address": "newvault.example.com",
                             "port": 8230,
-                            "ssl_verify": True,
                         },
                     )
                 ],

--- a/quipucords/api/auth/hashicorp_vault/view.py
+++ b/quipucords/api/auth/hashicorp_vault/view.py
@@ -125,8 +125,9 @@ class HashiCorpVaultViewSet(viewsets.GenericViewSet):
                 OpenApiExample(
                     "Request to define a HashiCorp Vault server",
                     description="HashiCorp Vault server definition with a client"
-                    " certificate and key. client_cert and client_key are single line"
-                    " base64 encodings of the certificate pem files.",
+                    " certificate, key and CA cert. client_cert, client_key and"
+                    " ca_cert are single line base64 encodings of the certificate"
+                    " pem files.",
                     value={
                         "address": "vault.example.com",
                         "port": 8200,

--- a/quipucords/api/messages.py
+++ b/quipucords/api/messages.py
@@ -150,7 +150,6 @@ LIGHTSPEED_ALREADY_LOGGED_OUT = "Already logged out"
 # HashiCorp Vault messages
 HASHICORP_VAULT_NOT_DEFINED = "HashiCorp Vault server is not defined"
 HASHICORP_VAULT_ALREADY_EXISTS = "HashiCorp Vault server definition already exists"
-HASHICORP_VAULT_MUST_SPECIFY_CA_CERT = "Must specify a ca_cert when ssl_verify is True"
 HASHICORP_VAULT_INVALID_ADDRESS = "Address must be a valid FQDN, IPv4 or IPv6 address"
 HASHICORP_VAULT_VALID_CLIENT_CERT_REQUIRED = (
     "Valid client certificate is required for HashiCorp Vault authentication"

--- a/quipucords/tests/api/auth/conftest.py
+++ b/quipucords/tests/api/auth/conftest.py
@@ -154,14 +154,7 @@ def hashicorp_vault_data(hashicorp_vault_cert_content, hashicorp_vault_key_conte
     return {
         "address": "vault.example.com",
         "port": 8200,
-        "ssl_verify": False,
         "client_cert": client_cert_b64,
         "client_key": client_key_b64,
         "ca_cert": ca_cert_b64,
     }
-
-
-@pytest.fixture()
-def hashicorp_vault_data_with_ssl(hashicorp_vault_data):
-    """Return a valid HashiCorp Vault server definition with SSL verification."""
-    return {**hashicorp_vault_data, "ssl_verify": True}

--- a/quipucords/tests/api/auth/test_auth_hashicorp_vault.py
+++ b/quipucords/tests/api/auth/test_auth_hashicorp_vault.py
@@ -167,7 +167,6 @@ class TestHashiCorpVaultHelpers:
         invalid_cert = "not-valid-base64!@#$"
         vault_token = get_or_create_hashicorp_vault_token()
         vault_token.metadata = hashicorp_vault_data | {
-            "ssl_verify": True,
             HASHICORP_VAULT_CA_CERT: invalid_cert,
         }
         vault_token.save()
@@ -346,7 +345,6 @@ class TestHashiCorpVaultCreate:
         assert response.data == {
             "address": "vault.example.com",
             "port": 8200,
-            "ssl_verify": False,
         }
 
     def test_create_hashicorp_vault_already_exists(
@@ -458,40 +456,6 @@ class TestHashiCorpVaultCreate:
         assert response.status_code == http.HTTPStatus.BAD_REQUEST
         err_message = response.data["address"][0]
         assert messages.HASHICORP_VAULT_INVALID_ADDRESS in str(err_message)
-
-    def test_create_hashicorp_vault_invalid_ssl_verify(
-        self, client_logged_in, hashicorp_vault_data
-    ):
-        """Test creating a HashiCorp Vault with an invalid ssl_verify."""
-        invalid_data = {**hashicorp_vault_data}
-        invalid_data["ssl_verify"] = "Not-Boolean"
-
-        response = client_logged_in.post(
-            reverse(HASHICORP_VAULT_VIEW),
-            data=invalid_data,
-            content_type="application/json",
-        )
-
-        assert response.status_code == http.HTTPStatus.BAD_REQUEST
-        err_message = response.data["ssl_verify"][0]
-        assert "Must be a valid boolean" in str(err_message)
-
-    def test_create_hashicorp_vault_empty_ssl_verify(
-        self, client_logged_in, hashicorp_vault_data
-    ):
-        """Test creating a HashiCorp Vault with an empty ssl_verify."""
-        invalid_data = {**hashicorp_vault_data}
-        invalid_data["ssl_verify"] = ""
-
-        response = client_logged_in.post(
-            reverse(HASHICORP_VAULT_VIEW),
-            data=invalid_data,
-            content_type="application/json",
-        )
-
-        assert response.status_code == http.HTTPStatus.BAD_REQUEST
-        err_message = response.data["ssl_verify"][0]
-        assert "Must be a valid boolean" in str(err_message)
 
     def test_create_hashicorp_vault_missing_client_cert(
         self, client_logged_in, hashicorp_vault_data
@@ -626,11 +590,11 @@ class TestHashiCorpVaultCreate:
             f"Failed to base64 decode the HashiCorp Vault {HASHICORP_VAULT_CLIENT_CERT}"
         ) in str(err_message)
 
-    def test_create_hashicorp_vault_ssl_verify_without_ca_cert(
+    def test_create_hashicorp_vault_missing_ca_cert(
         self, client_logged_in, hashicorp_vault_data
     ):
-        """Test creating a HashiCorp Vault with ssl_verify=True but no ca_cert."""
-        invalid_data = {**hashicorp_vault_data, "ssl_verify": True}
+        """Test creating a HashiCorp Vault without ca_cert field."""
+        invalid_data = {**hashicorp_vault_data}
         del invalid_data[HASHICORP_VAULT_CA_CERT]
 
         response = client_logged_in.post(
@@ -641,13 +605,13 @@ class TestHashiCorpVaultCreate:
 
         assert response.status_code == http.HTTPStatus.BAD_REQUEST
         err_message = response.data[HASHICORP_VAULT_CA_CERT][0]
-        assert messages.HASHICORP_VAULT_MUST_SPECIFY_CA_CERT in str(err_message)
+        assert "This field is required" in str(err_message)
 
-    def test_create_hashicorp_vault_ssl_verify_with_an_empty_ca_cert(
+    def test_create_hashicorp_vault_empty_ca_cert(
         self, client_logged_in, hashicorp_vault_data
     ):
-        """Test creating a HashiCorp Vault with ssl_verify=True but no ca_cert."""
-        invalid_data = {**hashicorp_vault_data, "ssl_verify": True}
+        """Test creating a HashiCorp Vault with an empty ca_cert field."""
+        invalid_data = {**hashicorp_vault_data}
         invalid_data[HASHICORP_VAULT_CA_CERT] = ""
 
         response = client_logged_in.post(
@@ -797,7 +761,6 @@ class TestHashiCorpVaultRetrieve:
         assert response.data == {
             "address": "vault.example.com",
             "port": 8200,
-            "ssl_verify": False,
         }
 
     def test_retrieve_hashicorp_vault_success_does_not_access_vault(
@@ -820,7 +783,6 @@ class TestHashiCorpVaultRetrieve:
         assert response.data == {
             "address": hashicorp_vault_data["address"],
             "port": hashicorp_vault_data["port"],
-            "ssl_verify": hashicorp_vault_data["ssl_verify"],
         }
         mock_authenticate.assert_not_called()
 
@@ -869,7 +831,6 @@ class TestHashiCorpVaultUpdate:
             data=hashicorp_vault_data,
             content_type="application/json",
         )
-        ssl_verify = hashicorp_vault_data["ssl_verify"]
 
         updated_data = {
             **hashicorp_vault_data,
@@ -886,7 +847,6 @@ class TestHashiCorpVaultUpdate:
         assert response.data == {
             "address": "newvault.example.com",
             "port": 8210,
-            "ssl_verify": ssl_verify,
         }
 
     def test_update_hashicorp_vault_not_found(
@@ -1011,7 +971,6 @@ class TestHashiCorpVaultPartialUpdate:
         assert response.data == {
             "address": "vault.example.com",
             "port": 8230,
-            "ssl_verify": False,
         }
 
     def test_partial_update_hashicorp_vault_address(
@@ -1030,7 +989,6 @@ class TestHashiCorpVaultPartialUpdate:
             content_type="application/json",
         )
         port = hashicorp_vault_data["port"]
-        ssl_verify = hashicorp_vault_data["ssl_verify"]
 
         partial_data = {"address": "updated-vault.example.com"}
         response = client_logged_in.patch(
@@ -1043,7 +1001,6 @@ class TestHashiCorpVaultPartialUpdate:
         assert response.data == {
             "address": "updated-vault.example.com",
             "port": port,
-            "ssl_verify": ssl_verify,
         }
 
     def test_partial_update_hashicorp_vault_not_found(self, client_logged_in):
@@ -1085,36 +1042,6 @@ class TestHashiCorpVaultPartialUpdate:
         assert response.status_code == http.HTTPStatus.BAD_REQUEST
         err_message = response.data["port"][0]
         assert "A valid integer is required" in str(err_message)
-
-    def test_partial_update_hashicorp_vault_ssl_verify_requires_ca_cert(
-        self, client_logged_in, hashicorp_vault_data, mocker
-    ):
-        """Test partially updating ssl_verify to True requires ca_cert."""
-        mock_client = mocker.MagicMock()
-        mock_client.is_authenticated.return_value = True
-        mocker.patch(
-            "api.auth.hashicorp_vault.auth.hvac.Client", return_value=mock_client
-        )
-
-        hashicorp_vault_data_no_ca = {**hashicorp_vault_data}
-        del hashicorp_vault_data_no_ca[HASHICORP_VAULT_CA_CERT]
-
-        client_logged_in.post(
-            reverse(HASHICORP_VAULT_VIEW),
-            data=hashicorp_vault_data_no_ca,
-            content_type="application/json",
-        )
-
-        partial_data = {"ssl_verify": True}
-        response = client_logged_in.patch(
-            reverse(HASHICORP_VAULT_VIEW),
-            data=partial_data,
-            content_type="application/json",
-        )
-
-        assert response.status_code == http.HTTPStatus.BAD_REQUEST
-        err_message = response.data[HASHICORP_VAULT_CA_CERT][0]
-        assert messages.HASHICORP_VAULT_MUST_SPECIFY_CA_CERT in str(err_message)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Removing the ssl_verify option for HashiCorp Vault settings and always require a CA_CERT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - HashiCorp Vault configurations now require a CA certificate.
  - TLS certificate verification is always enabled for Vault connections.
  - The `ssl_verify` option is no longer supported.
  - Vault configuration responses no longer include `ssl_verify`.

- **Documentation**
  - Updated API request/response examples to include the required `ca_cert` field and remove `ssl_verify`.

- **Tests**
  - Updated authentication and certificate-related test expectations to match the new validation rules and response schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->