### PR TITLE
build: remove unused pip from container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -74,8 +74,8 @@ COPY --from=builder /opt/venv /opt/venv
 # Copy server code
 COPY . .
 
-# Install quipucords as package
-RUN pip install -v -e .
+# Install quipucords as package, and remove pip afterwards
+RUN pip install -v -e . && pip uninstall pip setuptools wheel -y
 
 # Collect static files
 RUN make server-static


### PR DESCRIPTION
We don't actually use pip at runtime. Removing it at build time reduces the risk of later misuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build process to install Quipucords in editable mode.
  * Removed packaging tools from the final container image to reduce unnecessary contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->