### PR TITLE
fix(ansible): fall back to jobs when host_metrics returns 401/403/404

### DIFF
--- a/quipucords/scanner/ansible/inspect.py
+++ b/quipucords/scanner/ansible/inspect.py
@@ -20,6 +20,10 @@ from scanner.ansible.runner import AnsibleTaskRunner
 
 logger = getLogger(__name__)
 
+# HTTP statuses that mean host_metrics is listed but not usable for this
+# credential/server. Fall back to the slower /jobs/ path instead of failing.
+HOST_METRICS_FALLBACK_HTTP_STATUSES = (401, 403, 404)
+
 
 class InspectTaskRunner(AnsibleTaskRunner):
     """Inspection phase task runner for ansible scanner."""
@@ -199,8 +203,6 @@ class InspectTaskRunner(AnsibleTaskRunner):
                 )
                 inspection_status = InspectResult.FAILED
 
-        # Collect unique hosts that have run jobs
-        # Try host_metrics endpoint first (much faster), fall back to jobs if needed
         try:
             results["jobs"] = self.get_jobs_fact()
         except RequestException:
@@ -220,10 +222,6 @@ class InspectTaskRunner(AnsibleTaskRunner):
             return self.success_message, ScanTask.COMPLETED
         return self.failure_message, ScanTask.FAILED
 
-    # HTTP statuses that mean host_metrics is listed but not usable for this
-    # credential/server. Fall back to the slower /jobs/ path instead of failing.
-    HOST_METRICS_FALLBACK_HTTP_STATUSES = (401, 403, 404)
-
     def get_jobs_fact(self) -> dict:
         """
         Collect unique hosts that have run automation.
@@ -235,6 +233,8 @@ class InspectTaskRunner(AnsibleTaskRunner):
         Stored in legacy "jobs" structure for backward compatibility.
         TODO Drop fake "jobs" storage when we drop support for AAP < 2.4.
         """
+        # Collect unique hosts that have run jobs.
+        # Try host_metrics endpoint first (much faster), fall back to jobs if needed.
         use_host_metrics = (
             settings.QUIPUCORDS_AAP_USE_HOST_METRICS and self.endpoints.host_metrics
         )
@@ -251,7 +251,7 @@ class InspectTaskRunner(AnsibleTaskRunner):
                 }
             except HTTPError as error:
                 status_code = getattr(error.response, "status_code", None)
