### PR TITLE
Improve and future-proof JWS version detection

### DIFF
--- a/quipucords/fingerprinter/jboss_web_server.py
+++ b/quipucords/fingerprinter/jboss_web_server.py
@@ -1,5 +1,7 @@
 """Ingests raw facts to determine the status of JBoss Web Server on system."""
 
+import re
+
 from api.models import Product
 from fingerprinter.constants import META_DATA_KEY, PRESENCE_KEY
 from fingerprinter.utils import generate_raw_fact_members, product_entitlement_found
@@ -24,30 +26,18 @@ JWS_CLASSIFICATIONS = {
     "Apache/2.2.22 (Unix)Apache Tomcat/6.0.35": "EWS 2.0.0",
     "Apache/2.2.22 (Unix)Apache Tomcat/6.0.37": "EWS 2.0.1",
     "Apache/2.2.26 (Unix)Apache Tomcat/6.0.41": "EWS 2.1.x",
-    "JWS_3.0.1": "JWS 3.0.1",
-    "JWS_3.0.2": "JWS 3.0.2",
-    "JWS_3.0.3": "JWS 3.0.3",
-    "JWS_3.1.0": "JWS 3.1.0",
-    "JWS_3.1.1": "JWS 3.1.1",
-    "JWS_3.1.2": "JWS 3.1.2",
-    "JWS_3.1.3": "JWS 3.1.3",
-    "JWS_3.1.4": "JWS 3.1.4",
-    "JWS_3.1.5": "JWS 3.1.5",
-    "JWS_3.1.6": "JWS 3.1.6",
-    "JWS_3.1.7": "JWS 3.1.7",
-    "JWS_3.1.8": "JWS 3.1.8",
-    "JWS_3.1.9": "JWS 3.1.9",
-    "Red Hat JBoss Web Server - Version 5.0 GA": "JWS 5.0",
-    "Red Hat JBoss Web Server - Version 5.0.0 GA": "JWS 5.0.0",
-    "jws5": "JWS 5.x.x",
-    "Red Hat JBoss Web Server - Version 5.1 GA": "JWS 5.1",
-    "Red Hat JBoss Web Server - Version 5.1.0 GA": "JWS 5.1.0",
-    "Red Hat JBoss Web Server - Version 5.2 GA": "JWS 5.2",
-    "Red Hat JBoss Web Server - Version 5.2.0 GA": "JWS 5.2.0",
-    "Red Hat JBoss Web Server - Version 5.3 GA": "JWS 5.3",
-    "Red Hat JBoss Web Server - Version 5.3.0 GA": "JWS 5.3",
-    "Red Hat JBoss Web Server - Version 5.3.1 GA": "JWS 5.3.1",
 }
+
+JWS_GA_PATTERN = re.compile(
+    r"Red Hat JBoss Web Server - Version (?P<found_version>[0-9\.]+) GA"
+)
+JWS_PATCH_PATTERN = re.compile(
+    r"""Red\ Hat\ JBoss\ Web\ Server\ -\ Version
+    \ (?P<major_version>[0-9\.]+)\ SP(?P<patch_version>[0-9]+)
+    """,
+    re.VERBOSE,
+)
+JWS_UNIT_NAME_PATTERN = re.compile(r"jws(?P<major_version>[0-9]+)")
 
 
 def get_version(raw_versions):
