### PR TITLE
fix: harden crate tarball extraction against link-based path traversal

### DIFF
--- a/scripts/prepare_rust_deps.py
+++ b/scripts/prepare_rust_deps.py
@@ -20,6 +20,16 @@ def _sha256(content: bytes):
     return hashlib.sha256(content).hexdigest()
 
 
+def _crate_tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.TarInfo:
+    # Rust crates never legitimately contain hardlinks or symlinks; reject them
+    # outright rather than relying solely on the built-in 'data' filter, which
+    # has known limitations around link-based extraction path traversal.
+    # TODO: remove this wrapper once CPython's tarfile link handling is hardened.
+    if member.islnk() or member.issym():
+        raise tarfile.FilterError(f"unexpected link in crate tarball: {member.name}")
+    return tarfile.data_filter(member, dest_path)
+
+
 def generate_cargo_checksum(crate_path: Path):
     """Generate a cargo checksum dictionary for a vendored crate.
 
@@ -46,7 +56,7 @@ def prepare_crate_as_vendored_dep(crate_path: Path):
     checksums = generate_cargo_checksum(crate_path)
     with tarfile.open(crate_path) as tarball:
         folder_name = tarball.getnames()[0].split("/")[0]
-        tarball.extractall(crate_path.parent, filter="data")
+        tarball.extractall(crate_path.parent, filter=_crate_tar_filter)  # noqa: S202
     cargo_checksum = crate_path.parent / folder_name / ".cargo-checksum.json"
     json.dump(checksums, cargo_checksum.open("w"))
     print(f"Wrote {cargo_checksum}")


### PR DESCRIPTION
The 'data' filter passed to tarfile.extractall() has known limitations around hardlink/symlink interactions that can allow extraction to escape the destination directory.  Rust .crate archives from crates.io never legitimately contain hardlinks or symlinks, so introduce a custom filter (_crate_tar_filter) that rejects both link types outright before delegating to tarfile.data_filter() for the remaining checks.

This is a defense-in-depth measure applied to the build-time crate unpacking step (scripts/prepare_rust_deps.py, invoked by the Konflux pipeline before pip compiles Rust-based wheels).  Runtime code is unaffected: api/common/common_report.py only writes tar archives.

The custom filter should be removed and filter="data" restored once CPython's tarfile link handling is appropriately hardened upstream.

Assisted-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crate extraction security by rejecting hardlinks and symlinks before processing archive contents.
  * Preserved safe handling of extracted files through the existing data validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->