### PR TITLE
fix: Update the router definition for the vault auth endpoint to allow DRF-Spectacular see all actions

### DIFF
--- a/quipucords/api/urls.py
+++ b/quipucords/api/urls.py
@@ -42,9 +42,6 @@ ROUTER_V1.register(r"jobs", ScanJobViewSetV1, basename="scanjob")
 ROUTER_V1.register(r"users", UserViewSet, basename="users")
 
 ROUTER_V2 = SimpleRouter()
-ROUTER_V2.register(
-    r"auth/hashicorp-vault", HashiCorpVaultViewSet, basename="hashicorp-vault"
-)
 ROUTER_V2.register(r"credentials", CredentialViewSetV2, basename="credentials")
 ROUTER_V2.register(r"sources", SourceViewSet, basename="source")
 ROUTER_V2.register(r"jobs", ScanJobViewSet, basename="job")
@@ -77,6 +74,19 @@ v1_urls = [
 ]
 
 v2_urls = [
+    path(
+        "auth/hashicorp-vault/",
+        HashiCorpVaultViewSet.as_view(
+            {
+                "get": "list",
+                "post": "post",
+                "put": "put",
+                "patch": "patch",
+                "delete": "delete",
+            }
+        ),
+        name="hashicorp-vault-list",
+    ),
     *ROUTER_V2.urls,
     path("auth/lightspeed/login/", lightspeed_auth_login, name="lightspeed-auth-login"),
     path(


### PR DESCRIPTION
The DRF-Spectacular/OpenAPI Schema only showed the GET on the /api/v2/auth/hashicorp-vault/ endpoint.

Since HashiCorpVaultViewSet is a singleton — all operations live on the same URL with no {pk} which breaks the DRF simple router's assumptions of /api/v2/auth/hashicorp-vault/ for get/post, and /api/v2/auth/hashicorp-vault/{pk} for the put/patch/delete.

Because the router has no way to express that, we are replacing the ROUTER_V2.register(...) call with a manual path() that explicitly maps all five HTTP methods onto the single singleton URL:

```
  path(
      "auth/hashicorp-vault/",
       HashiCorpVaultViewSet.as_view({
          "get": "list",
          "post": "post",
          "put": "put",
          "patch": "patch",
          "delete": "delete",
       }),
       name="hashicorp-vault-list",
  ),
```

DRF-Spectacular discovers endpoints by reading the action_map defined into each registered URL pattern. With the router, only get was visible. With the explicit as_view({...}), all five methods are in the map, so DRF-Spectacular finds them all and picks up their @extend_schema definitions.

And now accessing the OpenAPI schema via http://localhost:8000/api/schema/swagger-ui/?version=v2#/ shows the examples we had for the POST/PUT/PATCH/DELETE actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API v2 routing for HashiCorp Vault authentication endpoints.
  * Ensured supported HTTP operations are correctly mapped for Vault authentication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->