@@ -56,12 +46,38 @@ def get_version(raw_versions):
     :param raw_versions: array of possible version strings
     """
     versions = []
+    if raw_versions is None:
+        return versions
 
-    if raw_versions is not None:
-        for version in raw_versions:
-            # Turn the found version string into a standard format
-            if version in JWS_CLASSIFICATIONS:
-                versions.append(JWS_CLASSIFICATIONS[version])
+    for version in raw_versions:
+        if std_version := JWS_CLASSIFICATIONS.get(version):
+            versions.append(std_version)
+            continue
+
+        if version.startswith("JWS_3"):
+            std_version = version.replace("_", " ", 1)
+            versions.append(std_version)
+            continue
+
+        if match := JWS_GA_PATTERN.fullmatch(version):
+            found_version = match.group("found_version")
+            std_version = f"JWS {found_version}"
+            versions.append(std_version)
+            continue
+
+        if match := JWS_PATCH_PATTERN.fullmatch(version):
+            major_version = match.group("major_version")
+            patch_version = match.group("patch_version")
+            std_version = f"JWS {major_version}.{patch_version}"
+            versions.append(std_version)
+            continue
+
+        if match := JWS_UNIT_NAME_PATTERN.fullmatch(version):
+            major_version = match.group("major_version")
+            std_version = f"JWS {major_version}.x.x"
+            versions.append(std_version)
+            continue
+
     return versions
 
 

--- a/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
+++ b/quipucords/scanner/network/runner/roles/jboss_ws/tasks/main.yml
@@ -145,7 +145,7 @@
 - name: combine versions into a list
   set_fact:
     jws_version: "{{
-        (internal_jws_version_2 .get('stdout_lines', []) +
+        (internal_jws_version_2.get('stdout_lines', []) +
          internal_jws_version_3.get('stdout_lines', []) +
          internal_jws_version_5_txtfile.get('stdout_lines', []) +
          internal_jws_version_5_systemctl.get('stdout_lines', []))|difference(['']) | unique }}"

--- a/quipucords/tests/fingerprinter/test_product_jws.py
+++ b/quipucords/tests/fingerprinter/test_product_jws.py
@@ -23,6 +23,14 @@ class ProductJWSTest(TestCase):
 
         self.assertEqual(versions, expected)
 
+    def test_get_version_none(self):
+        """Test the get_version function with None param."""
+        raw_versions = None
+        versions = get_version(raw_versions)
+        expected = []
+
+        self.assertEqual(versions, expected)
+
     def test_detect_ws_present(self):
         """Test the detect_jboss_ws method."""
         expected = {

--- a/quipucords/tests/fingerprinter/test_product_jws_version.py
+++ b/quipucords/tests/fingerprinter/test_product_jws_version.py
@@ -1,0 +1,87 @@
+"""Test the product JBoss Web Server get_version.
+
+This file is split out of test_product_jws because django.test.TestCase
+conflicts with pytest.mark.parametrize.
+"""
+
+import pytest
+
+from fingerprinter.jboss_web_server import get_version
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    (
+        # real values from zip files - pattern used since JWS 5.0
+        ("Red Hat JBoss Web Server - Version 5.0 SP3", "JWS 5.0.3"),
+        ("Red Hat JBoss Web Server - Version 5.3 SP2", "JWS 5.3.2"),
+        ("Red Hat JBoss Web Server - Version 6.0 SP5", "JWS 6.0.5"),
+        ("Red Hat JBoss Web Server - Version 7.0 GA", "JWS 7.0"),
+        ("jws6", "JWS 6.x.x"),
+        ("jws7", "JWS 7.x.x"),
+        # artificial values following the same pattern
+        ("Red Hat JBoss Web Server - Version 17.0 GA", "JWS 17.0"),
+        ("Red Hat JBoss Web Server - Version 7.10 GA", "JWS 7.10"),
+        ("Red Hat JBoss Web Server - Version 5.13 SP2", "JWS 5.13.2"),
+        ("Red Hat JBoss Web Server - Version 6.0 SP15", "JWS 6.0.15"),
+        ("jws19", "JWS 19.x.x"),
+        # all these values used to exist in static map JWS_CLASSIFICATIONS
+        # we add them here to ensure backwards compatibility
+        ("JWS_3.0.1", "JWS 3.0.1"),
+        ("JWS_3.0.2", "JWS 3.0.2"),
+        ("JWS_3.0.3", "JWS 3.0.3"),
+        ("JWS_3.1.0", "JWS 3.1.0"),
+        ("JWS_3.1.1", "JWS 3.1.1"),
+        ("JWS_3.1.2", "JWS 3.1.2"),
+        ("JWS_3.1.3", "JWS 3.1.3"),
+        ("JWS_3.1.4", "JWS 3.1.4"),
+        ("JWS_3.1.5", "JWS 3.1.5"),
+        ("JWS_3.1.6", "JWS 3.1.6"),
+        ("JWS_3.1.7", "JWS 3.1.7"),
+        ("JWS_3.1.8", "JWS 3.1.8"),
+        ("JWS_3.1.9", "JWS 3.1.9"),
+        ("Red Hat JBoss Web Server - Version 5.0 GA", "JWS 5.0"),
+        ("Red Hat JBoss Web Server - Version 5.0.0 GA", "JWS 5.0.0"),
+        ("jws5", "JWS 5.x.x"),
+        ("Red Hat JBoss Web Server - Version 5.1 GA", "JWS 5.1"),
+        ("Red Hat JBoss Web Server - Version 5.1.0 GA", "JWS 5.1.0"),
+        ("Red Hat JBoss Web Server - Version 5.2 GA", "JWS 5.2"),
+        ("Red Hat JBoss Web Server - Version 5.2.0 GA", "JWS 5.2.0"),
+        ("Red Hat JBoss Web Server - Version 5.3 GA", "JWS 5.3"),
+        # the commented one below used to be in a map, but it is inconsistent
+        # with earlier three-digit GA. Keeping it here for reference,
+        # but unless we want to special-case 5.3.0 only, let's just handle
+        # them all the same way.
+        # Minor versions of JWS do not receive extra support (like RHEL does).
+        # JWS 5.x has ELS2 until end of 2030, but that means 5.8.x
+        # ("Red Hat JBoss Web Server - Version 5.3.0 GA", "JWS 5.3"),
+        ("Red Hat JBoss Web Server - Version 5.3.0 GA", "JWS 5.3.0"),
+        ("Red Hat JBoss Web Server - Version 5.3.1 GA", "JWS 5.3.1"),
+    ),
+)
+def test_get_version(raw, expected):
+    """Test the get_version function."""
+    versions = get_version([raw])
+
+    assert versions == [expected]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "jws 5",
+        "jws5-standalone",
+        "JWS_2.1.0",
+        "Red Hat JBoss Web Server Version 7.0 GA",
+        "Red Hat JBoss Web Server Version 5.0 SP3",
+        "Red Hat JBoss Web Server - Version 5.3.2",
+        "Red Hat JBoss Web Server - Version 6.0SP5",
+        "Red Hat JBoss Web Server - Version 7.0GA",
+        "This one ain't even trying",
+    ),
+)
+def test_get_version_negative(raw):
+    """Test things that could be mistaken for JWS version."""
+    versions = get_version([raw])
+
+    assert versions == []


### PR DESCRIPTION
JWS installed from zip will count as "potential", unless we also identify a version, when it will be upgraded to "present".

However, JWS version identification depended on static map. That made perfect sense back in 2018, when some JWS versions only reported Apache and Tomcat versions. But since JWS 3.x, JWS is self-reporting correctly and we can just extract version from one of handful of well-known strings.

As long as strings remain unchanged, this also allows us to detect versions released in the future, including versions with multiple digits.

Relates to JIRA: DISCOVERY-1443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded JBoss Web Server (JWS) version detection to handle more version string formats, including GA, patch, underscore/legacy forms, and unit-name patterns.
  - Improved normalization so more raw inputs map to consistent canonical version outputs.

- **Bug Fixes**
  - Version detection now safely returns no version results when version information is missing.
  - Fixed a minor template whitespace issue in JWS version list combination.

- **Tests**
  - Added unit tests covering successful JWS version normalization and negative/ambiguous inputs, including `None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->