### PR TITLE
Bump uv lower bound to 0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ convention = "pep257"
 
 [tool.uv]
 package = true
-required-version = ">=0.7"
+required-version = ">=0.11"
 # Use environment markers to limit library selection to only cpython and linux/macos
 # https://docs.python.org/3/library/sys.html#sys.platform
 environments = [


### PR DESCRIPTION
This should prevent uv.lock revision field from jumping back and forth between 2 and 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of the project’s package management tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->