-                if status_code not in self.HOST_METRICS_FALLBACK_HTTP_STATUSES:
+                if status_code not in HOST_METRICS_FALLBACK_HTTP_STATUSES:
                     raise
                 logger.warning(
                     "host_metrics returned HTTP %(status_code)s for %(source_name)s; "

--- a/quipucords/scanner/ansible/inspect.py
+++ b/quipucords/scanner/ansible/inspect.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin
 from django.conf import settings
 from django.db import transaction
 from requests import ConnectionError as RequestConnError
-from requests import RequestException
+from requests import HTTPError, RequestException
 
 from api.connresult.model import SystemConnectionResult
 from api.models import InspectGroup, InspectResult, RawFact, Scan, ScanTask
@@ -202,40 +202,7 @@ class InspectTaskRunner(AnsibleTaskRunner):
         # Collect unique hosts that have run jobs
         # Try host_metrics endpoint first (much faster), fall back to jobs if needed
         try:
-            if settings.QUIPUCORDS_AAP_USE_HOST_METRICS and self.endpoints.host_metrics:
-                logger.info(
-                    "Using host_metrics endpoint for %(source_name)s",
-                    {"source_name": self.scan_task.source.name},
-                )
-                # Store in legacy "jobs" structure for backward compatibility.
-                # job_ids is empty because host_metrics doesn't provide job IDs.
-                results["jobs"] = {
-                    "job_ids": [],
-                    "unique_hosts": sorted(self.get_unique_hosts_from_metrics()),
-                }
-                # TODO Drop fake "jobs" storage when we drop support for AAP < 2.4.
-                # We could replace that with a simpler higher-level item like:
-                # results["unique_hosts"] = sorted(self.get_unique_hosts_from_metrics())
-                # Update semver appropriately since details report output will change.
-            else:
-                if not settings.QUIPUCORDS_AAP_USE_HOST_METRICS:
-                    logger.info(
-                        "host_metrics disabled by QUIPUCORDS_AAP_USE_HOST_METRICS "
-                        "setting, using jobs endpoint for %(source_name)s",
-                        {"source_name": self.scan_task.source.name},
-                    )
-                else:
-                    logger.info(
-                        "host_metrics endpoint not available, "
-                        "falling back to jobs endpoint for %(source_name)s",
-                        {"source_name": self.scan_task.source.name},
-                    )
-                # Use jobs endpoint (iterates through all jobs to extract unique hosts)
-                jobs_data = self.get_jobs()
-                results["jobs"] = {
-                    "job_ids": jobs_data["job_ids"],
-                    "unique_hosts": sorted(jobs_data["unique_hosts"]),
-                }
+            results["jobs"] = self.get_jobs_fact()
         except RequestException:
             logger.exception(
                 "Error collecting unique hosts for ansible host '%(system_name)s'.",
@@ -252,6 +219,67 @@ class InspectTaskRunner(AnsibleTaskRunner):
         if self.scan_task.systems_scanned:
             return self.success_message, ScanTask.COMPLETED
         return self.failure_message, ScanTask.FAILED
+
+    # HTTP statuses that mean host_metrics is listed but not usable for this
+    # credential/server. Fall back to the slower /jobs/ path instead of failing.
+    HOST_METRICS_FALLBACK_HTTP_STATUSES = (401, 403, 404)
+
+    def get_jobs_fact(self) -> dict:
+        """
+        Collect unique hosts that have run automation.
+
+        Prefer /host_metrics/ when available (much faster). Fall back to /jobs/
+        when host_metrics is disabled, missing, or returns auth/not-found errors
+        (for example AAP RBAC denying host_metrics while /hosts/ still works).
+
+        Stored in legacy "jobs" structure for backward compatibility.
+        TODO Drop fake "jobs" storage when we drop support for AAP < 2.4.
+        """
+        use_host_metrics = (
+            settings.QUIPUCORDS_AAP_USE_HOST_METRICS and self.endpoints.host_metrics
+        )
+        if use_host_metrics:
+            try:
+                logger.info(
+                    "Using host_metrics endpoint for %(source_name)s",
+                    {"source_name": self.scan_task.source.name},
+                )
+                # job_ids is empty because host_metrics doesn't provide job IDs.
+                return {
+                    "job_ids": [],
+                    "unique_hosts": sorted(self.get_unique_hosts_from_metrics()),
+                }
+            except HTTPError as error:
+                status_code = getattr(error.response, "status_code", None)
+                if status_code not in self.HOST_METRICS_FALLBACK_HTTP_STATUSES:
+                    raise
+                logger.warning(
+                    "host_metrics returned HTTP %(status_code)s for %(source_name)s; "
+                    "falling back to jobs endpoint",
+                    {
+                        "status_code": status_code,
+                        "source_name": self.scan_task.source.name,
+                    },
+                )
+        elif not settings.QUIPUCORDS_AAP_USE_HOST_METRICS:
+            logger.info(
+                "host_metrics disabled by QUIPUCORDS_AAP_USE_HOST_METRICS "
+                "setting, using jobs endpoint for %(source_name)s",
+                {"source_name": self.scan_task.source.name},
+            )
+        else:
+            logger.info(
+                "host_metrics endpoint not available, "
+                "falling back to jobs endpoint for %(source_name)s",
+                {"source_name": self.scan_task.source.name},
+            )
+
+        # Use jobs endpoint (iterates through all jobs to extract unique hosts)
+        jobs_data = self.get_jobs()
+        return {
+            "job_ids": jobs_data["job_ids"],
+            "unique_hosts": sorted(jobs_data["unique_hosts"]),
+        }
 
     @property
     def max_concurrency(self):

--- a/quipucords/tests/scanner/ansible/test_inspect.py
+++ b/quipucords/tests/scanner/ansible/test_inspect.py
@@ -10,7 +10,10 @@ from api.inspectresult.model import InspectResult
 from api.models import ScanTask
 from constants import DataSources
 from scanner.ansible.exceptions import AnsibleApiDetectionError
-from scanner.ansible.inspect import InspectTaskRunner
+from scanner.ansible.inspect import (
+    HOST_METRICS_FALLBACK_HTTP_STATUSES,
+    InspectTaskRunner,
+)
 from scanner.ansible.runner import AnsibleTaskRunner
 from scanner.exceptions import ScanFailureError
 from tests.factories import CredentialFactory, ScanTaskFactory
@@ -269,7 +272,7 @@ def test_inspect_falls_back_to_jobs_when_host_metrics_unavailable(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("status_code", (401, 403, 404))
+@pytest.mark.parametrize("status_code", HOST_METRICS_FALLBACK_HTTP_STATUSES)
 def test_inspect_falls_back_to_jobs_when_host_metrics_http_error(
     mocker, mock_client, scan_task, status_code
 ):

--- a/quipucords/tests/scanner/ansible/test_inspect.py
+++ b/quipucords/tests/scanner/ansible/test_inspect.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from django.test import override_settings
-from requests import RequestException
+from requests import HTTPError, RequestException
 
 from api.inspectresult.model import InspectResult
 from api.models import ScanTask
@@ -266,6 +266,95 @@ def test_inspect_falls_back_to_jobs_when_host_metrics_unavailable(
     assert sorted(results["jobs"]["unique_hosts"]) == sorted(
         ["host1.example.com", "host2.example.com"]
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status_code", (401, 403, 404))
+def test_inspect_falls_back_to_jobs_when_host_metrics_http_error(
+    mocker, mock_client, scan_task, status_code
+):
+    """Fall back to /jobs/ when host_metrics returns auth/not-found errors."""
+    runner = InspectTaskRunner(scan_task=scan_task, scan_job=scan_task.job)
+    runner.client = mock_client
+
+    runner.endpoints = InspectTaskRunner.AAP_ENDPOINTS(
+        me="/api/v2/me",
+        ping="/api/v2/ping",
+        hosts="/api/v2/hosts",
+        jobs="/api/v2/jobs",
+        host_metrics="/api/v2/host_metrics",
+    )
+
+    http_error = HTTPError(f"{status_code} Client Error")
+    http_error.response = mocker.Mock(status_code=status_code)
+
+    mocker.patch.object(runner, "get_instance_details", return_value={"version": "2.4"})
+    mocker.patch.object(runner, "get_hosts", return_value=[{"name": "localhost"}])
+    mocker.patch.object(runner, "get_unique_hosts_from_metrics", side_effect=http_error)
+    mocker.patch.object(
+        runner,
+        "get_jobs",
+        return_value={
+            "job_ids": [1, 2],
+            "unique_hosts": {"host1.example.com"},
+        },
+    )
+    mocker.patch.object(runner, "save_results")
+
+    with override_settings(QUIPUCORDS_AAP_USE_HOST_METRICS=True):
+        runner.inspect()
+
+    runner.get_unique_hosts_from_metrics.assert_called_once()
+    runner.get_jobs.assert_called_once()
+
+    call_args = runner.save_results.call_args
+    assert call_args is not None
+    status = call_args[0][0]
+    results = call_args[0][1]
+    assert status == InspectResult.SUCCESS
+    assert results["jobs"]["job_ids"] == [1, 2]
+    assert results["jobs"]["unique_hosts"] == ["host1.example.com"]
+    assert "comparison" in results
+
+
+@pytest.mark.django_db
+def test_inspect_does_not_fallback_on_host_metrics_server_error(
+    mocker, mock_client, scan_task
+):
+    """Do not fall back to /jobs/ for unexpected host_metrics HTTP errors."""
+    runner = InspectTaskRunner(scan_task=scan_task, scan_job=scan_task.job)
+    runner.client = mock_client
+
+    runner.endpoints = InspectTaskRunner.AAP_ENDPOINTS(
+        me="/api/v2/me",
+        ping="/api/v2/ping",
+        hosts="/api/v2/hosts",
+        jobs="/api/v2/jobs",
+        host_metrics="/api/v2/host_metrics",
+    )
+
+    http_error = HTTPError("500 Server Error")
+    http_error.response = mocker.Mock(status_code=500)
+
+    mocker.patch.object(runner, "get_instance_details", return_value={"version": "2.4"})
+    mocker.patch.object(runner, "get_hosts", return_value=[{"name": "localhost"}])
+    mocker.patch.object(runner, "get_unique_hosts_from_metrics", side_effect=http_error)
+    mocker.patch.object(runner, "get_jobs")
+    mocker.patch.object(runner, "save_results")
+
+    with override_settings(QUIPUCORDS_AAP_USE_HOST_METRICS=True):
+        runner.inspect()
+
+    runner.get_unique_hosts_from_metrics.assert_called_once()
+    runner.get_jobs.assert_not_called()
+
+    call_args = runner.save_results.call_args
+    assert call_args is not None
+    status = call_args[0][0]
+    results = call_args[0][1]
+    assert status == InspectResult.FAILED
+    assert "jobs" not in results
+    assert "comparison" not in results
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Avoid marking AAP inspect as failed when host_metrics is advertised but denied by RBAC; collect unique hosts via /jobs/ instead.

Relates to JIRA: DISCOVERY-1403
Generated by: Cursor (Grok 4.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host discovery when host-metrics is enabled but unavailable.
  * When host-metrics fails with authorization/not-found errors, the scanner now automatically falls back to jobs-based host discovery and preserves legacy-shaped job results.
  * Keeps existing failure behavior for unexpected server errors so genuine service issues are surfaced.
* **Tests**
  * Added and extended coverage for host-metrics fallback behavior and non-fallback scenarios, aligned to the supported error statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->